### PR TITLE
Add user notes field to gear schema and UI

### DIFF
--- a/docs/gear-specification-system.md
+++ b/docs/gear-specification-system.md
@@ -18,6 +18,7 @@ The central table that stores common gear information:
   - `mountId`: Single mount reference (kept for backward compatibility, stores "primary" mount)
   - Mount relationships managed via `gear_mounts` junction table for multi-mount support
 - **Metadata**: Release date, price, thumbnail URL
+- **User Notes**: `notes` — `text[]` for unstructured notes
 - **Commerce**: `mpbMaxPriceUsdCents` — optional MPB max price (USD cents)
 - **Core Specs**: Physical dimensions (width, height, depth in mm), weight
 - **Timestamps**: Created/updated tracking
@@ -193,6 +194,13 @@ The registry exports `buildGearSpecsSections(item: GearItem)` which returns `Spe
 1. Add field to database schema
 2. Add entry to spec registry with label and formatted value
 3. Field automatically appears in appropriate section
+
+### Notes Field
+
+- Schema: `gear.notes` (`text[]`), stores an array of strings
+- Normalization: Input via edit form is validated and trimmed to `string[]` (`null` clears notes)
+- UI: A "Notes" section appears at the bottom of the edit form with a repeater allowing users to add/remove note items. Each item is a textarea. Users click "+ Add note" to create a new note.
+- Submission Preview: Notes are included in the confirmation modal; items are summarized inline.
 
 ## Indexing Strategy
 

--- a/drizzle/0030_premium_cargill.sql
+++ b/drizzle/0030_premium_cargill.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "app"."gear" ADD COLUMN "notes" text[];

--- a/drizzle/meta/0030_snapshot.json
+++ b/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,4448 @@
+{
+  "id": "d9645621-2b49-400e-97dc-1bf049f945b0",
+  "prevId": "ebb3bc56-594b-426c-8575-24d196cf18eb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app.account": {
+      "name": "account",
+      "schema": "app",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.af_area_modes": {
+      "name": "af_area_modes",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_name": {
+          "name": "search_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "af_area_modes_brand_idx": {
+          "name": "af_area_modes_brand_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "af_area_modes_name_idx": {
+          "name": "af_area_modes_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "af_area_modes_search_name_idx": {
+          "name": "af_area_modes_search_name_idx",
+          "columns": [
+            {
+              "expression": "search_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "af_area_modes_brand_id_brands_id_fk": {
+          "name": "af_area_modes_brand_id_brands_id_fk",
+          "tableFrom": "af_area_modes",
+          "tableTo": "brands",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.audit_logs": {
+      "name": "audit_logs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "action": {
+          "name": "action",
+          "type": "audit_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gear_edit_id": {
+          "name": "gear_edit_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_created_idx": {
+          "name": "audit_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_action_idx": {
+          "name": "audit_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_actor_idx": {
+          "name": "audit_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_gear_idx": {
+          "name": "audit_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_edit_idx": {
+          "name": "audit_edit_idx",
+          "columns": [
+            {
+              "expression": "gear_edit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_actor_user_id_user_id_fk": {
+          "name": "audit_logs_actor_user_id_user_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "audit_logs_gear_id_gear_id_fk": {
+          "name": "audit_logs_gear_id_gear_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_logs_gear_edit_id_gear_edits_id_fk": {
+          "name": "audit_logs_gear_edit_id_gear_edits_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "gear_edits",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_edit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.badge_awards_log": {
+      "name": "badge_awards_log",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "badgeKey": {
+          "name": "badgeKey",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "badge_award_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awardedAt": {
+          "name": "awardedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "badge_awards_log_user_idx": {
+          "name": "badge_awards_log_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "badge_awards_log_awarded_idx": {
+          "name": "badge_awards_log_awarded_idx",
+          "columns": [
+            {
+              "expression": "awardedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "badge_awards_log_badge_idx": {
+          "name": "badge_awards_log_badge_idx",
+          "columns": [
+            {
+              "expression": "badgeKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "badge_awards_log_userId_user_id_fk": {
+          "name": "badge_awards_log_userId_user_id_fk",
+          "tableFrom": "badge_awards_log",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.brands": {
+      "name": "brands",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "brands_name_unique": {
+          "name": "brands_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "brands_slug_unique": {
+          "name": "brands_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.camera_af_area_specs": {
+      "name": "camera_af_area_specs",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "af_area_mode_id": {
+          "name": "af_area_mode_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "camera_af_area_specs_af_area_mode_idx": {
+          "name": "camera_af_area_specs_af_area_mode_idx",
+          "columns": [
+            {
+              "expression": "af_area_mode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "camera_af_area_specs_gear_idx": {
+          "name": "camera_af_area_specs_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "camera_af_area_specs_gear_id_gear_id_fk": {
+          "name": "camera_af_area_specs_gear_id_gear_id_fk",
+          "tableFrom": "camera_af_area_specs",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "camera_af_area_specs_af_area_mode_id_af_area_modes_id_fk": {
+          "name": "camera_af_area_specs_af_area_mode_id_af_area_modes_id_fk",
+          "tableFrom": "camera_af_area_specs",
+          "tableTo": "af_area_modes",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "af_area_mode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "camera_af_area_specs_gear_id_af_area_mode_id_pk": {
+          "name": "camera_af_area_specs_gear_id_af_area_mode_id_pk",
+          "columns": [
+            "gear_id",
+            "af_area_mode_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.camera_card_slots": {
+      "name": "camera_card_slots",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_index": {
+          "name": "slot_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_form_factors": {
+          "name": "supported_form_factors",
+          "type": "card_form_factor_enum[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_buses": {
+          "name": "supported_buses",
+          "type": "card_bus_enum[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_speed_classes": {
+          "name": "supported_speed_classes",
+          "type": "card_speed_class_enum[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_camera_card_slot": {
+          "name": "uniq_camera_card_slot",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slot_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.camera_specs": {
+      "name": "camera_specs",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sensor_format_id": {
+          "name": "sensor_format_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_mp": {
+          "name": "resolution_mp",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sensor_stacking_type": {
+          "name": "sensor_stacking_type",
+          "type": "sensor_stacking_types_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sensor_tech_type": {
+          "name": "sensor_tech_type",
+          "type": "sensor_tech_types_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_back_side_illuminated": {
+          "name": "is_back_side_illuminated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso_min": {
+          "name": "iso_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso_max": {
+          "name": "iso_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sensor_readout_speed_ms": {
+          "name": "sensor_readout_speed_ms",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_raw_bit_depth": {
+          "name": "max_raw_bit_depth",
+          "type": "raw_bit_depth_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_ibis": {
+          "name": "has_ibis",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_electronic_vibration_reduction": {
+          "name": "has_electronic_vibration_reduction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cipa_stabilization_rating_stops": {
+          "name": "cipa_stabilization_rating_stops",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_pixel_shift_shooting": {
+          "name": "has_pixel_shift_shooting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_anti_aliasing_filter": {
+          "name": "has_anti_aliasing_filter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processor_name": {
+          "name": "processor_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_weather_sealing": {
+          "name": "has_weather_sealing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focus_points": {
+          "name": "focus_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "af_subject_categories": {
+          "name": "af_subject_categories",
+          "type": "camera_af_subject_categories_enum[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_focus_peaking": {
+          "name": "has_focus_peaking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_focus_bracketing": {
+          "name": "has_focus_bracketing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_max": {
+          "name": "shutter_speed_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_min": {
+          "name": "shutter_speed_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_fps_raw": {
+          "name": "max_fps_raw",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_fps_jpg": {
+          "name": "max_fps_jpg",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flash_sync_speed": {
+          "name": "flash_sync_speed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_silent_shooting_available": {
+          "name": "has_silent_shooting_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_shutter_types": {
+          "name": "available_shutter_types",
+          "type": "shutter_types_enum[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cipa_battery_shots_per_charge": {
+          "name": "cipa_battery_shots_per_charge",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_batteries": {
+          "name": "supported_batteries",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usb_power_delivery": {
+          "name": "usb_power_delivery",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usb_charging": {
+          "name": "usb_charging",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_log_color_profile": {
+          "name": "has_log_color_profile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_10_bit_video": {
+          "name": "has_10_bit_video",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_12_bit_video": {
+          "name": "has_12_bit_video",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_intervalometer": {
+          "name": "has_intervalometer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_self_timer": {
+          "name": "has_self_timer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_built_in_flash": {
+          "name": "has_built_in_flash",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_hot_shoe": {
+          "name": "has_hot_shoe",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "camera_specs_sensor_idx": {
+          "name": "camera_specs_sensor_idx",
+          "columns": [
+            {
+              "expression": "sensor_format_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "camera_specs_gear_id_gear_id_fk": {
+          "name": "camera_specs_gear_id_gear_id_fk",
+          "tableFrom": "camera_specs",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "camera_specs_sensor_format_id_sensor_formats_id_fk": {
+          "name": "camera_specs_sensor_format_id_sensor_formats_id_fk",
+          "tableFrom": "camera_specs",
+          "tableTo": "sensor_formats",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "sensor_format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.compare_pair_counts": {
+      "name": "compare_pair_counts",
+      "schema": "app",
+      "columns": {
+        "pair_key": {
+          "name": "pair_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_a_id": {
+          "name": "gear_a_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_b_id": {
+          "name": "gear_b_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pair_counts_gear_a_idx": {
+          "name": "pair_counts_gear_a_idx",
+          "columns": [
+            {
+              "expression": "gear_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pair_counts_gear_b_idx": {
+          "name": "pair_counts_gear_b_idx",
+          "columns": [
+            {
+              "expression": "gear_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pair_counts_count_idx": {
+          "name": "pair_counts_count_idx",
+          "columns": [
+            {
+              "expression": "count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compare_pair_counts_gear_a_id_gear_id_fk": {
+          "name": "compare_pair_counts_gear_a_id_gear_id_fk",
+          "tableFrom": "compare_pair_counts",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "compare_pair_counts_gear_b_id_gear_id_fk": {
+          "name": "compare_pair_counts_gear_b_id_gear_id_fk",
+          "tableFrom": "compare_pair_counts",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "compare_pair_counts_gear_a_id_gear_b_id_pk": {
+          "name": "compare_pair_counts_gear_a_id_gear_b_id_pk",
+          "columns": [
+            "gear_a_id",
+            "gear_b_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.fixed_lens_specs": {
+      "name": "fixed_lens_specs",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_prime": {
+          "name": "is_prime",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_min_mm": {
+          "name": "focal_length_min_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_max_mm": {
+          "name": "focal_length_max_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_aperture_wide": {
+          "name": "max_aperture_wide",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_aperture_tele": {
+          "name": "max_aperture_tele",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_aperture_wide": {
+          "name": "min_aperture_wide",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_aperture_tele": {
+          "name": "min_aperture_tele",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_autofocus": {
+          "name": "has_autofocus",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minimum_focus_distance_mm": {
+          "name": "minimum_focus_distance_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "front_element_rotates": {
+          "name": "front_element_rotates",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "front_filter_thread_size_mm": {
+          "name": "front_filter_thread_size_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_lens_hood": {
+          "name": "has_lens_hood",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fixed_lens_specs_focal_idx": {
+          "name": "fixed_lens_specs_focal_idx",
+          "columns": [
+            {
+              "expression": "focal_length_min_mm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "focal_length_max_mm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fixed_lens_specs_gear_id_gear_id_fk": {
+          "name": "fixed_lens_specs_gear_id_gear_id_fk",
+          "tableFrom": "fixed_lens_specs",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear": {
+      "name": "gear",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(220)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_name": {
+          "name": "search_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_number": {
+          "name": "model_number",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gear_type": {
+          "name": "gear_type",
+          "type": "gear_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mount_id": {
+          "name": "mount_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "announced_date": {
+          "name": "announced_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "announce_date_precision": {
+          "name": "announce_date_precision",
+          "type": "date_precision_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'DAY'"
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date_precision": {
+          "name": "release_date_precision",
+          "type": "date_precision_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'DAY'"
+        },
+        "msrp_now_usd_cents": {
+          "name": "msrp_now_usd_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "msrp_at_launch_usd_cents": {
+          "name": "msrp_at_launch_usd_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mpb_max_price_usd_cents": {
+          "name": "mpb_max_price_usd_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_grams": {
+          "name": "weight_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width_mm": {
+          "name": "width_mm",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height_mm": {
+          "name": "height_mm",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth_mm": {
+          "name": "depth_mm",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_manufacturer": {
+          "name": "link_manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_mpb": {
+          "name": "link_mpb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_amazon": {
+          "name": "link_amazon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_search_idx": {
+          "name": "gear_search_idx",
+          "columns": [
+            {
+              "expression": "search_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_type_brand_idx": {
+          "name": "gear_type_brand_idx",
+          "columns": [
+            {
+              "expression": "gear_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_brand_mount_idx": {
+          "name": "gear_brand_mount_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mount_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_brand_id_brands_id_fk": {
+          "name": "gear_brand_id_brands_id_fk",
+          "tableFrom": "gear",
+          "tableTo": "brands",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "gear_mount_id_mounts_id_fk": {
+          "name": "gear_mount_id_mounts_id_fk",
+          "tableFrom": "gear",
+          "tableTo": "mounts",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "mount_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gear_slug_unique": {
+          "name": "gear_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "gear_name_unique": {
+          "name": "gear_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "gear_model_number_unique": {
+          "name": "gear_model_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "model_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_edits": {
+      "name": "gear_edits",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_edits_status_idx": {
+          "name": "gear_edits_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_edits_gear_idx": {
+          "name": "gear_edits_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_edits_created_by_idx": {
+          "name": "gear_edits_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_edits_gear_id_gear_id_fk": {
+          "name": "gear_edits_gear_id_gear_id_fk",
+          "tableFrom": "gear_edits",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_edits_created_by_id_user_id_fk": {
+          "name": "gear_edits_created_by_id_user_id_fk",
+          "tableFrom": "gear_edits",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_genres": {
+      "name": "gear_genres",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_genres_gear_idx": {
+          "name": "gear_genres_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_genres_genre_idx": {
+          "name": "gear_genres_genre_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_genres_gear_id_gear_id_fk": {
+          "name": "gear_genres_gear_id_gear_id_fk",
+          "tableFrom": "gear_genres",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_genres_genre_id_genres_id_fk": {
+          "name": "gear_genres_genre_id_genres_id_fk",
+          "tableFrom": "gear_genres",
+          "tableTo": "genres",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_genres_gear_id_genre_id_pk": {
+          "name": "gear_genres_gear_id_genre_id_pk",
+          "columns": [
+            "gear_id",
+            "genre_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_mounts": {
+      "name": "gear_mounts",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mount_id": {
+          "name": "mount_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_mounts_gear_idx": {
+          "name": "gear_mounts_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_mounts_mount_idx": {
+          "name": "gear_mounts_mount_idx",
+          "columns": [
+            {
+              "expression": "mount_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_mounts_gear_id_gear_id_fk": {
+          "name": "gear_mounts_gear_id_gear_id_fk",
+          "tableFrom": "gear_mounts",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_mounts_mount_id_mounts_id_fk": {
+          "name": "gear_mounts_mount_id_mounts_id_fk",
+          "tableFrom": "gear_mounts",
+          "tableTo": "mounts",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "mount_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_mounts_gear_id_mount_id_pk": {
+          "name": "gear_mounts_gear_id_mount_id_pk",
+          "columns": [
+            "gear_id",
+            "mount_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_popularity_daily": {
+      "name": "gear_popularity_daily",
+      "schema": "app",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wishlist_adds": {
+          "name": "wishlist_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "owner_adds": {
+          "name": "owner_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compare_adds": {
+          "name": "compare_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "review_submits": {
+          "name": "review_submits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "api_fetches": {
+          "name": "api_fetches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gpd_gear_idx": {
+          "name": "gpd_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gpd_date_idx": {
+          "name": "gpd_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_popularity_daily_gear_id_gear_id_fk": {
+          "name": "gear_popularity_daily_gear_id_gear_id_fk",
+          "tableFrom": "gear_popularity_daily",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_popularity_daily_date_gear_id_pk": {
+          "name": "gear_popularity_daily_date_gear_id_pk",
+          "columns": [
+            "date",
+            "gear_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_popularity_lifetime": {
+      "name": "gear_popularity_lifetime",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "views_lifetime": {
+          "name": "views_lifetime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wishlist_lifetime_adds": {
+          "name": "wishlist_lifetime_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "owner_lifetime_adds": {
+          "name": "owner_lifetime_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compare_lifetime_adds": {
+          "name": "compare_lifetime_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "review_lifetime_submits": {
+          "name": "review_lifetime_submits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "api_fetch_lifetime": {
+          "name": "api_fetch_lifetime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gpl_gear_idx": {
+          "name": "gpl_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_popularity_lifetime_gear_id_gear_id_fk": {
+          "name": "gear_popularity_lifetime_gear_id_gear_id_fk",
+          "tableFrom": "gear_popularity_lifetime",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_popularity_windows": {
+      "name": "gear_popularity_windows",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeframe": {
+          "name": "timeframe",
+          "type": "popularity_timeframe",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of_date": {
+          "name": "as_of_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "views_sum": {
+          "name": "views_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wishlist_adds_sum": {
+          "name": "wishlist_adds_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "owner_adds_sum": {
+          "name": "owner_adds_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compare_adds_sum": {
+          "name": "compare_adds_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "review_submits_sum": {
+          "name": "review_submits_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "api_fetches_sum": {
+          "name": "api_fetches_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gpw_timeframe_idx": {
+          "name": "gpw_timeframe_idx",
+          "columns": [
+            {
+              "expression": "timeframe",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_popularity_windows_gear_id_gear_id_fk": {
+          "name": "gear_popularity_windows_gear_id_gear_id_fk",
+          "tableFrom": "gear_popularity_windows",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_popularity_windows_gear_id_timeframe_pk": {
+          "name": "gear_popularity_windows_gear_id_timeframe_pk",
+          "columns": [
+            "gear_id",
+            "timeframe"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.genres": {
+      "name": "genres",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applies_to": {
+          "name": "applies_to",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genres_name_unique": {
+          "name": "genres_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "genres_slug_unique": {
+          "name": "genres_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.invites": {
+      "name": "invites",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "inviteeName": {
+          "name": "inviteeName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_used": {
+          "name": "is_used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "usedByUserId": {
+          "name": "usedByUserId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invites_created_by_idx": {
+          "name": "invites_created_by_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_is_used_idx": {
+          "name": "invites_is_used_idx",
+          "columns": [
+            {
+              "expression": "is_used",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_used_by_idx": {
+          "name": "invites_used_by_idx",
+          "columns": [
+            {
+              "expression": "usedByUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_createdById_user_id_fk": {
+          "name": "invites_createdById_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "createdById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "invites_usedByUserId_user_id_fk": {
+          "name": "invites_usedByUserId_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "usedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.lens_specs": {
+      "name": "lens_specs",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_prime": {
+          "name": "is_prime",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_min_mm": {
+          "name": "focal_length_min_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_max_mm": {
+          "name": "focal_length_max_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_aperture_wide": {
+          "name": "max_aperture_wide",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_aperture_tele": {
+          "name": "max_aperture_tele",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_aperture_wide": {
+          "name": "min_aperture_wide",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_aperture_tele": {
+          "name": "min_aperture_tele",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_stabilization": {
+          "name": "has_stabilization",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cipa_stabilization_rating_stops": {
+          "name": "cipa_stabilization_rating_stops",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_stabilization_switch": {
+          "name": "has_stabilization_switch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_autofocus": {
+          "name": "has_autofocus",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_macro": {
+          "name": "is_macro",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "magnification": {
+          "name": "magnification",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minimum_focus_distance_mm": {
+          "name": "minimum_focus_distance_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_focus_ring": {
+          "name": "has_focus_ring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focus_motor_type": {
+          "name": "focus_motor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_af_mf_switch": {
+          "name": "has_af_mf_switch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_focus_limiter": {
+          "name": "has_focus_limiter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_focus_recall_button": {
+          "name": "has_focus_recall_button",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_elements": {
+          "name": "number_elements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_element_groups": {
+          "name": "number_element_groups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_diffractive_optics": {
+          "name": "has_diffractive_optics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_diaphragm_blades": {
+          "name": "number_diaphragm_blades",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_rounded_diaphragm_blades": {
+          "name": "has_rounded_diaphragm_blades",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_internal_zoom": {
+          "name": "has_internal_zoom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_internal_focus": {
+          "name": "has_internal_focus",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "front_element_rotates": {
+          "name": "front_element_rotates",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mount_material": {
+          "name": "mount_material",
+          "type": "mount_material_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_weather_sealing": {
+          "name": "has_weather_sealing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_aperture_ring": {
+          "name": "has_aperture_ring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_custom_control_rings": {
+          "name": "number_custom_control_rings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_function_buttons": {
+          "name": "number_function_buttons",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepts_filter_types": {
+          "name": "accepts_filter_types",
+          "type": "lens_filter_types_enum[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "front_filter_thread_size_mm": {
+          "name": "front_filter_thread_size_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rear_filter_thread_size_mm": {
+          "name": "rear_filter_thread_size_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drop_in_filter_size_mm": {
+          "name": "drop_in_filter_size_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_built_in_teleconverter": {
+          "name": "has_built_in_teleconverter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_lens_hood": {
+          "name": "has_lens_hood",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_tripod_collar": {
+          "name": "has_tripod_collar",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lens_specs_focal_idx": {
+          "name": "lens_specs_focal_idx",
+          "columns": [
+            {
+              "expression": "focal_length_min_mm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "focal_length_max_mm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lens_specs_gear_id_gear_id_fk": {
+          "name": "lens_specs_gear_id_gear_id_fk",
+          "tableFrom": "lens_specs",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.mounts": {
+      "name": "mounts",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mounts_brand_id_brands_id_fk": {
+          "name": "mounts_brand_id_brands_id_fk",
+          "tableFrom": "mounts",
+          "tableTo": "brands",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mounts_value_unique": {
+          "name": "mounts_value_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.ownerships": {
+      "name": "ownerships",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ownership_gear_idx": {
+          "name": "ownership_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ownerships_user_id_user_id_fk": {
+          "name": "ownerships_user_id_user_id_fk",
+          "tableFrom": "ownerships",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ownerships_gear_id_gear_id_fk": {
+          "name": "ownerships_gear_id_gear_id_fk",
+          "tableFrom": "ownerships",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ownerships_user_id_gear_id_pk": {
+          "name": "ownerships_user_id_gear_id_pk",
+          "columns": [
+            "user_id",
+            "gear_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.popularity_events": {
+      "name": "popularity_events",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitor_id": {
+          "name": "visitor_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "popularity_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pop_events_gear_idx": {
+          "name": "pop_events_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pop_events_gear_type_idx": {
+          "name": "pop_events_gear_type_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pop_events_created_idx": {
+          "name": "pop_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pop_events_visitor_idx": {
+          "name": "pop_events_visitor_idx",
+          "columns": [
+            {
+              "expression": "visitor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pop_events_gear_visitor_created_idx": {
+          "name": "pop_events_gear_visitor_created_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visitor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "popularity_events_gear_id_gear_id_fk": {
+          "name": "popularity_events_gear_id_gear_id_fk",
+          "tableFrom": "popularity_events",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "popularity_events_user_id_user_id_fk": {
+          "name": "popularity_events_user_id_user_id_fk",
+          "tableFrom": "popularity_events",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.review_summaries": {
+      "name": "review_summaries",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "summary_text": {
+          "name": "summary_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_summaries_updated_idx": {
+          "name": "review_summaries_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_summaries_gear_id_gear_id_fk": {
+          "name": "review_summaries_gear_id_gear_id_fk",
+          "tableFrom": "review_summaries",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.reviews": {
+      "name": "reviews",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "review_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommend": {
+          "name": "recommend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reviews_status_idx": {
+          "name": "reviews_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_gear_idx": {
+          "name": "reviews_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_created_by_idx": {
+          "name": "reviews_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_gear_id_gear_id_fk": {
+          "name": "reviews_gear_id_gear_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_created_by_id_user_id_fk": {
+          "name": "reviews_created_by_id_user_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.rollup_runs": {
+      "name": "rollup_runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "as_of_date": {
+          "name": "as_of_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_date": {
+          "name": "corrected_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_rows": {
+          "name": "daily_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "late_arrivals": {
+          "name": "late_arrivals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "windows_rows": {
+          "name": "windows_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifetime_total_rows": {
+          "name": "lifetime_total_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rollup_runs_created_idx": {
+          "name": "rollup_runs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.sensor_formats": {
+      "name": "sensor_formats",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_factor": {
+          "name": "crop_factor",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sensor_formats_name_unique": {
+          "name": "sensor_formats_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "sensor_formats_slug_unique": {
+          "name": "sensor_formats_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.session": {
+      "name": "session",
+      "schema": "app",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "t_user_id_idx": {
+          "name": "t_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.staff_verdicts": {
+      "name": "staff_verdicts",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pros": {
+          "name": "pros",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cons": {
+          "name": "cons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "who_for": {
+          "name": "who_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_for": {
+          "name": "not_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alternatives": {
+          "name": "alternatives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "staff_verdicts_author_idx": {
+          "name": "staff_verdicts_author_idx",
+          "columns": [
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_verdicts_gear_id_gear_id_fk": {
+          "name": "staff_verdicts_gear_id_gear_id_fk",
+          "tableFrom": "staff_verdicts",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staff_verdicts_author_user_id_user_id_fk": {
+          "name": "staff_verdicts_author_user_id_user_id_fk",
+          "tableFrom": "staff_verdicts",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.use_case_ratings": {
+      "name": "use_case_ratings",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ucr_gear_idx": {
+          "name": "ucr_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ucr_genre_idx": {
+          "name": "ucr_genre_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "use_case_ratings_gear_id_gear_id_fk": {
+          "name": "use_case_ratings_gear_id_gear_id_fk",
+          "tableFrom": "use_case_ratings",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "use_case_ratings_genre_id_genres_id_fk": {
+          "name": "use_case_ratings_genre_id_genres_id_fk",
+          "tableFrom": "use_case_ratings",
+          "tableTo": "genres",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "use_case_ratings_gear_id_genre_id_pk": {
+          "name": "use_case_ratings_gear_id_genre_id_pk",
+          "columns": [
+            "gear_id",
+            "genre_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.user_badges": {
+      "name": "user_badges",
+      "schema": "app",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badgeKey": {
+          "name": "badgeKey",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awardedAt": {
+          "name": "awardedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "source": {
+          "name": "source",
+          "type": "badge_award_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_override": {
+          "name": "sort_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_badges_userId_user_id_fk": {
+          "name": "user_badges_userId_user_id_fk",
+          "tableFrom": "user_badges",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_badges_userId_badgeKey_pk": {
+          "name": "user_badges_userId_badgeKey_pk",
+          "columns": [
+            "userId",
+            "badgeKey"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.user": {
+      "name": "user",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "member_number": {
+          "name": "member_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "user_member_number_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "invite_id": {
+          "name": "invite_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_member_number_unique": {
+          "name": "user_member_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.verification_token": {
+      "name": "verification_token",
+      "schema": "app",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_token_identifier_token_pk": {
+          "name": "verification_token_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.wishlists": {
+      "name": "wishlists",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wishlist_gear_idx": {
+          "name": "wishlist_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wishlists_user_id_user_id_fk": {
+          "name": "wishlists_user_id_user_id_fk",
+          "tableFrom": "wishlists",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wishlists_gear_id_gear_id_fk": {
+          "name": "wishlists_gear_id_gear_id_fk",
+          "tableFrom": "wishlists",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "wishlists_user_id_gear_id_pk": {
+          "name": "wishlists_user_id_gear_id_pk",
+          "columns": [
+            "user_id",
+            "gear_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.camera_af_subject_categories_enum": {
+      "name": "camera_af_subject_categories_enum",
+      "schema": "public",
+      "values": [
+        "people",
+        "animals",
+        "vehicles",
+        "birds",
+        "aircraft"
+      ]
+    },
+    "public.audit_action": {
+      "name": "audit_action",
+      "schema": "public",
+      "values": [
+        "GEAR_CREATE",
+        "GEAR_RENAME",
+        "GEAR_EDIT_PROPOSE",
+        "GEAR_EDIT_APPROVE",
+        "GEAR_EDIT_REJECT",
+        "GEAR_EDIT_MERGE",
+        "REVIEW_APPROVE",
+        "REVIEW_REJECT"
+      ]
+    },
+    "public.badge_award_source": {
+      "name": "badge_award_source",
+      "schema": "public",
+      "values": [
+        "auto",
+        "manual"
+      ]
+    },
+    "public.card_bus_enum": {
+      "name": "card_bus_enum",
+      "schema": "public",
+      "values": [
+        "sd_default",
+        "uhs_i",
+        "uhs_ii",
+        "uhs_iii",
+        "sd_express",
+        "cfexpress_pcie_gen3x1",
+        "cfexpress_pcie_gen3x2",
+        "cfexpress_pcie_gen4x1",
+        "cfexpress_pcie_gen4x2",
+        "xqd_1_0",
+        "xqd_2_0",
+        "cfast_sata_ii",
+        "cfast_sata_iii",
+        "cf_udma4",
+        "cf_udma5",
+        "cf_udma6",
+        "cf_udma7",
+        "sxs_pcie_gen1",
+        "sxs_pcie_gen2",
+        "p2_pci"
+      ]
+    },
+    "public.card_form_factor_enum": {
+      "name": "card_form_factor_enum",
+      "schema": "public",
+      "values": [
+        "sd",
+        "cfexpress_type_a",
+        "cfexpress_type_b",
+        "cfexpress_type_c",
+        "xqd",
+        "cfast",
+        "compactflash_type_i",
+        "compactflash_type_ii",
+        "memory_stick_pro_duo",
+        "memory_stick_pro_hg_duo",
+        "xd_picture_card",
+        "smartmedia",
+        "sxs",
+        "p2"
+      ]
+    },
+    "public.card_speed_class_enum": {
+      "name": "card_speed_class_enum",
+      "schema": "public",
+      "values": [
+        "c2",
+        "c4",
+        "c6",
+        "c10",
+        "u1",
+        "u3",
+        "v6",
+        "v10",
+        "v30",
+        "v60",
+        "v90",
+        "vpg_20",
+        "vpg_65",
+        "vpg_130"
+      ]
+    },
+    "public.date_precision_enum": {
+      "name": "date_precision_enum",
+      "schema": "public",
+      "values": [
+        "YEAR",
+        "MONTH",
+        "DAY"
+      ]
+    },
+    "public.gear_type": {
+      "name": "gear_type",
+      "schema": "public",
+      "values": [
+        "CAMERA",
+        "LENS"
+      ]
+    },
+    "public.lens_filter_types_enum": {
+      "name": "lens_filter_types_enum",
+      "schema": "public",
+      "values": [
+        "none",
+        "front-screw-on",
+        "rear-screw-on",
+        "rear-bayonet",
+        "rear-gel-slot",
+        "rear-drop-in",
+        "internal-rotary"
+      ]
+    },
+    "public.mount_material_enum": {
+      "name": "mount_material_enum",
+      "schema": "public",
+      "values": [
+        "metal",
+        "plastic"
+      ]
+    },
+    "public.popularity_event_type": {
+      "name": "popularity_event_type",
+      "schema": "public",
+      "values": [
+        "view",
+        "wishlist_add",
+        "owner_add",
+        "compare_add",
+        "review_submit",
+        "api_fetch"
+      ]
+    },
+    "public.popularity_timeframe": {
+      "name": "popularity_timeframe",
+      "schema": "public",
+      "values": [
+        "7d",
+        "30d"
+      ]
+    },
+    "public.proposal_status": {
+      "name": "proposal_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED",
+        "MERGED"
+      ]
+    },
+    "public.raw_bit_depth_enum": {
+      "name": "raw_bit_depth_enum",
+      "schema": "public",
+      "values": [
+        "10",
+        "12",
+        "14",
+        "16"
+      ]
+    },
+    "public.review_status": {
+      "name": "review_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED"
+      ]
+    },
+    "public.sensor_stacking_types_enum": {
+      "name": "sensor_stacking_types_enum",
+      "schema": "public",
+      "values": [
+        "unstacked",
+        "partially-stacked",
+        "fully-stacked"
+      ]
+    },
+    "public.sensor_tech_types_enum": {
+      "name": "sensor_tech_types_enum",
+      "schema": "public",
+      "values": [
+        "cmos",
+        "ccd"
+      ]
+    },
+    "public.shutter_types_enum": {
+      "name": "shutter_types_enum",
+      "schema": "public",
+      "values": [
+        "mechanical",
+        "efc",
+        "electronic"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "USER",
+        "EDITOR",
+        "ADMIN"
+      ]
+    },
+    "public.viewfinder_types_enum": {
+      "name": "viewfinder_types_enum",
+      "schema": "public",
+      "values": [
+        "none",
+        "optical",
+        "electronic"
+      ]
+    }
+  },
+  "schemas": {
+    "app": "app"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1759706337411,
       "tag": "0029_warm_terrax",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1759708880811,
+      "tag": "0030_premium_cargill",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/(pages)/gear/_components/edit-gear/edit-gear-form.tsx
+++ b/src/app/(app)/(pages)/gear/_components/edit-gear/edit-gear-form.tsx
@@ -14,6 +14,7 @@ import { CoreFields } from "./fields-core";
 import { LensFields } from "./fields-lenses";
 import CameraFields from "./fields-cameras";
 import { FixedLensFields } from "./fields-fixed-lens";
+import { NotesFields } from "~/app/(app)/(pages)/gear/_components/edit-gear/fields-notes";
 import { MOUNTS } from "~/lib/generated";
 import type { gear, cameraSpecs, lensSpecs } from "~/server/db/schema";
 import { useRouter } from "next/navigation";
@@ -168,6 +169,7 @@ function EditGearForm({
       "linkMpb",
       "linkAmazon",
       "genres",
+      "notes",
     ] as const;
     const coreDiff = diffByKeys(gearData as any, formData as any, coreKeys);
     if (Object.keys(coreDiff).length > 0) payload.core = coreDiff;
@@ -511,6 +513,16 @@ function EditGearForm({
         />
       )}
 
+      {/* Notes (appears last) */}
+      <NotesFields
+        notes={
+          Array.isArray((formData as any).notes)
+            ? ((formData as any).notes as string[])
+            : []
+        }
+        onChange={(next: string[]) => handleChange("notes", next)}
+      />
+
       {showActions && (
         <div className="flex justify-end space-x-4">
           <Button
@@ -573,6 +585,10 @@ function EditGearForm({
                           if (k === "mountId") {
                             const ids = v ? [String(v)] : [];
                             display = getMountLongNamesById(ids);
+                          }
+                          if (k === "notes") {
+                            const arr = Array.isArray(v) ? (v as string[]) : [];
+                            display = arr.join("; ");
                           }
                           const label =
                             k === "mountIds" ? "Mounts" : humanizeKey(k);

--- a/src/app/(app)/(pages)/gear/_components/edit-gear/fields-notes.tsx
+++ b/src/app/(app)/(pages)/gear/_components/edit-gear/fields-notes.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Label } from "~/components/ui/label";
+import { Button } from "~/components/ui/button";
+import { Textarea } from "~/components/ui/textarea";
+
+interface NotesFieldsProps {
+  notes: string[];
+  onChange: (next: string[]) => void;
+}
+
+export function NotesFields({ notes, onChange }: NotesFieldsProps) {
+  const values = useMemo(() => (Array.isArray(notes) ? notes : []), [notes]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Notes</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="space-y-2">
+          <Label className="text-muted-foreground text-sm">
+            Add unstructured notes about this gear. Keep each thought as a
+            separate note.
+          </Label>
+        </div>
+
+        <div className="space-y-3">
+          {values.map((val, idx) => (
+            <div key={idx} className="space-y-2">
+              <Textarea
+                value={val}
+                onChange={(e) => {
+                  const next = [...values];
+                  next[idx] = e.target.value;
+                  onChange(next);
+                }}
+                placeholder={`Note #${idx + 1}`}
+                rows={3}
+              />
+              <div className="flex justify-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    const next = values.filter((_, i) => i !== idx);
+                    onChange(next);
+                  }}
+                >
+                  Remove
+                </Button>
+              </div>
+            </div>
+          ))}
+
+          <div>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => onChange([...values, ""])}
+            >
+              + Add note
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(app)/(pages)/gear/_components/specs-table.tsx
+++ b/src/app/(app)/(pages)/gear/_components/specs-table.tsx
@@ -14,6 +14,7 @@ export type SpecsTableSection = {
     label: string;
     value: ReactNode | undefined;
     tooltip?: string;
+    fullWidth?: boolean;
   }[];
 };
 export default function SpecsTable({
@@ -33,30 +34,43 @@ export default function SpecsTable({
                 {section.title}
               </h3>
               {section.data
-                .filter((item) => item.value !== undefined)
-                .map((item, index) => (
-                  <div
-                    key={item.label}
-                    className={`hover:bg-secondary/50 flex h-full items-center justify-between px-4 py-2 transition-colors duration-200 ${
-                      index % 2 === 0 ? "bg-background" : "bg-accent/60"
-                    }`}
-                  >
-                    <div className="space-x-3">
-                      <span className="text-muted-foreground">
-                        {item.label}
-                      </span>
-                      {item.tooltip && (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <InfoIcon className="text-muted-foreground h-4 w-4" />
-                          </TooltipTrigger>
-                          <TooltipContent>{item.tooltip}</TooltipContent>
-                        </Tooltip>
-                      )}
+                .filter((row) => row.value !== undefined)
+                .map((row, index) => {
+                  const baseClass = `hover:bg-secondary/50 px-4 py-2 transition-colors duration-200 ${
+                    index % 2 === 0 ? "bg-background" : "bg-accent/60"
+                  }`;
+                  if (row.fullWidth) {
+                    return (
+                      <div
+                        key={`${section.title}-full-${index}`}
+                        className={baseClass}
+                      >
+                        {row.value}
+                      </div>
+                    );
+                  }
+                  return (
+                    <div
+                      key={row.label}
+                      className={`flex h-full items-center justify-between ${baseClass}`}
+                    >
+                      <div className="space-x-3">
+                        <span className="text-muted-foreground">
+                          {row.label}
+                        </span>
+                        {row.tooltip && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <InfoIcon className="text-muted-foreground h-4 w-4" />
+                            </TooltipTrigger>
+                            <TooltipContent>{row.tooltip}</TooltipContent>
+                          </Tooltip>
+                        )}
+                      </div>
+                      <div className="text-right">{row.value}</div>
                     </div>
-                    <div className="text-right">{item.value}</div>
-                  </div>
-                ))}
+                  );
+                })}
             </div>
           </div>
         ))}

