### PR TITLE
Main > Development

### DIFF
--- a/src/server/admin/gear/service.ts
+++ b/src/server/admin/gear/service.ts
@@ -129,7 +129,7 @@ export async function setGearThumbnailService(params: {
   thumbnailUrl: string | null;
 }): Promise<{ id: string; slug: string; thumbnailUrl: string | null }> {
   const session = await requireUser();
-  if (!requireRole(session, ["ADMIN"] as UserRole[])) {
+  if (!requireRole(session, ["ADMIN", "EDITOR"] as UserRole[])) {
     throw Object.assign(new Error("Unauthorized"), { status: 401 });
   }
 


### PR DESCRIPTION
This pull request makes a small but important change to the authorization logic in the `setGearThumbnailService` function. Now, both users with the `ADMIN` and `EDITOR` roles are allowed to set gear thumbnails, instead of just `ADMIN` users.

- Authorization update: Expanded allowed roles in `setGearThumbnailService` to include both `ADMIN` and `EDITOR`, allowing editors to set gear thumbnails. (`src/server/admin/gear/service.ts`)