### PR TITLE
Remove guided preview step from video modes manager

### DIFF
--- a/docs/camera-specs/camera-video-modes.md
+++ b/docs/camera-specs/camera-video-modes.md
@@ -23,8 +23,12 @@ The video specs system stores every advertised capture mode as an individual row
 
 - **Specs Table Summary** – Groups rows by `resolution_key` and renders `resolution_label – up to {max fps} fps – {bit depth}-bit`.
 - **Detail Modal** – Builds a static matrix with resolution columns (sorted ascending using pixel dimensions or parsed “K/P” labels) and FPS rows (sorted descending). Each cell is filled with a shared bit-depth color (`src/lib/video/colors.ts`), prints `{bit depth}-bit`, and shows a Lucide `Crop` icon when `crop_factor` is `true`.
-- **Guided Editor** – Walks contributors through (1) selecting resolutions via the custom multi-select, (2) choosing FPS sets per resolution, (3) painting bit depth and forced-crop states on the matrix-style editor, and (4) previewing the auto-generated per-mode list before saving. Clicking a cell toggles the current brush value, ensuring every resolution × FPS combo expands into the right number of mode rows.
+- **Guided Editor** – Walks contributors through (1) selecting resolutions via the custom multi-select, (2) choosing FPS sets per resolution, and (3) painting bit depth and forced-crop states on the matrix-style editor. Clicking a cell toggles the current brush value, ensuring every resolution × FPS combo expands into the right number of mode rows before staging the changes in the gear form.
 - **Matrix Editor** – The painting grid replaces the old “advanced table.” It mirrors the display matrix so contributors can rapidly assign bit depths and crop flags with brush controls (mutually exclusive bit-depth vs crop brushes, clear toggles, drag-to-fill).
+
+### Codec granularity
+
+The database still stores one row per codec (contributors set `codec_label` when authoring modes), which keeps the door open for very specific codec-level differences. The current UI, however, only exposes bit-depth brushes and “max bit rate” assignments; it automatically fans out the implied codec rows behind the scenes. If we later need per-codec editing again, we can extend the manager to surface those labels while preserving the existing rows, so no migration is required.
 
 ### Code Map
 

--- a/src/app/(app)/(pages)/gear/_components/edit-gear/video-modes-manager.tsx
+++ b/src/app/(app)/(pages)/gear/_components/edit-gear/video-modes-manager.tsx
@@ -531,13 +531,6 @@ export function VideoModesManager({
     prevOpenRef.current = open;
   }, [open, value, initialModes, hydrateFromValue]);
 
-  const stagedModesCount = useMemo(() => {
-    if (Array.isArray(value) && value.length) return value.length;
-    if (Array.isArray(initialModes) && initialModes.length)
-      return initialModes.length;
-    return 0;
-  }, [initialModes, value]);
-
   const applyResolutionState = (
     nextResolutions: GuidedResolution[],
     newlyAddedKeys: string[] = [],
@@ -879,11 +872,6 @@ export function VideoModesManager({
         <div className="flex items-center justify-between">
           <div>
             <div className="text-sm font-medium">Video Modes</div>
-            <div className="text-muted-foreground text-xs">
-              {stagedModesCount
-                ? `${stagedModesCount} mode${stagedModesCount === 1 ? "" : "s"} configured`
-                : "No modes configured"}
-            </div>
           </div>
           <Button type="button" onClick={() => setOpen(true)}>
             Open Video Modes Manager
@@ -1195,52 +1183,6 @@ export function VideoModesManager({
                       })
                     }
                   />
-                )}
-              </section>
-
-              <section className="space-y-3 rounded-md border p-3">
-                <h4 className="text-sm font-semibold">
-                  Step 5: Preview generated modes
-                </h4>
-                {guidedPreview.length === 0 ? (
-                  <div className="text-muted-foreground text-xs">
-                    Complete the steps above to see a preview.
-                  </div>
-                ) : (
-                  <div className="overflow-auto rounded-md border">
-                    <table className="min-w-full border-collapse text-sm">
-                      <thead>
-                        <tr className="bg-muted/30 text-muted-foreground text-xs tracking-wide uppercase">
-                          <th className="px-3 py-2 text-left">Resolution</th>
-                          <th className="px-3 py-2 text-left">FPS</th>
-                          <th className="px-3 py-2 text-left">
-                            Codec (max available)
-                          </th>
-                          <th className="px-3 py-2 text-left">Bit depth</th>
-                          <th className="px-3 py-2 text-left">Crop</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {guidedPreview.map((mode) => (
-                          <tr key={mode.id} className="border-t">
-                            <td className="px-3 py-2">
-                              {mode.resolutionLabel}
-                            </td>
-                            <td className="px-3 py-2">{mode.fps}</td>
-                            <td className="px-3 py-2">{mode.codecLabel}</td>
-                            <td className="px-3 py-2">{mode.bitDepth}-bit</td>
-                            <td className="px-3 py-2">
-                              {mode.cropFactor ? (
-                                <Crop className="text-muted-foreground h-4 w-4" />
-                              ) : (
-                                "—"
-                              )}
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
                 )}
               </section>
             </div>


### PR DESCRIPTION
Eliminates the preview table and staged modes count from the guided editor in the video modes manager component. Updates documentation to clarify the new workflow, where contributors stage changes in the gear form without a separate preview step.