--- a/src/lib/specs/registry.tsx
+++ b/src/lib/specs/registry.tsx
@@ -777,8 +777,38 @@ export function buildGearSpecsSections(item: GearItem): SpecsTableSection[] {
         ]
       : [core, ...lensSections];
 
+  // Append Notes at the very bottom for both gear types
+  const notesSection = Array.isArray((item as any).notes)
+    ? {
+        title: "Notes",
+        data: [
+          {
+            label: "",
+            fullWidth: true,
+            value: (() => {
+              const list = ((item as any).notes as string[]).filter(
+                (n) => typeof n === "string" && n.trim().length > 0,
+              );
+              return list.length ? (
+                <ul className="text-muted-foreground list-disc space-y-1 pl-4 text-sm">
+                  {list.map((note, idx) => (
+                    <li key={idx}>{note}</li>
+                  ))}
+                </ul>
+              ) : undefined;
+            })(),
+          },
+        ],
+      }
+    : null;
+
   // Filter out rows with non-displayable values at registry level
-  return sections.map((section) => ({
+  const sectionsWithNotes =
+    notesSection && notesSection.data.length > 0
+      ? [...sections, notesSection]
+      : sections;
+
+  return sectionsWithNotes.map((section) => ({
     ...section,
     data: section.data.filter((row) => hasDisplayValue(row.value)),
   }));

--- a/src/server/db/normalizers.ts
+++ b/src/server/db/normalizers.ts
@@ -183,6 +183,23 @@ export function normalizeProposalPayloadForDb(
           return num === null ? undefined : num;
         }, z.number().nullable().optional())
         .optional(),
+      // Free-form notes: normalize to array of trimmed non-empty strings
+      notes: z
+        .preprocess((value) => {
+          if (value === null) return null;
+          if (Array.isArray(value)) {
+            const strings = value
+              .map((v) => (typeof v === "string" ? v.trim() : ""))
+              .filter((s) => s.length > 0);
+            return strings.length > 0 ? strings : [];
+          }
+          if (typeof value === "string") {
+            const s = value.trim();
+            return s.length > 0 ? [s] : [];
+          }
+          return undefined;
+        }, z.array(z.string()).nullable().optional())
+        .optional(),
     })
     .catchall(z.unknown());
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -360,6 +360,8 @@ export const gear = appSchema.table(
     linkAmazon: text("link_amazon"),
     // Denormalized shortlist of genre slugs for quick reads (authoritative list via join table)
     genres: jsonb("genres"),
+    // Unstructured user notes for the gear item (array of strings)
+    notes: text("notes").array(),
     createdAt,
     updatedAt,
   }),


### PR DESCRIPTION
Introduces a `notes` text[] column to the gear table for storing user notes. Updates the edit gear form to support adding, editing, and displaying multiple notes per gear item, with UI and normalization logic. Documentation and spec registry updated to describe the new notes functionality.