### PR TITLE
Refactor gear creation UI and admin pages

### DIFF
--- a/src/app/(admin)/admin/bulk-create/page.tsx
+++ b/src/app/(admin)/admin/bulk-create/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next";
-import GearBulkCreate from "../gear-bulk-create";
+import { redirect } from "next/navigation";
 
 export const metadata: Metadata = {
   title: "Bulk Create • Admin",
 };
 
 export default function Page() {
-  return <GearBulkCreate />;
+  redirect("/admin/gear");
 }

--- a/src/app/(admin)/admin/gear/page.tsx
+++ b/src/app/(admin)/admin/gear/page.tsx
@@ -1,6 +1,8 @@
 import { GearDataTable } from "./data-table";
 import { columns } from "./columns";
 import { fetchAdminGearItems } from "~/server/admin/gear/service";
+import GearBulkCreate from "../gear-bulk-create";
+import { auth } from "~/server/auth";
 
 const DEFAULT_PAGE_SIZE = 20;
 const MAX_PAGE_SIZE = 100;
@@ -13,6 +15,8 @@ type AdminGearPageProps = {
 export default async function AdminGearPage({
   searchParams,
 }: AdminGearPageProps) {
+  const session = await auth();
+  const userRole = session?.user?.role ?? "USER";
   const resolvedSearchParams = (await searchParams) ?? {};
 
   const pageParam = Array.isArray(resolvedSearchParams.page)
@@ -44,14 +48,28 @@ export default async function AdminGearPage({
   const clampedPage = Math.min(pageNumber - 1, Math.max(pageCount - 1, 0));
 
   return (
-    <GearDataTable
-      columns={columns}
-      data={items}
-      pageCount={pageCount}
-      currentPage={clampedPage}
-      pageSize={pageSize}
-      totalCount={totalCount}
-      pageSizeOptions={PAGE_SIZE_OPTIONS}
-    />
+    <div className="space-y-8">
+      {userRole === "ADMIN" && (
+        <div>
+          <h2 className="text-2xl font-bold">Bulk Create</h2>
+          <p className="text-muted-foreground mt-2">
+            Create many gear items for a brand and type with validation.
+          </p>
+          <div className="mt-4">
+            <GearBulkCreate />
+          </div>
+        </div>
+      )}
+
+      <GearDataTable
+        columns={columns}
+        data={items}
+        pageCount={pageCount}
+        currentPage={clampedPage}
+        pageSize={pageSize}
+        totalCount={totalCount}
+        pageSizeOptions={PAGE_SIZE_OPTIONS}
+      />
+    </div>
   );
 }

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -3,7 +3,6 @@ import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { FileText, Users, Settings } from "lucide-react";
 import { GearProposalsList } from "./gear-proposals-list";
-import { GearCreateCard } from "./gear-create";
 import { ReviewsApprovalQueue } from "./reviews-approval-queue";
 import { BadgesCatalog } from "./badges-catalog";
 import { BadgesTestToastButton } from "./badges-test-toast";
@@ -24,17 +23,7 @@ export default async function AdminPage() {
 
   return (
     <div className="space-y-8 px-8">
-      {user.role === "ADMIN" && (
-        <div>
-          <h2 className="text-2xl font-bold">Create Gear</h2>
-          <p className="text-muted-foreground mt-2">
-            Quick-create a new gear item with name, brand and type.
-          </p>
-          <div className="mt-4">
-            <GearCreateCard />
-          </div>
-        </div>
-      )}
+      {/* Single-gear creation moved to modal trigger in the sidebar */}
       {/* Quick Stats Cards */}
       {/* <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
         <Card>

--- a/src/app/(admin)/admin/sidebar.tsx
+++ b/src/app/(admin)/admin/sidebar.tsx
@@ -36,6 +36,7 @@ import {
 import Link from "next/link";
 import {
   BarChart3,
+  CombineIcon,
   Camera,
   Lock,
   LayoutDashboard,
@@ -48,12 +49,18 @@ import { Button } from "~/components/ui/button";
 import { Skeleton } from "~/components/ui/skeleton";
 import { GlobalSearchBar } from "~/components/search/global-search-bar";
 import { useSession } from "next-auth/react";
+import {
+  Dialog,
+  DialogContent,
+  DialogTrigger,
+} from "~/components/ui/dialog";
+import { GearCreateCard } from "./gear-create";
 
 const sidebarItems = [
   {
-    label: "Dashboard",
+    label: "Approvals",
     href: "/admin",
-    icon: <LayoutDashboard className="size-5" />,
+    icon: <CombineIcon className="size-5" />,
     allowed: ["ADMIN", "EDITOR"],
   },
   {
@@ -134,9 +141,16 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           </>
         ) : (
           <>
-            <Button size="sm" icon={<Plus className="size-5" />}>
-              Create Gear Item
-            </Button>
+            <Dialog>
+              <DialogTrigger asChild>
+                <Button size="sm" icon={<Plus className="size-5" />}>
+                  Create Gear Item
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="sm:max-w-3xl bg-transparent p-0 border-none shadow-none">
+                <GearCreateCard />
+              </DialogContent>
+            </Dialog>
             {/* Only show links the user is allowed to see */}
             {sidebarItems
               .filter((item) => isLinkAllowed(item.href))

--- a/src/app/(pages)/gear/_components/gear-contributors.tsx
+++ b/src/app/(pages)/gear/_components/gear-contributors.tsx
@@ -41,10 +41,10 @@ export async function GearContributors({ gearId }: GearContributorsProps) {
 
   // TODO: remove this once we have real contributors
   // TEMP: add two test contributors with counts
-  contributors = contributors.concat([
-    { id: "test_user_1", name: "Test User One", image: null, count: 7 },
-    { id: "test_user_2", name: "Test User Two", image: null, count: 5 },
-  ]);
+  // contributors = contributors.concat([
+  //   { id: "test_user_1", name: "Test User One", image: null, count: 7 },
+  //   { id: "test_user_2", name: "Test User Two", image: null, count: 5 },
+  // ]);
 
   // Sort by total fields contributed (desc)
   contributors.sort((a, b) => b.count - a.count);

--- a/src/components/layout/header-client.tsx
+++ b/src/components/layout/header-client.tsx
@@ -2,7 +2,7 @@
 
 import { useScrollState } from "@/lib/hooks/useScrollState";
 import { Button } from "../ui/button";
-import { LayoutDashboard, Menu } from "lucide-react";
+import { LayoutDashboard, LogIn, Menu } from "lucide-react";
 import { GlobalSearchBar } from "../search/global-search-bar";
 import { usePathname, useSearchParams } from "next/navigation";
 import Link from "next/link";
@@ -123,18 +123,11 @@ export default function HeaderClient({ user }: { user: HeaderUser }) {
                 </>
               ) : (
                 <>
-                  <Button variant="ghost" size="sm" asChild>
+                  <Button size="sm" asChild icon={<LogIn />}>
                     <Link
                       href={`/auth/signin?callbackUrl=${encodeURIComponent(callbackUrl)}`}
                     >
-                      Login
-                    </Link>
-                  </Button>
-                  <Button size="sm" asChild>
-                    <Link
-                      href={`/auth/signin?callbackUrl=${encodeURIComponent(callbackUrl)}&mode=signup`}
-                    >
-                      Sign up
+                      Sign In
                     </Link>
                   </Button>
                 </>


### PR DESCRIPTION
Bulk gear creation is now accessible only to admins on the gear page, while single gear creation is moved to a modal trigger in the sidebar. The bulk-create route now redirects to the gear admin page. Test contributors in gear contributors are commented out. The header login button is updated to use an icon and unified label.