### PR TITLE
Refactor staff verdict section into separate component

### DIFF
--- a/src/app/(app)/(pages)/gear/_components/manage-staff-verdict-modal.tsx
+++ b/src/app/(app)/(pages)/gear/_components/manage-staff-verdict-modal.tsx
@@ -267,7 +267,8 @@ export function ManageStaffVerdictModal({ slug }: { slug: string }) {
                 )}
               />
 
-              <FormField
+              {/* TODO: Set this up with a real gear selector */}
+              {/* <FormField
                 control={form.control}
                 name="alternatives"
                 render={({ field }) => (
@@ -279,7 +280,7 @@ export function ManageStaffVerdictModal({ slug }: { slug: string }) {
                     <FormMessage />
                   </FormItem>
                 )}
-              />
+              /> */}
 
               <div className="flex justify-end gap-2">
                 <Button

--- a/src/app/(app)/(pages)/gear/_components/staff-verdict-section.tsx
+++ b/src/app/(app)/(pages)/gear/_components/staff-verdict-section.tsx
@@ -1,0 +1,124 @@
+import { ManageStaffVerdictModal } from "./manage-staff-verdict-modal";
+
+interface StaffVerdict {
+  content?: string | null;
+  pros?: unknown;
+  cons?: unknown;
+  whoFor?: string | null;
+  notFor?: string | null;
+  alternatives?: unknown;
+}
+
+export function StaffVerdictSection({
+  slug,
+  verdict,
+}: {
+  slug: string;
+  verdict: StaffVerdict | null;
+}) {
+  if (
+    !verdict ||
+    !Boolean(
+      verdict.content ||
+        verdict.pros ||
+        verdict.cons ||
+        verdict.whoFor ||
+        verdict.notFor ||
+        verdict.alternatives,
+    )
+  ) {
+    return (
+      <section id="staff-verdict" className="mt-12 scroll-mt-24 space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold">Staff Verdict</h3>
+          <ManageStaffVerdictModal slug={slug} />
+        </div>
+      </section>
+    );
+  }
+
+  const pros = Array.isArray(verdict.pros) ? (verdict.pros as string[]) : null;
+  const cons = Array.isArray(verdict.cons) ? (verdict.cons as string[]) : null;
+  const alternatives = Array.isArray(verdict.alternatives)
+    ? (verdict.alternatives as string[])
+    : null;
+
+  return (
+    <section id="staff-verdict" className="scroll-mt-24 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-xl font-semibold">Staff Verdict</h3>
+        <ManageStaffVerdictModal slug={slug} />
+      </div>
+
+      <div className="border-border overflow-hidden rounded-md border p-6">
+        {verdict.content && (
+          <div className="space-y-2">
+            {verdict.content.split("\n").map((p: string, i: number) =>
+              p.trim() ? (
+                <p key={i} className="text-sm leading-relaxed opacity-80">
+                  {p}
+                </p>
+              ) : (
+                <br key={i} />
+              ),
+            )}
+          </div>
+        )}
+
+        {(Array.isArray(pros) && pros.length > 0) ||
+        (Array.isArray(cons) && cons.length > 0) ? (
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            {Array.isArray(pros) && pros.length > 0 && (
+              <div className="rounded border border-green-400/50 bg-green-400/5 p-3">
+                <div className="text-lg font-semibold">The Good</div>
+                <ul className="my-3 list-disc space-y-2 pl-5 text-sm text-green-600 dark:text-green-400">
+                  {pros.map((p: string, i: number) => (
+                    <li key={i}>{p}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {Array.isArray(cons) && cons.length > 0 && (
+              <div className="rounded border border-red-400/50 bg-red-400/5 p-3">
+                <div className="text-lg font-semibold">The Bad</div>
+                <ul className="my-3 list-disc space-y-2 pl-5 text-sm text-red-600 dark:text-red-400">
+                  {cons.map((c: string, i: number) => (
+                    <li key={i}>{c}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        ) : null}
+
+        {(verdict.whoFor || verdict.notFor) && (
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            {verdict.whoFor && (
+              <div className="border-border rounded border p-3">
+                <div className="text-lg font-semibold">Who it's for</div>
+                <p className="mt-4 text-sm leading-relaxed">{verdict.whoFor}</p>
+              </div>
+            )}
+            {verdict.notFor && (
+              <div className="border-border rounded border p-3">
+                <div className="text-lg font-semibold">Who it's not for</div>
+                <p className="mt-4 text-sm leading-relaxed">{verdict.notFor}</p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {Array.isArray(alternatives) && alternatives.length > 0 && (
+          <div className="mt-4">
+            <div className="text-lg font-semibold">Top alternatives</div>
+            <ul className="list-disc pl-5 text-sm">
+              {alternatives.map((a: string, i: number) => (
+                <li key={i}>{a}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
This pull request refactors and improves the "Staff Verdict" section on the gear detail page. The main change is the extraction of the staff verdict display logic into a new, dedicated component, which results in cleaner code and a more maintainable structure. It also introduces minor improvements to the display and admin controls for staff verdicts.

**Staff Verdict Section Refactor and Improvements:**

* Extracted the staff verdict display logic from `page.tsx` into a new `StaffVerdictSection` component, improving code organization and maintainability. The new component provides a more visually distinct layout for pros, cons, and other verdict details.
* Updated the main gear page (`page.tsx`) to use the new `StaffVerdictSection` component, simplifying the page and ensuring the staff verdict is only shown if there is content or the user is an admin. ([src/app/(app)/(pages)/gear/[slug]/page.tsxR31](diffhunk://#diff-4d6468da7f01caed2566fab8533038fbe4f97d6b74da463083454629ff3e8f55R31), [src/app/(app)/(pages)/gear/[slug]/page.tsxR241-R261](diffhunk://#diff-4d6468da7f01caed2566fab8533038fbe4f97d6b74da463083454629ff3e8f55R241-R261), [src/app/(app)/(pages)/gear/[slug]/page.tsxL302-L408](diffhunk://#diff-4d6468da7f01caed2566fab8533038fbe4f97d6b74da463083454629ff3e8f55L302-L408))
* Added server-side session and admin role checks to conditionally render the staff verdict section for admins, enabling management controls even if there is no existing verdict. ([src/app/(app)/(pages)/gear/[slug]/page.tsxR45-R46](diffhunk://#diff-4d6468da7f01caed2566fab8533038fbe4f97d6b74da463083454629ff3e8f55R45-R46), [src/app/(app)/(pages)/gear/[slug]/page.tsxR96-R97](diffhunk://#diff-4d6468da7f01caed2566fab8533038fbe4f97d6b74da463083454629ff3e8f55R96-R97))

**UI and Code Cleanups:**

* Moved the specifications section and sign-in CTA to follow the staff verdict section for improved page flow. ([src/app/(app)/(pages)/gear/[slug]/page.tsxR241-R261](diffhunk://#diff-4d6468da7f01caed2566fab8533038fbe4f97d6b74da463083454629ff3e8f55R241-R261), [src/app/(app)/(pages)/gear/[slug]/page.tsxL254-L269](diffhunk://#diff-4d6468da7f01caed2566fab8533038fbe4f97d6b74da463083454629ff3e8f55L254-L269))
* Commented out the unfinished alternatives selector in the `ManageStaffVerdictModal` to prevent confusion and clarify future implementation work. [[1]](diffhunk://#diff-31e18994e5df0d9d543aa9c317d1de151f8afc0e13eb0743891615ce32676283L270-R271) [[2]](diffhunk://#diff-31e18994e5df0d9d543aa9c317d1de151f8afc0e13eb0743891615ce32676283L282-R283)Moved the staff verdict display logic from the gear page to a new StaffVerdictSection component for better modularity and maintainability. Updated the gear page to use this new component and improved the UI structure. Also commented out the alternatives form field in the manage staff verdict modal pending a real gear selector implementation.