### PR TITLE
Handle 404 errors for gear pages and add revalidation

### DIFF
--- a/src/app/(app)/sitemap.ts
+++ b/src/app/(app)/sitemap.ts
@@ -3,6 +3,8 @@ import { fetchAllGearSlugs } from "~/server/gear/service";
 import { BRANDS, MOUNTS } from "~/lib/generated";
 import { getNewsPosts } from "~/server/payload/service";
 
+export const revalidate = 3600; // Revalidate every hour
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const slugs = await fetchAllGearSlugs();
   const newsPosts = await getNewsPosts();


### PR DESCRIPTION
Improves error handling in gear/[slug] page by returning a notFound response and custom metadata when a gear item is not found (404). Also adds a revalidate export to sitemap.ts to enable hourly revalidation.