### PR TITLE
Add Discord gear command and improve handler structure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@ AUTH_DISCORD_SECRET=""
 DISCORD_BOT_CLIENT_ID=""
 DISCORD_BOT_TOKEN=""
 DISCORD_BOT_PUBLIC_KEY=""
-DISCORD_BOT_GUILD_IDS="" # comma separated list
+DISCORD_BOT_GUILD_IDS="" # comma separated list (use your server if you're testing bot development)
 
 
 # Drizzle

--- a/scripts/discord/register-commands.ts
+++ b/scripts/discord/register-commands.ts
@@ -16,7 +16,7 @@ async function registerCommands() {
   );
 
   // Guild registration is instant, global takes ~1 hour
-  const guildIds = process.env.DISCORD_GUILD_IDS?.split(",") ?? [];
+  const guildIds = process.env.DISCORD_BOT_GUILD_IDS?.split(",") ?? [];
 
   if (guildIds.length > 0) {
     for (const guildId of guildIds) {

--- a/src/app/api/discord/route.ts
+++ b/src/app/api/discord/route.ts
@@ -41,7 +41,7 @@ export async function POST(req: NextRequest) {
       interaction as APIApplicationCommandInteraction
     ).data;
     const handler = commandHandlers[commandName];
-    if (handler) return handler();
+    if (handler) return handler(interaction);
 
     return NextResponse.json({
       type: 4,

--- a/src/server/discord-bot/commands/gear.ts
+++ b/src/server/discord-bot/commands/gear.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { InteractionResponseFlags } from "discord-interactions";
+import { searchGear } from "~/server/search/service";
+
+export const getGearCommand = {
+  definition: {
+    name: "gear",
+    description: "Search for gear and get the highest scoring result",
+    options: [
+      {
+        name: "search",
+        description: "Search text for gear",
+        type: 3, // STRING
+        required: true,
+      },
+    ],
+  },
+  handler: async (interaction: any) => {
+    const searchText = interaction.data.options?.[0]?.value;
+
+    if (!searchText) {
+      return NextResponse.json({
+        type: 4,
+        data: {
+          content: "Please provide search text for the gear command.",
+          flags: InteractionResponseFlags.EPHEMERAL,
+        },
+      });
+    }
+
+    try {
+      // Search for gear using the common search method
+      const searchResults = await searchGear({
+        query: searchText,
+        sort: "relevance",
+        page: 1,
+        pageSize: 1, // Only get the top result
+      });
+
+      if (searchResults.results.length === 0) {
+        return NextResponse.json({
+          type: 4,
+          data: {
+            content: `No gear found for "${searchText}". Try a different search term.`,
+            flags: InteractionResponseFlags.EPHEMERAL,
+          },
+        });
+      }
+
+      const topResult = searchResults.results[0]!;
+      const gearUrl = `https://sharply.app/gear/${topResult.slug}`;
+
+      return NextResponse.json({
+        type: 4,
+        data: {
+          content: `**${topResult.name}** by ${topResult.brandName}\n${gearUrl}`,
+        },
+      });
+    } catch (error) {
+      console.error("Error searching for gear:", error);
+      return NextResponse.json({
+        type: 4,
+        data: {
+          content:
+            "Sorry, there was an error searching for gear. Please try again later.",
+          flags: InteractionResponseFlags.EPHEMERAL,
+        },
+      });
+    }
+  },
+};

--- a/src/server/discord-bot/index.ts
+++ b/src/server/discord-bot/index.ts
@@ -1,15 +1,18 @@
 import type { RESTPostAPIChatInputApplicationCommandsJSONBody } from "discord-api-types/v10";
 
 import { pingCommand } from "./commands/ping";
+import { getGearCommand } from "./commands/gear";
 
-const commands = { ping: pingCommand };
+const commands = { ping: pingCommand, gear: getGearCommand };
 
 // Runtime dispatcher
-export const commandHandlers: Record<string, () => Response> =
-  Object.fromEntries(
-    Object.entries(commands).map(([name, cmd]) => [name, cmd.handler]),
-  );
+export const commandHandlers: Record<
+  string,
+  (interaction: any) => Response | Promise<Response>
+> = Object.fromEntries(
+  Object.entries(commands).map(([name, cmd]) => [name, cmd.handler]),
+);
 
 // Registration definitions
-export const commandDefinitions: RESTPostAPIChatInputApplicationCommandsJSONBody[] =  
+export const commandDefinitions: RESTPostAPIChatInputApplicationCommandsJSONBody[] =
   Object.values(commands).map((cmd) => cmd.definition);

--- a/src/server/search/data.ts
+++ b/src/server/search/data.ts
@@ -1,4 +1,9 @@
-import "server-only";
+// In Next.js runtime, enforce server-only import. In scripts (Node), skip.
+if (process.env.NEXT_RUNTIME) {
+  import("server-only").catch(() => {
+    console.warn("[search:data] server-only import failed, skipping.");
+  });
+}
 
 /**
  * Search Data Layer (server-only)

--- a/src/server/search/service.ts
+++ b/src/server/search/service.ts
@@ -1,4 +1,9 @@
-import "server-only";
+// In Next.js runtime, enforce server-only import. In scripts (Node), skip.
+if (process.env.NEXT_RUNTIME) {
+  import("server-only").catch(() => {
+    console.warn("[search:service] server-only import failed, skipping.");
+  });
+}
 
 import { gear, brands, mounts } from "~/server/db/schema";
 import { asc, desc, sql, and, type SQL } from "drizzle-orm";


### PR DESCRIPTION
Introduces a new 'gear' command for the Discord bot, allowing users to search for gear and receive the top result. Refactors command handler signatures to accept the interaction object, updates environment variable usage for guild IDs, and improves server-only import handling for search modules to better support both Next.js and Node script environments.