### PR TITLE
Update lens dimensions formatting and inputs

### DIFF
--- a/src/app/(app)/(pages)/gear/_components/edit-gear/fields-core.tsx
+++ b/src/app/(app)/(pages)/gear/_components/edit-gear/fields-core.tsx
@@ -77,6 +77,22 @@ function CoreFieldsComponent({
     [onChange],
   );
 
+  const handleLensDiameterChange = useCallback(
+    (value: number | null) => {
+      const nextValue = value ?? null;
+      onChange("widthMm", nextValue);
+      onChange("heightMm", nextValue);
+    },
+    [onChange],
+  );
+
+  const handleLensLengthChange = useCallback(
+    (value: number | null) => {
+      onChange("depthMm", value ?? null);
+    },
+    [onChange],
+  );
+
   const handleReleaseDateChange = useCallback(
     (value: string) => {
       if (!value) {
@@ -239,6 +255,18 @@ function CoreFieldsComponent({
   const formattedDepth = useMemo(() => {
     return currentSpecs.depthMm != null ? currentSpecs.depthMm : null;
   }, [currentSpecs.depthMm]);
+
+  const formattedLensDiameter = useMemo(() => {
+    if (gearType !== "LENS") return null;
+    if (currentSpecs.widthMm != null) return currentSpecs.widthMm;
+    if (currentSpecs.heightMm != null) return currentSpecs.heightMm;
+    return null;
+  }, [gearType, currentSpecs.widthMm, currentSpecs.heightMm]);
+
+  const formattedLensLength = useMemo(() => {
+    if (gearType !== "LENS") return null;
+    return currentSpecs.depthMm != null ? currentSpecs.depthMm : null;
+  }, [gearType, currentSpecs.depthMm]);
 
   // Safely format the mount value(s) for the select
   const formattedMountValue = useMemo(() => {
@@ -501,41 +529,75 @@ function CoreFieldsComponent({
           })()}
 
           {/* Dimensions */}
-          {showWhenMissing((initialSpecs as any)?.widthMm) && (
-            <NumberInput
-              id="widthMm"
-              label="Width"
-              value={formattedWidth}
-              onChange={(v) => onChange("widthMm", v)}
-              min={0}
-              step={0.1}
-              placeholder="e.g., 135.5"
-              suffix="mm"
-            />
-          )}
-          {showWhenMissing((initialSpecs as any)?.heightMm) && (
-            <NumberInput
-              id="heightMm"
-              label="Height"
-              value={formattedHeight}
-              onChange={(v) => onChange("heightMm", v)}
-              min={0}
-              step={0.1}
-              placeholder="e.g., 98.2"
-              suffix="mm"
-            />
-          )}
-          {showWhenMissing((initialSpecs as any)?.depthMm) && (
-            <NumberInput
-              id="depthMm"
-              label="Depth"
-              value={formattedDepth}
-              onChange={(v) => onChange("depthMm", v)}
-              min={0}
-              step={0.1}
-              placeholder="e.g., 75.8"
-              suffix="mm"
-            />
+          {gearType === "LENS" ? (
+            <>
+              {(
+                showWhenMissing((initialSpecs as any)?.widthMm) ||
+                showWhenMissing((initialSpecs as any)?.heightMm)
+              ) && (
+                <NumberInput
+                  id="diameterMm"
+                  label="Diameter"
+                  value={formattedLensDiameter}
+                  onChange={handleLensDiameterChange}
+                  min={0}
+                  step={0.1}
+                  placeholder="e.g., 90.5"
+                  suffix="mm"
+                />
+              )}
+              {showWhenMissing((initialSpecs as any)?.depthMm) && (
+                <NumberInput
+                  id="lengthMm"
+                  label="Length"
+                  value={formattedLensLength}
+                  onChange={handleLensLengthChange}
+                  min={0}
+                  step={0.1}
+                  placeholder="e.g., 150"
+                  suffix="mm"
+                />
+              )}
+            </>
+          ) : (
+            <>
+              {showWhenMissing((initialSpecs as any)?.widthMm) && (
+                <NumberInput
+                  id="widthMm"
+                  label="Width"
+                  value={formattedWidth}
+                  onChange={(v) => onChange("widthMm", v)}
+                  min={0}
+                  step={0.1}
+                  placeholder="e.g., 135.5"
+                  suffix="mm"
+                />
+              )}
+              {showWhenMissing((initialSpecs as any)?.heightMm) && (
+                <NumberInput
+                  id="heightMm"
+                  label="Height"
+                  value={formattedHeight}
+                  onChange={(v) => onChange("heightMm", v)}
+                  min={0}
+                  step={0.1}
+                  placeholder="e.g., 98.2"
+                  suffix="mm"
+                />
+              )}
+              {showWhenMissing((initialSpecs as any)?.depthMm) && (
+                <NumberInput
+                  id="depthMm"
+                  label="Depth"
+                  value={formattedDepth}
+                  onChange={(v) => onChange("depthMm", v)}
+                  min={0}
+                  step={0.1}
+                  placeholder="e.g., 75.8"
+                  suffix="mm"
+                />
+              )}
+            </>
           )}
 
           <div className="space-y-2 md:col-span-2">

--- a/src/lib/mapping/dimensions-map.ts
+++ b/src/lib/mapping/dimensions-map.ts
@@ -28,6 +28,35 @@ export function formatDimensions(params: {
     .join(" × ");
 }
 
+/**
+ * Specialized formatter for cylindrical lens dimensions.
+ * Displays "Diameter" (from width/height) and "Length" (from depth).
+ */
+export function formatLensDimensions(params: {
+  widthMm?: number | null | undefined;
+  heightMm?: number | null | undefined;
+  depthMm?: number | null | undefined;
+}): string | null {
+  const { widthMm, heightMm, depthMm } = params;
+  const diameterSource =
+    typeof widthMm === "number"
+      ? widthMm
+      : typeof heightMm === "number"
+        ? heightMm
+        : null;
+  const lengthValue = typeof depthMm === "number" ? depthMm : null;
+
+  if (diameterSource == null && lengthValue == null) return null;
+
+  const parts: string[] = [];
+  if (diameterSource != null)
+    parts.push(`Diameter ${formatNumber(diameterSource)}mm`);
+  if (lengthValue != null)
+    parts.push(`Length ${formatNumber(lengthValue)}mm`);
+
+  return parts.join(" × ");
+}
+
 function formatNumber(n: number): string {
   if (Number.isInteger(n)) return String(n);
   return Number(n.toFixed(1)).toString();

--- a/src/lib/mapping/index.ts
+++ b/src/lib/mapping/index.ts
@@ -12,7 +12,7 @@ export { getMountDisplayName, getMountLongName } from "./mounts-map";
 export { formatPrice } from "./price-map";
 
 // Dimensions formatting utilities
-export { formatDimensions } from "./dimensions-map";
+export { formatDimensions, formatLensDimensions } from "./dimensions-map";
 export {
   titleizeCardEnum,
   formatCardSlotDetails,

--- a/src/lib/specs/registry.tsx
+++ b/src/lib/specs/registry.tsx
@@ -4,6 +4,7 @@ import { formatHumanDateWithPrecision } from "~/lib/utils";
 import {
   formatPrice,
   formatDimensions,
+  formatLensDimensions,
   formatCardSlotDetails,
   formatCameraType,
 } from "~/lib/mapping";
@@ -173,7 +174,7 @@ export const specDictionary: SpecSectionDef[] = [
             item.depthMm == null
           )
             return undefined;
-          const dims = formatDimensions({
+          const dimensionsInput = {
             widthMm:
               typeof item.widthMm === "number"
                 ? item.widthMm
@@ -192,7 +193,11 @@ export const specDictionary: SpecSectionDef[] = [
                 : item.depthMm != null
                   ? Number(item.depthMm)
                   : null,
-          });
+          };
+          const dims =
+            item.gearType === "LENS"
+              ? formatLensDimensions(dimensionsInput)
+              : formatDimensions(dimensionsInput);
           return dims || undefined;
         },
         editElementId: "widthMm",


### PR DESCRIPTION
## Summary
- add a lens-specific formatter so specs display diameter × length while preserving camera L×W×H formatting
- update the spec registry to use the new formatter and ensure cameras keep the existing layout
- simplify the lens edit form by replacing width/height inputs with a shared diameter input plus a dedicated length input

## Testing
- `npm run lint` *(fails: missing required environment variables such as AUTH_SECRET, DATABASE_URL, etc.)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691735d7092c832d9b95df17f47dfe5b)