### PR TITLE
Remove price source labels from pricing UI

### DIFF
--- a/src/app/(app)/(pages)/brand/[slug]/page.tsx
+++ b/src/app/(app)/(pages)/brand/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { GearCard } from "~/components/gear/gear-card";
 import BrandTrendingList from "./_components/brand-trending-list";
+import { formatPreferredPrice } from "~/lib/mapping";
 
 interface BrandPageProps {
   params: Promise<{
@@ -87,6 +88,12 @@ export default async function BrandPage({ params }: BrandPageProps) {
                       month: "short",
                     })
                   : null
+              }
+              priceText={
+                formatPreferredPrice({
+                  mpbMaxPriceUsdCents: item.mpbMaxPriceUsdCents,
+                  msrpNowUsdCents: item.msrpNowUsdCents,
+                }).displayText
               }
             />
           ))}

--- a/src/app/(app)/(pages)/browse/[[...segments]]/page.tsx
+++ b/src/app/(app)/(pages)/browse/[[...segments]]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { loadHubData, buildSeo } from "~/server/gear/browse/service";
 import { BRANDS, MOUNTS } from "~/lib/constants";
+import { formatPreferredPrice } from "~/lib/mapping";
 import AllGearContent from "../_components/all-gear-content";
 import BrandContent from "../_components/brand-content";
 import { GearCard } from "~/components/gear/gear-card";
@@ -128,9 +129,10 @@ export default async function BrowseCatchAll({
                   : null
               }
               priceText={
-                g.msrpNowUsdCents != null
-                  ? `$${(g.msrpNowUsdCents / 100).toLocaleString()}`
-                  : null
+                formatPreferredPrice({
+                  mpbMaxPriceUsdCents: g.mpbMaxPriceUsdCents,
+                  msrpNowUsdCents: g.msrpNowUsdCents,
+                }).displayText
               }
             />
           ))}
@@ -176,9 +178,10 @@ export default async function BrowseCatchAll({
                 : null
             }
             priceText={
-              g.msrpNowUsdCents != null
-                ? `$${(g.msrpNowUsdCents / 100).toLocaleString()}`
-                : null
+              formatPreferredPrice({
+                mpbMaxPriceUsdCents: g.mpbMaxPriceUsdCents,
+                msrpNowUsdCents: g.msrpNowUsdCents,
+              }).displayText
             }
           />
         ))}

--- a/src/app/(app)/(pages)/browse/_components/all-gear-content.tsx
+++ b/src/app/(app)/(pages)/browse/_components/all-gear-content.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { GearCard } from "~/components/gear/gear-card";
 import { Button } from "~/components/ui/button";
 import { BRANDS } from "~/lib/constants";
+import { formatPreferredPrice } from "~/lib/mapping";
 import { OtherBrandsSelect } from "./other-brands-select";
 import { getLatestGear } from "~/server/gear/browse/data";
 import { fetchTrending } from "~/server/popularity/service";
@@ -88,9 +89,10 @@ export default async function AllGearContent({
                   : null
               }
               priceText={
-                g.msrpNowUsdCents != null
-                  ? `$${(g.msrpNowUsdCents / 100).toLocaleString()}`
-                  : null
+                formatPreferredPrice({
+                  mpbMaxPriceUsdCents: g.mpbMaxPriceUsdCents,
+                  msrpNowUsdCents: g.msrpNowUsdCents,
+                }).displayText
               }
             />
           ))}
@@ -120,9 +122,10 @@ export default async function AllGearContent({
               brandName={g.brandName}
               gearType={g.gearType}
               priceText={
-                (g as any).msrpNowUsdCents != null
-                  ? `$${(((g as any).msrpNowUsdCents as number) / 100).toLocaleString()}`
-                  : null
+                formatPreferredPrice({
+                  mpbMaxPriceUsdCents: (g as any).mpbMaxPriceUsdCents,
+                  msrpNowUsdCents: (g as any).msrpNowUsdCents,
+                }).displayText
               }
             />
           ))}

