### PR TITLE
Development

### DIFF
--- a/src/app/(app)/(pages)/gear/[slug]/page.tsx
+++ b/src/app/(app)/(pages)/gear/[slug]/page.tsx
@@ -51,11 +51,17 @@ export async function generateMetadata({
 }: GearPageProps): Promise<Metadata> {
   const { slug } = await params;
   const item: GearItem = await fetchGearBySlug(slug);
+  const verdict = await fetchStaffVerdict(slug);
+  const description = verdict
+    ? `${item.name} specs and reviews. ${verdict?.content ?? ""}`
+    : `${item.name} specs and reviews. Sharply is the newest and most comprehensive photography gear database and review platform featuring expert reviews, real specs, and side-by-side comparisons in a modern, minimalist interface.`;
   return {
     title: `${item.name}: Specs & Reviews`,
+    description,
     openGraph: {
       title: `${item.name}: Specs & Reviews`,
       images: [item.thumbnailUrl ?? ""],
+      description,
     },
   };
 }


### PR DESCRIPTION
This pull request enhances the metadata generation for gear item pages by incorporating staff verdicts and improving Open Graph support. The most important changes are:

Metadata improvements:

* The page description now includes the staff verdict content if available, making the metadata more informative and relevant. ([src/app/(app)/(pages)/gear/[slug]/page.tsxR54-R64](diffhunk://#diff-4d6468da7f01caed2566fab8533038fbe4f97d6b74da463083454629ff3e8f55R54-R64))
* The Open Graph metadata now includes the gear item's thumbnail image and the improved description, enhancing link previews on social platforms. ([src/app/(app)/(pages)/gear/[slug]/page.tsxR54-R64](diffhunk://#diff-4d6468da7f01caed2566fab8533038fbe4f97d6b74da463083454629ff3e8f55R54-R64))