### PR TITLE
Add server-only package and type declaration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "react-hook-form": "^7.63.0",
         "react-icons": "^5.5.0",
         "react-parallax-tilt": "^1.7.309",
+        "server-only": "^0.0.1",
         "slugify": "^1.6.6",
         "sonner": "^2.0.7",
         "swr": "^2.3.6",
@@ -16411,6 +16412,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "react-hook-form": "^7.63.0",
     "react-icons": "^5.5.0",
     "react-parallax-tilt": "^1.7.309",
+    "server-only": "^0.0.1",
     "slugify": "^1.6.6",
     "sonner": "^2.0.7",
     "swr": "^2.3.6",

--- a/src/types/server-only.d.ts
+++ b/src/types/server-only.d.ts
@@ -1,0 +1,1 @@
+declare module "server-only";


### PR DESCRIPTION
Added 'server-only' as a dependency in package.json and package-lock.json. Introduced a module declaration for 'server-only' in src/types/server-only.d.ts to support TypeScript usage.