### PR TITLE
Add API route and client-side data fetching for admin gear table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "react-parallax-tilt": "^1.7.309",
         "slugify": "^1.6.6",
         "sonner": "^2.0.7",
+        "swr": "^2.3.6",
         "tailwind-merge": "^3.3.1",
         "uploadthing": "^7.7.4",
         "vaul": "^1.1.2",
@@ -5480,6 +5481,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -9786,6 +9796,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.6.tgz",
+      "integrity": "sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/tailwind-merge": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react-parallax-tilt": "^1.7.309",
     "slugify": "^1.6.6",
     "sonner": "^2.0.7",
+    "swr": "^2.3.6",
     "tailwind-merge": "^3.3.1",
     "uploadthing": "^7.7.4",
     "vaul": "^1.1.2",

--- a/src/app/(admin)/admin/gear/data-table.tsx
+++ b/src/app/(admin)/admin/gear/data-table.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useCallback, useMemo, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import {
   useReactTable,
   getCoreRowModel,
@@ -9,7 +15,7 @@ import {
   getSortedRowModel,
   type SortingState,
 } from "@tanstack/react-table";
-import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import useSWR from "swr";
 import type { AdminGearTableRow } from "~/types/gear";
 import {
   Table,
@@ -36,57 +42,66 @@ import {
   SelectValue,
 } from "~/components/ui/select";
 import { Input } from "~/components/ui/input";
-import { normalizeFuzzyTokens } from "~/lib/utils/fuzzy";
+import { useDebounce } from "~/lib/hooks/useDebounce";
+import { Loader2 } from "lucide-react";
 
 // (client component) will contain our <DataTable /> component.
 
 interface GearDataTableProps {
   columns: ColumnDef<AdminGearTableRow>[];
-  data: AdminGearTableRow[];
-  pageCount: number;
-  currentPage: number;
-  pageSize: number;
-  totalCount: number;
   pageSizeOptions: readonly number[];
 }
 
 export function GearDataTable({
   columns,
-  data,
-  pageCount,
-  currentPage,
-  pageSize,
-  totalCount,
   pageSizeOptions,
 }: GearDataTableProps) {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const searchParamsString = useMemo(
-    () => searchParams?.toString() ?? "",
-    [searchParams],
-  );
   const [sorting, setSorting] = useState<SortingState>([
     { id: "createdAt", desc: true },
   ]);
 
   const [searchValue, setSearchValue] = useState<string>("");
-  const searchTokens = useMemo(() => {
-    if (!searchValue.trim()) return [];
-    return normalizeFuzzyTokens(searchValue);
-  }, [searchValue]);
+  const debouncedQuery = useDebounce(searchValue, 300);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [page, setPage] = useState<number>(0);
+  const [pageSize, setPageSize] = useState<number>(pageSizeOptions[1] ?? 20);
 
-  const filteredData = useMemo(() => {
-    if (searchTokens.length === 0) return data;
-    return data.filter((item) => {
-      const haystack =
-        `${item.name} ${item.brandName} ${item.slug ?? ""}`.toLowerCase();
-      return searchTokens.every((token) => haystack.includes(token));
-    });
-  }, [data, searchTokens]);
+  const key = useMemo(() => {
+    const q = debouncedQuery.trim();
+    const params = new URLSearchParams();
+    params.set("page", String(page + 1));
+    params.set("limit", String(pageSize));
+    if (q) params.set("q", q);
+    return `/api/admin/gear/list?${params.toString()}`;
+  }, [debouncedQuery, page, pageSize]);
+
+  const fetcher = useCallback(async (url: string) => {
+    const res = await fetch(url, { method: "GET" });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(text || `Request failed: ${res.status}`);
+    }
+    return (await res.json()) as {
+      items: AdminGearTableRow[];
+      totalCount: number;
+    };
+  }, []);
+
+  const {
+    data,
+    isLoading: swrLoading,
+    isValidating,
+  } = useSWR(key, fetcher, {
+    keepPreviousData: true,
+    revalidateOnFocus: false,
+  });
+
+  const items = data?.items ?? [];
+  const totalCount = data?.totalCount ?? 0;
+  const pageCount = pageSize > 0 ? Math.ceil(totalCount / pageSize) : 0;
 
   const table = useReactTable({
-    data: filteredData,
+    data: items,
     columns,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
@@ -95,23 +110,22 @@ export function GearDataTable({
     },
     onSortingChange: setSorting,
   });
+  useEffect(() => {
+    // stop loading when data settles
+    if (!swrLoading && !isValidating && data) {
+      setIsLoading(false);
+    }
+  }, [data, swrLoading, isValidating]);
 
   const handlePageChange = useCallback(
     (nextPage: number) => {
-      if (nextPage < 0 || nextPage >= pageCount || nextPage === currentPage) {
+      if (nextPage < 0 || nextPage >= pageCount || nextPage === page) {
         return;
       }
-
-      const params = new URLSearchParams(searchParamsString);
-      params.set("page", String(nextPage + 1));
-      params.set("limit", String(pageSize));
-
-      const queryString = params.toString();
-      router.push(queryString ? `${pathname}?${queryString}` : pathname, {
-        scroll: false,
-      });
+      setIsLoading(true);
+      setPage(nextPage);
     },
-    [currentPage, pageCount, pageSize, pathname, router, searchParamsString],
+    [page, pageCount],
   );
 
   const handlePageSizeChange = useCallback(
@@ -119,21 +133,15 @@ export function GearDataTable({
       if (!pageSizeOptions.includes(nextSize) || nextSize === pageSize) {
         return;
       }
-
-      const params = new URLSearchParams(searchParamsString);
-      params.set("limit", String(nextSize));
-      params.set("page", "1");
-
-      const queryString = params.toString();
-      router.push(queryString ? `${pathname}?${queryString}` : pathname, {
-        scroll: false,
-      });
+      setIsLoading(true);
+      setPageSize(nextSize);
+      setPage(0);
     },
-    [pageSize, pageSizeOptions, pathname, router, searchParamsString],
+    [pageSize, pageSizeOptions],
   );
 
-  const canPrevious = currentPage > 0;
-  const canNext = currentPage + 1 < pageCount;
+  const canPrevious = page > 0;
+  const canNext = page + 1 < pageCount;
 
   const pageItems = useMemo(() => {
     if (pageCount <= 1) return null;
@@ -141,7 +149,7 @@ export function GearDataTable({
     const items: ReactNode[] = [];
     const totalToShow = 5;
     const half = Math.floor(totalToShow / 2);
-    let start = Math.max(currentPage - half, 0);
+    let start = Math.max(page - half, 0);
     const end = Math.min(start + totalToShow - 1, pageCount - 1);
 
     if (end - start + 1 < totalToShow) {
@@ -153,7 +161,7 @@ export function GearDataTable({
         <PaginationItem key={pageIdx}>
           <PaginationLink
             href="#"
-            isActive={pageIdx === currentPage}
+            isActive={pageIdx === page}
             onClick={(event) => {
               event.preventDefault();
               handlePageChange(pageIdx);
@@ -192,119 +200,143 @@ export function GearDataTable({
     }
 
     return items;
-  }, [currentPage, handlePageChange, pageCount]);
+  }, [page, handlePageChange, pageCount]);
 
   const visibleRowCount = table.getRowModel().rows.length;
-  const originalRowCount = data.length;
+  const busy = isLoading || swrLoading || isValidating;
 
   return (
     <div className="overflow-hidden rounded-md border">
       <div className="flex flex-col gap-3 border-b px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
-        <Input
-          value={searchValue}
-          onChange={(event) => setSearchValue(event.target.value)}
-          placeholder="Filter by name, slug, brand..."
-          className="max-w-md bg-white"
-        />
-      </div>
-      <Table>
-        <TableHeader>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow key={headerGroup.id}>
-              {headerGroup.headers.map((header) => {
-                return (
-                  <TableHead key={header.id}>
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                  </TableHead>
-                );
-              })}
-            </TableRow>
-          ))}
-        </TableHeader>
-        <TableBody>
-          {table.getRowModel().rows?.length ? (
-            table.getRowModel().rows.map((row) => (
-              <TableRow
-                key={row.id}
-                data-state={row.getIsSelected() && "selected"}
-              >
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))
-          ) : (
-            <TableRow>
-              <TableCell colSpan={columns.length} className="h-24 text-center">
-                No results.
-              </TableCell>
-            </TableRow>
+        <div className="relative max-w-md">
+          <Input
+            value={searchValue}
+            onChange={(event) => {
+              setSearchValue(event.target.value);
+              setIsLoading(true);
+            }}
+            placeholder="Filter by name, slug, brand..."
+            className="bg-white pr-10"
+          />
+          {busy && (
+            <div className="text-muted-foreground pointer-events-none absolute top-1/2 right-3 -translate-y-1/2">
+              <Loader2 className="size-4 animate-spin" />
+            </div>
           )}
-        </TableBody>
-      </Table>
-      <div className="flex flex-col gap-2 border-t px-4 py-2 sm:flex-row sm:items-center sm:justify-between">
-        <div className="text-muted-foreground text-sm">
-          Showing {visibleRowCount} of {originalRowCount} items
         </div>
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
-          <div className="flex items-center gap-2 text-sm">
-            <span className="text-muted-foreground">Rows per page:</span>
-            <Select
-              value={String(pageSize)}
-              onValueChange={(value) => handlePageSizeChange(Number(value))}
-            >
-              <SelectTrigger className="h-9 w-[5.5rem]">
-                <SelectValue aria-label={`Rows per page ${pageSize}`} />
-              </SelectTrigger>
-              <SelectContent>
-                {pageSizeOptions.map((option) => (
-                  <SelectItem key={option} value={String(option)}>
-                    {option}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+      </div>
+      <div
+        className={
+          busy ? "opacity-60 transition-opacity" : "transition-opacity"
+        }
+      >
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                    </TableHead>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center"
+                >
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+        <div className="flex flex-col gap-2 border-t px-4 py-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-muted-foreground text-sm">
+            Showing {visibleRowCount} of {totalCount} items
           </div>
-          <Pagination className="w-auto">
-            <PaginationContent>
-              <PaginationItem>
-                <PaginationPrevious
-                  aria-disabled={!canPrevious}
-                  tabIndex={canPrevious ? 0 : -1}
-                  href={canPrevious ? "#" : undefined}
-                  onClick={(event) => {
-                    event.preventDefault();
-                    handlePageChange(currentPage - 1);
-                  }}
-                  className={
-                    !canPrevious ? "pointer-events-none opacity-50" : undefined
-                  }
-                />
-              </PaginationItem>
-              {pageItems}
-              <PaginationItem>
-                <PaginationNext
-                  aria-disabled={!canNext}
-                  tabIndex={canNext ? 0 : -1}
-                  href={canNext ? "#" : undefined}
-                  onClick={(event) => {
-                    event.preventDefault();
-                    handlePageChange(currentPage + 1);
-                  }}
-                  className={
-                    !canNext ? "pointer-events-none opacity-50" : undefined
-                  }
-                />
-              </PaginationItem>
-            </PaginationContent>
-          </Pagination>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+            <div className="flex items-center gap-2 text-sm">
+              <span className="text-muted-foreground">Rows per page:</span>
+              <Select
+                value={String(pageSize)}
+                onValueChange={(value) => handlePageSizeChange(Number(value))}
+              >
+                <SelectTrigger className="h-9 w-[5.5rem]">
+                  <SelectValue aria-label={`Rows per page ${pageSize}`} />
+                </SelectTrigger>
+                <SelectContent>
+                  {pageSizeOptions.map((option) => (
+                    <SelectItem key={option} value={String(option)}>
+                      {option}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Pagination className="w-auto">
+              <PaginationContent>
+                <PaginationItem>
+                  <PaginationPrevious
+                    aria-disabled={!canPrevious}
+                    tabIndex={canPrevious ? 0 : -1}
+                    href={canPrevious ? "#" : undefined}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      handlePageChange(page - 1);
+                    }}
+                    className={
+                      !canPrevious
+                        ? "pointer-events-none opacity-50"
+                        : undefined
+                    }
+                  />
+                </PaginationItem>
+                {pageItems}
+                <PaginationItem>
+                  <PaginationNext
+                    aria-disabled={!canNext}
+                    tabIndex={canNext ? 0 : -1}
+                    href={canNext ? "#" : undefined}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      handlePageChange(page + 1);
+                    }}
+                    className={
+                      !canNext ? "pointer-events-none opacity-50" : undefined
+                    }
+                  />
+                </PaginationItem>
+              </PaginationContent>
+            </Pagination>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/(admin)/admin/gear/page.tsx
+++ b/src/app/(admin)/admin/gear/page.tsx
@@ -1,6 +1,5 @@
 import { GearDataTable } from "./data-table";
 import { columns } from "./columns";
-import { fetchAdminGearItems } from "~/server/admin/gear/service";
 import GearBulkCreate from "../gear-bulk-create";
 import { auth } from "~/server/auth";
 
@@ -8,44 +7,9 @@ const DEFAULT_PAGE_SIZE = 20;
 const MAX_PAGE_SIZE = 100;
 const PAGE_SIZE_OPTIONS = [10, 20, 50, 100] as const;
 
-type AdminGearPageProps = {
-  searchParams?: Promise<Record<string, string | string[] | undefined>>;
-};
-
-export default async function AdminGearPage({
-  searchParams,
-}: AdminGearPageProps) {
+export default async function AdminGearPage() {
   const session = await auth();
   const userRole = session?.user?.role ?? "USER";
-  const resolvedSearchParams = (await searchParams) ?? {};
-
-  const pageParam = Array.isArray(resolvedSearchParams.page)
-    ? resolvedSearchParams.page[0]
-    : resolvedSearchParams.page;
-  const limitParam = Array.isArray(resolvedSearchParams.limit)
-    ? resolvedSearchParams.limit[0]
-    : resolvedSearchParams.limit;
-
-  const pageNumber = Math.max(parseInt(pageParam ?? "1", 10) || 1, 1);
-  const requestedPageSize =
-    parseInt(limitParam ?? String(DEFAULT_PAGE_SIZE), 10) || DEFAULT_PAGE_SIZE;
-
-  const normalizedPageSize = PAGE_SIZE_OPTIONS.includes(
-    requestedPageSize as (typeof PAGE_SIZE_OPTIONS)[number],
-  )
-    ? requestedPageSize
-    : DEFAULT_PAGE_SIZE;
-
-  const pageSize = Math.min(Math.max(normalizedPageSize, 1), MAX_PAGE_SIZE);
-  const offset = (pageNumber - 1) * pageSize;
-
-  const { items, totalCount } = await fetchAdminGearItems({
-    limit: pageSize,
-    offset,
-  });
-
-  const pageCount = pageSize > 0 ? Math.ceil(totalCount / pageSize) : 0;
-  const clampedPage = Math.min(pageNumber - 1, Math.max(pageCount - 1, 0));
 
   return (
     <div className="space-y-8">
@@ -61,15 +25,7 @@ export default async function AdminGearPage({
       </div>
       {/* )} */}
 
-      <GearDataTable
-        columns={columns}
-        data={items}
-        pageCount={pageCount}
-        currentPage={clampedPage}
-        pageSize={pageSize}
-        totalCount={totalCount}
-        pageSizeOptions={PAGE_SIZE_OPTIONS}
-      />
+      <GearDataTable columns={columns} pageSizeOptions={PAGE_SIZE_OPTIONS} />
     </div>
   );
 }

--- a/src/app/api/admin/gear/list/route.ts
+++ b/src/app/api/admin/gear/list/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { fetchAdminGearItems } from "~/server/admin/gear/service";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const sp = url.searchParams;
+
+  const DEFAULT_PAGE_SIZE = 20;
+  const MAX_PAGE_SIZE = 100;
+  const PAGE_SIZE_OPTIONS = new Set([10, 20, 50, 100]);
+
+  const pageParam = sp.get("page");
+  const limitParam = sp.get("limit");
+  const q = sp.get("q") ?? undefined;
+
+  const pageNumber = Math.max(parseInt(pageParam ?? "1", 10) || 1, 1);
+  const requestedPageSize =
+    parseInt(limitParam ?? String(DEFAULT_PAGE_SIZE), 10) || DEFAULT_PAGE_SIZE;
+
+  const normalizedPageSize = PAGE_SIZE_OPTIONS.has(requestedPageSize)
+    ? requestedPageSize
+    : DEFAULT_PAGE_SIZE;
+
+  const pageSize = Math.min(Math.max(normalizedPageSize, 1), MAX_PAGE_SIZE);
+  const offset = (pageNumber - 1) * pageSize;
+
+  const { items, totalCount } = await fetchAdminGearItems({
+    limit: pageSize,
+    offset,
+    q,
+  });
+
+  return NextResponse.json({ items, totalCount });
+}


### PR DESCRIPTION
Refactors the admin gear table to fetch data client-side using SWR and a new /api/admin/gear/list API route, enabling server-side pagination and search. Updates the data table component to handle loading states, debounced search, and pagination UI. The server data fetching logic now supports fuzzy search across gear name and slug. Removes server-side data fetching from the admin gear page, delegating all data loading to the client.