### PR TITLE
Development

### DIFF
--- a/src/app/(app)/(pages)/news/[slug]/page.tsx
+++ b/src/app/(app)/(pages)/news/[slug]/page.tsx
@@ -24,10 +24,17 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = await params;
   const page = await getNewsPostBySlug(slug);
+  const imageSrc =
+    page.thumbnail && typeof page.thumbnail === "object"
+      ? (page.thumbnail.url ?? undefined)
+      : undefined;
   return {
     title: `${page.title}`,
+    description: page.excerpt ?? "",
     openGraph: {
       title: `${page.title}`,
+      description: page.excerpt ?? "",
+      images: [imageSrc ?? ""],
     },
   };
 }


### PR DESCRIPTION
This pull request updates the news post page to improve metadata for SEO and social sharing, and refines the layout of the post title for better readability across screen sizes.

Metadata and SEO improvements:

* The `generateMetadata` function now sets the `description` field and uses the post excerpt for both the general and Open Graph metadata descriptions. It also includes the post's thumbnail image in Open Graph images for richer previews when sharing. ([src/app/(app)/(pages)/news/[slug]/page.tsxR27-R37](diffhunk://#diff-b322d15a668e91c6e2a7fa318c375495933ca9227f1a84122a6308f981a8e1b1R27-R37))

Layout enhancements:

* The main post title (`h1`) now has a maximum width, making it easier to read on larger screens and preventing overly long lines. ([src/app/(app)/(pages)/news/[slug]/page.tsxL56-R63](diffhunk://#diff-b322d15a668e91c6e2a7fa318c375495933ca9227f1a84122a6308f981a8e1b1L56-R63))