### PR TITLE
Require alt text for Media and update storage config

### DIFF
--- a/src/collections/Media.ts
+++ b/src/collections/Media.ts
@@ -11,12 +11,13 @@ export const Media: CollectionConfig = {
     {
       name: "alt",
       type: "text",
-      required: false,
+      required: true,
     },
   ],
   upload: {
     disableLocalStorage: true,
     mimeTypes: ["image/*"],
+    staticDir: "https://",
   },
   hooks: {
     beforeChange: [

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -18,20 +18,6 @@ import { LearnPages } from "./collections/LearnPages";
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
 
-const plugins: any[] = [
-  uploadthingStorage({
-    collections: {
-      media: {
-        disablePayloadAccessControl: true,
-      },
-    },
-    options: {
-      token: process.env.UPLOADTHING_TOKEN,
-      acl: "public-read",
-    },
-  }),
-];
-
 export default buildConfig({
   admin: {
     user: Users.slug,
@@ -69,7 +55,21 @@ export default buildConfig({
     },
   }),
   sharp,
-  plugins,
+  plugins: [
+    payloadCloudPlugin(),
+    // storage-adapter-placeholder
+    uploadthingStorage({
+      collections: {
+        media: {
+          disablePayloadAccessControl: true,
+        },
+      },
+      options: {
+        token: process.env.UPLOADTHING_TOKEN || "",
+        acl: "public-read",
+      },
+    }),
+  ],
   email:
     process.env.RESEND_EMAIL_FROM && process.env.RESEND_API_KEY
       ? resendAdapter({


### PR DESCRIPTION
The 'alt' field in the Media collection is now required to improve accessibility. The media upload configuration adds a staticDir property, and the plugins array in payload.config.ts is refactored to include payloadCloudPlugin and uploadthingStorage directly in the plugins list.