### PR TITLE
Remove duplicate About link from footer nav items

### DIFF
--- a/src/lib/nav-items.ts
+++ b/src/lib/nav-items.ts
@@ -167,12 +167,6 @@ export const navItems: NavItem[] = [
     ],
   },
   {
-    title: "About",
-    type: "link",
-    url: "/about",
-    hideFromNavbar: true,
-  },
-  {
     title: "Contact",
     type: "link",
     url: "/contact",


### PR DESCRIPTION
## Summary
- remove the duplicate About entry from the shared navigation data so the footer renders a single About link

## Testing
- npm run lint *(fails: missing required environment variables in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d92126f2e4832dbb642d186081b28e