--- a/src/app/(app)/(pages)/gear/[slug]/page.tsx
+++ b/src/app/(app)/(pages)/gear/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { formatPrice } from "~/lib/mapping";
+import { formatPreferredPrice } from "~/lib/mapping";
 import { formatHumanDate, getConstructionState } from "~/lib/utils";
 import { GearActionButtons } from "~/app/(app)/(pages)/gear/_components/gear-action-buttons";
 import {
@@ -154,6 +154,14 @@ export default async function GearPage({ params }: GearPageProps) {
     { label: item.name },
   ].filter(Boolean) as CrumbItem[];
 
+  const heroPrice = formatPreferredPrice({
+    mpbMaxPriceUsdCents: item.mpbMaxPriceUsdCents,
+    msrpNowUsdCents: item.msrpNowUsdCents,
+  });
+  const heroPriceText = heroPrice.hasPrice
+    ? heroPrice.amountText
+    : heroPrice.displayText;
+
   return (
     <main className="mx-auto max-w-7xl space-y-8 px-4 pt-20 sm:px-6">
       {/* Track page visit for popularity */}
@@ -184,11 +192,15 @@ export default async function GearPage({ params }: GearPageProps) {
               currentSlug={item.slug}
             />
           </div>
-          {item.msrpNowUsdCents && (
-            <div className="mt-2 text-lg font-semibold sm:text-2xl">
-              {formatPrice(item.msrpNowUsdCents)}
-            </div>
-          )}
+          <div
+            className={
+              heroPrice.hasPrice
+                ? "mt-2 text-lg font-semibold sm:text-2xl"
+                : "mt-2 text-base font-medium text-muted-foreground"
+            }
+          >
+            {heroPriceText}
+          </div>
         </div>
         {/* Badges */}
         <div>

--- a/src/app/(app)/(pages)/gear/page.tsx
+++ b/src/app/(app)/(pages)/gear/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { formatPrice } from "~/lib/mapping";
+import { formatPreferredPrice } from "~/lib/mapping";
 import { BRANDS } from "~/lib/constants";
 import { fetchGearForBrand } from "~/server/gear/service";
 import { Button } from "~/components/ui/button";
@@ -51,6 +51,12 @@ export default async function GearIndex() {
                       g.releaseDate
                         ? `Released ${new Date(g.releaseDate).getFullYear()}`
                         : null
+                    }
+                    priceText={
+                      formatPreferredPrice({
+                        mpbMaxPriceUsdCents: g.mpbMaxPriceUsdCents,
+                        msrpNowUsdCents: g.msrpNowUsdCents,
+                      }).displayText
                     }
                   />
                 </li>

--- a/src/app/(app)/(pages)/u/[handle]/page.tsx
+++ b/src/app/(app)/(pages)/u/[handle]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { formatPrice, getMountDisplayName } from "~/lib/mapping";
+import { formatPreferredPrice, getMountDisplayName } from "~/lib/mapping";
 import { UserReviewsList } from "~/app/(app)/(pages)/u/_components/user-reviews-list";
 import { UserBadges } from "~/app/(app)/(pages)/u/_components/user-badges";
 import {
@@ -154,6 +154,10 @@ export default async function UserProfilePage({
 
 // Gear card component for displaying individual items
 function GearCard({ item }: { item: any }) {
+  const priceDisplay = formatPreferredPrice({
+    mpbMaxPriceUsdCents: item.mpbMaxPriceUsdCents,
+    msrpNowUsdCents: item.msrpNowUsdCents,
+  });
   return (
     <Link
       href={`/gear/${item.slug}`}
@@ -191,13 +195,17 @@ function GearCard({ item }: { item: any }) {
               )}
             </div>
 
-            {item.msrpNowUsdCents && (
-              <div className="text-right">
-                <p className="font-medium">
-                  {formatPrice(item.msrpNowUsdCents)}
-                </p>
-              </div>
-            )}
+            <div className="text-right">
+              <p
+                className={
+                  priceDisplay.hasPrice
+                    ? "font-medium"
+                    : "text-muted-foreground text-sm"
+                }
+              >
+                {priceDisplay.displayText}
+              </p>
+            </div>
           </div>
         </div>
       </div>

--- a/src/lib/mapping/index.ts
+++ b/src/lib/mapping/index.ts
@@ -9,7 +9,7 @@
 export { getMountDisplayName, getMountLongName } from "./mounts-map";
 
 // Price formatting utilities
-export { formatPrice } from "./price-map";
+export { formatPrice, formatPreferredPrice } from "./price-map";
 
 // Dimensions formatting utilities
 export { formatDimensions } from "./dimensions-map";

--- a/src/lib/mapping/price-map.ts
+++ b/src/lib/mapping/price-map.ts
@@ -7,10 +7,76 @@
  * @param priceCents - Price in cents (e.g., 324900 for $3,249.00)
  * @returns Formatted price string (e.g., "$3,249.00")
  */
+const USD_COMPACT = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
 export function formatPrice(priceCents: number | null | undefined): string {
-  if (priceCents === null || priceCents === undefined)
-    return "Price not available";
+  if (!isFiniteNumber(priceCents)) return "Price not available";
 
   const dollars = priceCents / 100;
   return `$${dollars.toLocaleString()} USD`;
+}
+
+export type PreferredPriceSource = "mpb_max" | "msrp_now";
+
+export type PreferredPriceResult = {
+  source: PreferredPriceSource | null;
+  sourceLabel: string | null;
+  amountText: string | null;
+  displayText: string;
+  hasPrice: boolean;
+};
+
+const SOURCE_LABELS: Record<PreferredPriceSource, string> = {
+  mpb_max: "MPB",
+  msrp_now: "MSRP",
+};
+
+function formatUsdCompact(priceCents: number) {
+  return USD_COMPACT.format(priceCents / 100);
+}
+
+export function formatPreferredPrice(options: {
+  mpbMaxPriceUsdCents?: number | null;
+  msrpNowUsdCents?: number | null;
+  fallbackText?: string;
+}): PreferredPriceResult {
+  const fallbackText = options.fallbackText ?? "Price TBD";
+
+  const buildResult = (
+    source: PreferredPriceSource,
+    cents: number,
+  ): PreferredPriceResult => {
+    const amountText = formatUsdCompact(cents);
+    return {
+      source,
+      sourceLabel: SOURCE_LABELS[source],
+      amountText,
+      displayText: amountText,
+      hasPrice: true,
+    };
+  };
+
+  if (isFiniteNumber(options.mpbMaxPriceUsdCents)) {
+    return buildResult("mpb_max", options.mpbMaxPriceUsdCents);
+  }
+
+  if (isFiniteNumber(options.msrpNowUsdCents)) {
+    return buildResult("msrp_now", options.msrpNowUsdCents);
+  }
+
+  return {
+    source: null,
+    sourceLabel: null,
+    amountText: null,
+    displayText: fallbackText,
+    hasPrice: false,
+  };
 }

--- a/src/server/gear/browse/data.ts
+++ b/src/server/gear/browse/data.ts
@@ -79,6 +79,7 @@ export async function getLatestGear(
       releaseDate: gear.releaseDate,
       createdAt: gear.createdAt,
       msrpNowUsdCents: gear.msrpNowUsdCents,
+      mpbMaxPriceUsdCents: gear.mpbMaxPriceUsdCents,
     })
     .from(gear)
     .leftJoin(brands, eq(gear.brandId, brands.id))
@@ -113,6 +114,7 @@ export async function searchGear(input: SearchInput) {
           thumbnailUrl: gear.thumbnailUrl,
           releaseDate: gear.releaseDate,
           msrpNowUsdCents: gear.msrpNowUsdCents,
+          mpbMaxPriceUsdCents: gear.mpbMaxPriceUsdCents,
         })
         .from(gear)
         .leftJoin(gearMounts, sql`${gear.id} = ${gearMounts.gearId}`)
@@ -126,6 +128,7 @@ export async function searchGear(input: SearchInput) {
           thumbnailUrl: gear.thumbnailUrl,
           releaseDate: gear.releaseDate,
           msrpNowUsdCents: gear.msrpNowUsdCents,
+          mpbMaxPriceUsdCents: gear.mpbMaxPriceUsdCents,
         })
         .from(gear);
 

--- a/src/server/gear/data.ts
+++ b/src/server/gear/data.ts
@@ -165,6 +165,7 @@ export type GearCardRow = {
   brandSlug: string | null;
   thumbnailUrl: string | null;
   msrpNowUsdCents: number | null;
+  mpbMaxPriceUsdCents: number | null;
   msrpAtLaunchUsdCents: number | null;
   releaseDate: Date | null;
   createdAt: Date;
@@ -187,6 +188,7 @@ export async function fetchLatestGearCardsData(
       brandSlug: brands.slug,
       thumbnailUrl: gear.thumbnailUrl,
       msrpNowUsdCents: gear.msrpNowUsdCents,
+      mpbMaxPriceUsdCents: gear.mpbMaxPriceUsdCents,
       msrpAtLaunchUsdCents: gear.msrpAtLaunchUsdCents,
       releaseDate: gear.releaseDate,
       createdAt: gear.createdAt,
@@ -218,7 +220,8 @@ export async function fetchBrandGearData(
       brandName: brands.name,
       brandSlug: brands.slug,
       thumbnailUrl: gear.thumbnailUrl,
-      msrpUsdCents: gear.msrpNowUsdCents,
+      msrpNowUsdCents: gear.msrpNowUsdCents,
+      mpbMaxPriceUsdCents: gear.mpbMaxPriceUsdCents,
       releaseDate: gear.releaseDate,
       createdAt: gear.createdAt,
       resolutionMp: cameraSpecs.resolutionMp,

--- a/src/server/popularity/data.ts
+++ b/src/server/popularity/data.ts
@@ -115,6 +115,7 @@ export async function getTrendingData(
           brandId: gear.brandId,
           brandName: brands.name,
           msrpNowUsdCents: gear.msrpNowUsdCents,
+          mpbMaxPriceUsdCents: gear.mpbMaxPriceUsdCents,
         })
         .from(gearPopularityWindows)
         .innerJoin(gear, eq(gearPopularityWindows.gearId, gear.id))
@@ -131,6 +132,7 @@ export async function getTrendingData(
         brandName: r.brandName,
         gearType: r.gearType,
         msrpNowUsdCents: r.msrpNowUsdCents,
+        mpbMaxPriceUsdCents: r.mpbMaxPriceUsdCents,
         score: Number(r.score),
         stats: {
           views: Number(r.viewsSum),

--- a/src/server/users/service.ts
+++ b/src/server/users/service.ts
@@ -71,6 +71,7 @@ type GearListItem = {
   name: string;
   gearType: string;
   msrpNowUsdCents: number | null;
+  mpbMaxPriceUsdCents: number | null;
   thumbnailUrl: string | null;
   brand: { id: string; name: string; slug: string } | null;
   // mount removed from here; UI should resolve mounts separately if needed
@@ -86,6 +87,7 @@ export async function fetchUserWishlistItems(
       name: gear.name,
       gearType: gear.gearType,
       msrpNowUsdCents: gear.msrpNowUsdCents,
+      mpbMaxPriceUsdCents: gear.mpbMaxPriceUsdCents,
       thumbnailUrl: gear.thumbnailUrl,
       brand: { id: brands.id, name: brands.name, slug: brands.slug },
     })
@@ -106,6 +108,7 @@ export async function fetchUserOwnedItems(
       name: gear.name,
       gearType: gear.gearType,
       msrpNowUsdCents: gear.msrpNowUsdCents,
+      mpbMaxPriceUsdCents: gear.mpbMaxPriceUsdCents,
       thumbnailUrl: gear.thumbnailUrl,
       brand: { id: brands.id, name: brands.name, slug: brands.slug },
     })


### PR DESCRIPTION
## Summary
- update the shared preferred price formatter so its display text always renders only the dollar amount
- simplify the gear detail hero price rendering to use the formatter output directly (no MPB/MSRP prefixes)

## Testing
- `npm run lint` *(fails: missing AUTH_SECRET, AUTH_DISCORD_ID, AUTH_DISCORD_SECRET, AUTH_GOOGLE_ID, AUTH_GOOGLE_SECRET, DATABASE_URL, CRON_SECRET, DISCORD_ROLLUP_WEBHOOK_URL, OPENAI_API_KEY env vars)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691726905b00832d95d35472a20b12e9)