### PR TITLE
Development

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -35,6 +35,10 @@ const config = {
         protocol: "https",
         hostname: "8v5lpkd4bi.ufs.sh",
       },
+      {
+        protocol: "https",
+        hostname: "utfs.io",
+      },
     ],
   },
 };

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -46,7 +46,9 @@ export default buildConfig({
     // storage-adapter-placeholder
     uploadthingStorage({
       collections: {
-        media: true,
+        media: {
+          disablePayloadAccessControl: true,
+        },
       },
       options: {
         token: process.env.UPLOADTHING_TOKEN || "",


### PR DESCRIPTION
This pull request makes a small configuration change to the `media` collection in the upload storage adapter. The change disables Payload's access control for this collection.

* Disabled Payload access control for the `media` collection in the `uploadthingStorage` configuration in `src/payload.config.ts`.