### PR TITLE
Add catalog progress summary to page

### DIFF
--- a/docs/affiliate-links/mpb.md
+++ b/docs/affiliate-links/mpb.md
@@ -1,20 +1,38 @@
 ## MPB Link Flow
 
-- Gear records store an optional `linkMpb` column containing the relative or absolute path to the product on MPB (e.g., `/buy/used/canon-eos-r5/`).
-- The link generation logic in `src/lib/links/mpb.ts` handles market-specific path segments (e.g., `en-us`, `en-uk`, `en-eu`) and constructs the final direct MPB destination URL.
-- The gear page renders an MPB button that points to `/api/out/mpb?destinationPath=<encodedPath>&market=<marketCode>`.
+- Gear records store an optional `linkMpb` column containing a normalized MPB base product path (for example, `/product/canon-rf-24-70mm-f-2-8l-is-usm`).
+- Editors can paste any MPB product URL with any supported mount. The input is normalized before save by stripping the market segment and the known `-...-fit` suffix from the final slug segment.
+- MPB search URLs such as `/search?q=...` are no longer valid saved inputs and are rejected in the UI and route layer.
+- The link generation logic in `src/lib/links/mpb.ts` handles:
+  - market-specific storefront prefixes (`en-us`, `en-uk`, `en-eu`)
+  - mount-suffix normalization for storage
+  - mount-suffix reconstruction for outbound clicks
+- The gear page renders an MPB button that points to `/api/out/mpb?destinationPath=<basePath>&market=<marketCode>` and, when needed, appends `mountId=<mountId>`.
 - `src/app/(app)/api/out/mpb/route.ts` handles the redirection:
   - It resolves the `market` by prioritizing the query parameter (manually selected by the user), then falling back to server-side IP detection via Vercel edge headers.
   - If `destinationPath` is missing but a `gearSlug` or `gearId` is provided, it attempts to resolve the link from the database.
-  - It normalizes the destination into the selected MPB storefront and returns a 307 redirect.
-  - It rejects non-MPB absolute URLs with a 400 response so `/api/out/mpb` cannot be used as a generic redirect endpoint.
+  - If `mountId` is provided, it rebuilds the final MPB slug with the mapped `-...-fit` suffix before redirecting.
+  - It rejects MPB search URLs and non-MPB absolute URLs with a `400` response so `/api/out/mpb` cannot be used as a generic redirect endpoint.
+
+### Multi-Mount Lens Flow
+
+- For lenses with multiple mounts, the gear page checks the item’s `mountIds` against `MPB_MOUNT_PATHS_MAP`.
+- If more than one supported mount suffix is available, clicking the MPB card opens a modal so the user can choose the mount they want.
+- If a mount exists on the gear item but does not yet have an MPB suffix mapping, it is shown in the chooser as unavailable instead of redirecting to a broken URL.
+- If only one supported mount is available, the MPB card still opens directly without a modal.
 
 ### Market Detection & Internationalization
 
 - The system currently supports **US**, **UK**, and **EU** markets.
 - User selection is managed via a global `CountryProvider` and persisted in Local Storage.
-- **Future I18n Note**: This implementation is designed to integrate with a broader internationalization strategy. We plan to use "Method 2: Intelligent Mapping," where the user's language selection (e.g., German) automatically maps to the appropriate affiliate market (e.g., EU) while allowing for manual overrides in the footer.
+- **Future I18n Note**: This implementation is designed to integrate with a broader internationalization strategy. We plan to use "Method 2: Intelligent Mapping," where the user's language selection (for example, German) automatically maps to the appropriate affiliate market (for example, EU) while allowing for manual overrides in the footer.
 
 ```text
-linkMpb input --> GearLinks (with market param) --> /api/out/mpb?destinationPath=<path>&market=<market> --> getMpbDestinationUrl() --> 307 redirect
+MPB product link input
+  -> normalize to stored base path
+  -> GearLinks
+  -> optional mount picker for multi-mount lenses
+  -> /api/out/mpb?destinationPath=<basePath>&market=<market>&mountId=<mountId?>
+  -> getMpbDestinationUrl()
+  -> 307 redirect
 ```

--- a/src/app/(app)/(admin)/admin/gear-create.tsx
+++ b/src/app/(app)/(admin)/admin/gear-create.tsx
@@ -5,6 +5,11 @@ import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "~/components/ui/tooltip";
+import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
@@ -27,6 +32,8 @@ import type { GearType } from "~/types/gear";
 import { ENUMS } from "~/lib/constants";
 import { humanizeKey } from "~/lib/utils";
 import { splitBrandsWithPriority } from "~/lib/brands";
+import { normalizeMpbLinkInput } from "~/lib/links/mpb";
+import { InfoIcon } from "lucide-react";
 
 type Brand = { id: string; name: string };
 type FuzzyItem = { id: string; slug: string; name: string };
@@ -37,6 +44,9 @@ export function GearCreateCard() {
   const [linkManufacturer, setLinkManufacturer] = useState("");
   const [linkMpb, setLinkMpb] = useState("");
   const [linkAmazon, setLinkAmazon] = useState("");
+  const [mpbNoticeUrl, setMpbNoticeUrl] = useState<string | null>(null);
+  const [mpbPreviewUrl, setMpbPreviewUrl] = useState<string | null>(null);
+  const [mpbError, setMpbError] = useState<string | null>(null);
   const [brandId, setBrandId] = useState<string>("");
   const [gearType, setGearType] = useState<GearType | "">("");
   const [brands, setBrands] = useState<Brand[]>([]);
@@ -91,6 +101,9 @@ export function GearCreateCard() {
     setLinkManufacturer("");
     setLinkMpb("");
     setLinkAmazon("");
+    setMpbNoticeUrl(null);
+    setMpbPreviewUrl(null);
+    setMpbError(null);
     setSlugPreview("");
     setProceedAnyway(false);
     setHardSlugConflict(false);
@@ -132,6 +145,18 @@ export function GearCreateCard() {
 
   const onSubmit = async () => {
     try {
+      const normalizedMpbResult = normalizeMpbLinkInput(linkMpb);
+      if (normalizedMpbResult.kind === "search") {
+        setMpbError(
+          "MPB search URLs are no longer supported. Paste the MPB link with any fit instead.",
+        );
+        return;
+      }
+      if (normalizedMpbResult.kind === "invalid") {
+        setMpbError("Paste an MPB product link or relative product path.");
+        return;
+      }
+
       setLoading(true);
       setCreatedSlug(null);
       const { actionCreateGear } = await import("~/server/admin/gear/actions");
@@ -141,7 +166,10 @@ export function GearCreateCard() {
         gearType: gearType as "CAMERA" | "LENS",
         modelNumber: modelNumber.trim() || undefined,
         linkManufacturer: linkManufacturer.trim() || undefined,
-        linkMpb: linkMpb.trim() || undefined,
+        linkMpb:
+          normalizedMpbResult.kind === "product"
+            ? normalizedMpbResult.normalizedPath
+            : undefined,
         linkAmazon: linkAmazon.trim() || undefined,
         force: proceedAnyway,
       });
@@ -153,6 +181,9 @@ export function GearCreateCard() {
       setLinkManufacturer("");
       setLinkMpb("");
       setLinkAmazon("");
+      setMpbNoticeUrl(null);
+      setMpbPreviewUrl(null);
+      setMpbError(null);
       setSlugPreview("");
       setHardSlugConflict(false);
       setHardModelConflict(false);
@@ -163,6 +194,48 @@ export function GearCreateCard() {
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleMpbLinkInputChange = (value: string) => {
+    setLinkMpb(value);
+    setMpbNoticeUrl(null);
+    setMpbError(null);
+
+    const result = normalizeMpbLinkInput(value);
+    if (result.kind === "product" && result.wasNormalized) {
+      setMpbPreviewUrl(result.normalizedPath);
+      return;
+    }
+
+    setMpbPreviewUrl(null);
+  };
+
+  const handleMpbLinkBlur = (value: string) => {
+    const result = normalizeMpbLinkInput(value);
+
+    if (result.kind === "empty") {
+      setLinkMpb("");
+      setMpbNoticeUrl(null);
+      setMpbPreviewUrl(null);
+      setMpbError(null);
+      return;
+    }
+
+    if (result.kind === "product") {
+      setLinkMpb(result.normalizedPath);
+      setMpbNoticeUrl(result.wasNormalized ? result.normalizedPath : null);
+      setMpbPreviewUrl(null);
+      setMpbError(null);
+      return;
+    }
+
+    setMpbNoticeUrl(null);
+    setMpbPreviewUrl(null);
+    setMpbError(
+      result.kind === "search"
+        ? "MPB search URLs are no longer supported. Paste the MPB link with any fit instead."
+        : "Paste an MPB product link or relative product path.",
+    );
   };
 
   // Debounced preflight check
@@ -361,15 +434,65 @@ export function GearCreateCard() {
             />
           </div>
           <div className="space-y-1 md:col-span-3">
-            <Label htmlFor="link-mpb">MPB Link</Label>
+            <div className="flex items-center gap-2">
+              <Label htmlFor="link-mpb">MPB Link</Label>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="text-muted-foreground hover:text-foreground inline-flex"
+                    aria-label="How MPB link saving works"
+                  >
+                    <InfoIcon className="size-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs text-xs">
+                  We trim the fit from the pasted MPB link, store the base path,
+                  then rebuild the fit-specific destination later based on the
+                  mount the user wants to visit.
+                </TooltipContent>
+              </Tooltip>
+            </div>
             <Input
               id="link-mpb"
-              type="url"
+              type="text"
               value={linkMpb}
-              onChange={(e) => setLinkMpb(e.target.value)}
-              placeholder="https://www.mpb.com/..."
+              onChange={(e) => handleMpbLinkInputChange(e.target.value)}
+              onBlur={(e) => handleMpbLinkBlur(e.target.value)}
+              placeholder="paste the mpb link with any fit"
               disabled={!brandId || !gearType}
             />
+            {mpbError ? (
+              <p className="text-xs text-red-600">{mpbError}</p>
+            ) : mpbNoticeUrl ? (
+              <p className="text-muted-foreground mt-1 text-xs">
+                This link will be saved as{" "}
+                <a
+                  href={mpbNoticeUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline"
+                >
+                  {mpbNoticeUrl}
+                </a>
+                .
+              </p>
+            ) : (
+              mpbPreviewUrl && (
+                <p className="text-muted-foreground mt-1 text-xs">
+                  This link will be saved as{" "}
+                  <a
+                    href={mpbPreviewUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    {mpbPreviewUrl}
+                  </a>
+                  .
+                </p>
+              )
+            )}
           </div>
           <div className="space-y-1 md:col-span-3">
             <Label htmlFor="link-amazon">Amazon Link</Label>

--- a/src/app/(app)/(pages)/gear/[slug]/page.tsx
+++ b/src/app/(app)/(pages)/gear/[slug]/page.tsx
@@ -265,8 +265,8 @@ export default async function GearPage({
     hasCreatorVideos: creatorVideos.length > 0,
     hasRawSamples: Boolean(
       item.gearType === "CAMERA" &&
-        item.rawSamples &&
-        item.rawSamples.length > 0,
+      item.rawSamples &&
+      item.rawSamples.length > 0,
     ),
     hasAlternatives: alternatives.length > 0,
     hasRelatedArticles: relatedNews.length > 0,
@@ -412,7 +412,7 @@ export default async function GearPage({
           {item.gearType === "CAMERA" &&
             item.rawSamples &&
             item.rawSamples.length > 0 && (
-              <section id="raw-samples" className="space-y-3 scroll-mt-24">
+              <section id="raw-samples" className="scroll-mt-24 space-y-3">
                 <h3 className="text-lg font-semibold">Raw Samples</h3>
                 <div className="space-y-2">
                   {item.rawSamples.map((sample) => (
@@ -468,6 +468,8 @@ export default async function GearPage({
           <div className="mb-8">
             <GearLinks
               slug={item.slug}
+              gearType={item.gearType}
+              mountIds={item.mountIds ?? null}
               brandName={item.brands?.name ?? brand?.name ?? null}
               linkManufacturer={item.linkManufacturer ?? null}
               linkMpb={item.linkMpb ?? null}

--- a/src/app/(app)/(pages)/gear/_components/edit-gear/edit-gear-form.tsx
+++ b/src/app/(app)/(pages)/gear/_components/edit-gear/edit-gear-form.tsx
@@ -459,6 +459,9 @@ function EditGearForm({
         "hasBuiltInTeleconverter",
         "hasLensHood",
         "hasTripodCollar",
+        "isTiltShift",
+        "tiltDegrees",
+        "shiftMm",
       ] as const;
 
       // Submit-time safeguard: if focal-length min and max are equal, treat as prime

--- a/src/app/(app)/(pages)/gear/_components/edit-gear/fields-core.tsx
+++ b/src/app/(app)/(pages)/gear/_components/edit-gear/fields-core.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, memo, useMemo, useState } from "react";
+import { useCallback, useEffect, memo, useMemo, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Label } from "~/components/ui/label";
 import { DateInput } from "~/components/custom-inputs";
@@ -22,6 +22,7 @@ import {
   toDisplayAmazonProductLink,
 } from "~/lib/validation/amazon";
 import { normalizeBhProductLink } from "~/lib/validation/bhphoto";
+import { normalizeMpbLinkInput } from "~/lib/links/mpb";
 import { useSession } from "~/lib/auth/auth-client";
 import { requireRole } from "~/lib/auth/auth-helpers";
 
@@ -165,6 +166,16 @@ function CoreFieldsComponent({
 
   const [amazonNoticeUrl, setAmazonNoticeUrl] = useState<string | null>(null);
   const [amazonPreviewUrl, setAmazonPreviewUrl] = useState<string | null>(null);
+  const [mpbInputValue, setMpbInputValue] = useState(
+    currentSpecs.linkMpb || "",
+  );
+  const [mpbNoticeUrl, setMpbNoticeUrl] = useState<string | null>(null);
+  const [mpbPreviewUrl, setMpbPreviewUrl] = useState<string | null>(null);
+  const [mpbError, setMpbError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setMpbInputValue(currentSpecs.linkMpb || "");
+  }, [currentSpecs.linkMpb]);
 
   const handleAmazonLinkInputChange = useCallback(
     (value: string) => {
@@ -212,6 +223,53 @@ function CoreFieldsComponent({
         return;
       }
       onChange("linkBh", trimmed.length ? trimmed : null);
+    },
+    [onChange],
+  );
+
+  const handleMpbLinkInputChange = useCallback((value: string) => {
+    setMpbInputValue(value);
+    setMpbNoticeUrl(null);
+    setMpbError(null);
+
+    const result = normalizeMpbLinkInput(value);
+    if (result.kind === "product" && result.wasNormalized) {
+      setMpbPreviewUrl(result.normalizedPath);
+      return;
+    }
+
+    setMpbPreviewUrl(null);
+  }, []);
+
+  const handleMpbLinkBlur = useCallback(
+    (value: string) => {
+      const result = normalizeMpbLinkInput(value);
+
+      if (result.kind === "empty") {
+        setMpbInputValue("");
+        setMpbNoticeUrl(null);
+        setMpbPreviewUrl(null);
+        setMpbError(null);
+        onChange("linkMpb", null);
+        return;
+      }
+
+      if (result.kind === "product") {
+        setMpbInputValue(result.normalizedPath);
+        setMpbNoticeUrl(result.wasNormalized ? result.normalizedPath : null);
+        setMpbPreviewUrl(null);
+        setMpbError(null);
+        onChange("linkMpb", result.normalizedPath);
+        return;
+      }
+
+      setMpbNoticeUrl(null);
+      setMpbPreviewUrl(null);
+      setMpbError(
+        result.kind === "search"
+          ? "MPB search URLs are no longer supported. Paste the MPB link with any fit instead."
+          : "Paste an MPB product link or relative product path.",
+      );
     },
     [onChange],
   );
@@ -688,15 +746,65 @@ function CoreFieldsComponent({
 
           {showWhenMissing((initialSpecs as any)?.linkMpb) && (
             <div className="space-y-2 md:col-span-2">
-              <Label htmlFor="linkMpb">MPB Link</Label>
+              <div className="flex items-center gap-2">
+                <Label htmlFor="linkMpb">MPB Link</Label>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className="text-muted-foreground hover:text-foreground inline-flex"
+                      aria-label="How MPB link saving works"
+                    >
+                      <InfoIcon className="size-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs text-xs">
+                    We trim the fit from the pasted MPB link, store the base
+                    path, then rebuild the fit-specific destination later based
+                    on the mount the user wants to visit.
+                  </TooltipContent>
+                </Tooltip>
+              </div>
               <input
                 id="linkMpb"
-                type="url"
-                value={currentSpecs.linkMpb || ""}
-                onChange={(e) => handleLinkChange("linkMpb", e.target.value)}
+                type="text"
+                value={mpbInputValue}
+                onChange={(e) => handleMpbLinkInputChange(e.target.value)}
+                onBlur={(e) => handleMpbLinkBlur(e.target.value)}
                 className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-                placeholder="https://www.mpb.com/..."
+                placeholder="paste the mpb link with any fit"
               />
+              {mpbError ? (
+                <p className="mt-1 text-xs text-red-600">{mpbError}</p>
+              ) : mpbNoticeUrl ? (
+                <p className="text-muted-foreground mt-1 text-xs">
+                  This link will be saved as{" "}
+                  <a
+                    href={mpbNoticeUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    {mpbNoticeUrl}
+                  </a>
+                  .
+                </p>
+              ) : (
+                mpbPreviewUrl && (
+                  <p className="text-muted-foreground mt-1 text-xs">
+                    This link will be saved as{" "}
+                    <a
+                      href={mpbPreviewUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline"
+                    >
+                      {mpbPreviewUrl}
+                    </a>
+                    .
+                  </p>
+                )
+              )}
             </div>
           )}
 

--- a/src/app/(app)/(pages)/gear/_components/edit-gear/fields-lenses.tsx
+++ b/src/app/(app)/(pages)/gear/_components/edit-gear/fields-lenses.tsx
@@ -76,6 +76,7 @@ function LensFieldsComponent({
   const isPrimeLens = currentSpecs?.isPrime === true;
   const hasStabilization = currentSpecs?.hasStabilization === true;
   const hasAutofocus = currentSpecs?.hasAutofocus === true;
+  const isTiltShift = currentSpecs?.isTiltShift === true;
   const CLEAR_SENSOR_FORMAT_VALUE = "none";
   const sensorFormatOptions = useMemo(
     () =>
@@ -676,6 +677,53 @@ function LensFieldsComponent({
               allowNull
               showStateText
               onChange={(value) => handleFieldChange("hasTripodCollar", value)}
+            />
+          )}
+
+          {/* Is Tilt-Shift */}
+          {showWhenMissing((initialSpecs as any)?.isTiltShift) && (
+            <BooleanInput
+              id="isTiltShift"
+              label="Is Tilt-Shift"
+              checked={currentSpecs?.isTiltShift ?? null}
+              allowNull
+              showStateText
+              onChange={(value) => {
+                handleFieldChange("isTiltShift", value);
+                if (value !== true) {
+                  // Clear dependent fields when not a tilt-shift lens
+                  handleFieldChange("tiltDegrees", null);
+                  handleFieldChange("shiftMm", null);
+                }
+              }}
+            />
+          )}
+
+          {/* Tilt Degrees */}
+          {showWhenMissing((initialSpecs as any)?.tiltDegrees) && (
+            <NumberInput
+              id="tiltDegrees"
+              label="Tilt"
+              suffix="°"
+              disabled={!isTiltShift}
+              value={isTiltShift ? numOrNull(currentSpecs?.tiltDegrees) : null}
+              onChange={(value) => handleFieldChange("tiltDegrees", value)}
+              step={0.1}
+              min={0}
+            />
+          )}
+
+          {/* Shift mm */}
+          {showWhenMissing((initialSpecs as any)?.shiftMm) && (
+            <NumberInput
+              id="shiftMm"
+              label="Shift"
+              suffix="mm"
+              disabled={!isTiltShift}
+              value={isTiltShift ? numOrNull(currentSpecs?.shiftMm) : null}
+              onChange={(value) => handleFieldChange("shiftMm", value)}
+              step={0.1}
+              min={0}
             />
           )}
         </div>

--- a/src/app/(app)/(pages)/gear/_components/gear-links.tsx
+++ b/src/app/(app)/(pages)/gear/_components/gear-links.tsx
@@ -2,19 +2,37 @@
 
 import { track } from "@vercel/analytics";
 import Link from "next/link";
+import { useMemo, useState, type ReactNode } from "react";
+import { FaAmazon } from "react-icons/fa";
+import { SiFujifilm, SiLeica, SiNikon, SiSony } from "react-icons/si";
+import { CircleQuestionMark } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "~/components/ui/dialog";
+import { useCountry } from "~/lib/hooks/useCountry";
+import {
+  getMpbMountSuffix,
+  hasKnownMpbMountSuffix,
+  isMpbSearchInput,
+} from "~/lib/links/mpb";
+import { getMountLongNameById } from "~/lib/mapping/mounts-map";
 import { formatPrice } from "~/lib/mapping";
 import { parseAmazonAsin } from "~/lib/validation/amazon";
-import { FaAmazon } from "react-icons/fa";
-import { SiNikon, SiSony, SiFujifilm, SiLeica } from "react-icons/si";
-import MpbLogo from "public/mpb-logo";
-import type { ReactNode } from "react";
 import { BRANDS } from "~/lib/generated";
+import type { GearType } from "~/types/gear";
 import { CanonLogo } from "public/canon-logo";
-import { CircleQuestionMark } from "lucide-react";
-import { useCountry } from "~/lib/hooks/useCountry";
+import MpbLogo from "public/mpb-logo";
 
 interface GearLinksProps {
   slug: string;
+  gearType: GearType;
+  mountIds?: string[] | null;
   linkManufacturer: string | null;
   linkMpb: string | null;
   linkAmazon: string | null;
@@ -24,8 +42,16 @@ interface GearLinksProps {
   msrpNowUsdCents?: number | null;
 }
 
+type MpbMountOption = {
+  id: string;
+  label: string;
+  supported: boolean;
+};
+
 export function GearLinks({
   slug,
+  gearType,
+  mountIds,
   brandName,
   linkManufacturer,
   linkMpb,
@@ -34,7 +60,9 @@ export function GearLinks({
   mpbMaxPriceUsdCents,
   msrpNowUsdCents,
 }: GearLinksProps) {
-  const { countryCode, locale } = useCountry();
+  const { locale } = useCountry();
+  const [isMpbDialogOpen, setIsMpbDialogOpen] = useState(false);
+
   const amazonAsin = parseAmazonAsin(linkAmazon) ?? null;
   const amazonRedirectHref = amazonAsin
     ? `/api/out/amazon?asin=${encodeURIComponent(
@@ -73,107 +101,214 @@ export function GearLinks({
       : "New";
   const normalizedBrandName =
     typeof brandName === "string" ? brandName.trim() : "";
-  const brandSlug =
-    normalizedBrandName
-      ? (BRANDS.find(
-          (brand) =>
-            brand.name.toLowerCase() === normalizedBrandName.toLowerCase(),
-        )?.slug ?? "")
-      : "";
+  const brandSlug = normalizedBrandName
+    ? (BRANDS.find(
+        (brand) =>
+          brand.name.toLowerCase() === normalizedBrandName.toLowerCase(),
+      )?.slug ?? "")
+    : "";
   const manufacturerStyles = getManufacturerStyles(brandSlug);
+
+  const mpbMarket = locale.affiliate.mpbMarket;
+  const isLegacyMpbSearchLink = isMpbSearchInput(linkMpb);
+  const uniqueMountIds = useMemo(
+    () => Array.from(new Set((mountIds ?? []).filter(Boolean))),
+    [mountIds],
+  );
+  const mpbMountOptions = useMemo<MpbMountOption[]>(
+    () =>
+      uniqueMountIds.map((mountId) => ({
+        id: mountId,
+        label: getMountLongNameById(mountId),
+        supported: Boolean(getMpbMountSuffix(mountId)),
+      })),
+    [uniqueMountIds],
+  );
+  const supportedMpbMounts = mpbMountOptions.filter((mount) => mount.supported);
+  const hasLegacyMountedLink = hasKnownMpbMountSuffix(linkMpb);
+  const shouldShowMpbChooser =
+    !isLegacyMpbSearchLink &&
+    gearType === "LENS" &&
+    mpbMountOptions.length > 1 &&
+    supportedMpbMounts.length > 1;
+  const directMpbMountId =
+    gearType === "LENS" ? (supportedMpbMounts[0]?.id ?? null) : null;
+  const directMpbHref = useMemo(() => {
+    if (!linkMpb) return undefined;
+    if (shouldShowMpbChooser) return undefined;
+
+    if (isLegacyMpbSearchLink) {
+      return buildMpbOutHref(linkMpb, mpbMarket, null);
+    }
+
+    if (gearType !== "LENS") {
+      return buildMpbOutHref(linkMpb, mpbMarket, null);
+    }
+
+    if (supportedMpbMounts.length === 1 && directMpbMountId) {
+      return buildMpbOutHref(linkMpb, mpbMarket, directMpbMountId);
+    }
+
+    if (hasLegacyMountedLink) {
+      return buildMpbOutHref(linkMpb, mpbMarket, null);
+    }
+
+    return undefined;
+  }, [
+    directMpbMountId,
+    gearType,
+    hasLegacyMountedLink,
+    isLegacyMpbSearchLink,
+    linkMpb,
+    mpbMarket,
+    shouldShowMpbChooser,
+    supportedMpbMounts.length,
+  ]);
+  const isMpbUnavailable =
+    Boolean(linkMpb) && !shouldShowMpbChooser && !directMpbHref;
 
   if (!hasAny) return null;
 
-  const mpbMarket = locale.affiliate.mpbMarket;
-  const mpbOutLink = linkMpb
-    ? `/api/out/mpb?destinationPath=${encodeURIComponent(linkMpb)}${
-        mpbMarket ? `&market=${encodeURIComponent(mpbMarket)}` : ""
-      }`
-    : undefined;
+  function handleMpbMountSelection(mountId: string) {
+    if (!linkMpb) return;
+    const href = buildMpbOutHref(linkMpb, mpbMarket, mountId);
+    if (!href) return;
+
+    void track("gear_link_click", {
+      slug,
+      linkType: "mpb",
+      mountId,
+    });
+
+    window.open(href, "_blank", "noopener,noreferrer");
+    setIsMpbDialogOpen(false);
+  }
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold">Links</h2>
+    <>
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Links</h2>
+        </div>
+
+        {linkManufacturer && (
+          <AffiliateLinkCard
+            href={linkManufacturer}
+            title={manufacturerStyles.title}
+            description="Official site"
+            backgroundClass={manufacturerStyles.backgroundClass}
+            textColorClass={manufacturerStyles.textColorClass}
+            logo={manufacturerStyles.logo}
+            onClick={() =>
+              void track("gear_link_click", {
+                slug,
+                linkType: "manufacturer",
+              })
+            }
+          />
+        )}
+        {linkMpb && (
+          <AffiliateLinkCard
+            href={directMpbHref}
+            title="See on MPB"
+            description={
+              isMpbUnavailable
+                ? "Used • Mount-specific MPB link unavailable"
+                : mpbPriceDescription
+            }
+            backgroundClass="bg-[#0b002b] hover:bg-[#0b002b]/80"
+            textColorClass="text-white"
+            logo={<MpbLogo className="h-8 w-8 text-[#ff18bd]" />}
+            disabled={isMpbUnavailable}
+            onClick={() => {
+              if (shouldShowMpbChooser) {
+                setIsMpbDialogOpen(true);
+                return;
+              }
+
+              void track("gear_link_click", {
+                slug,
+                linkType: "mpb",
+                mountId: directMpbMountId,
+              });
+            }}
+          />
+        )}
+        {amazonAsin && amazonRedirectHref && (
+          <AffiliateLinkCard
+            href={amazonRedirectHref}
+            title="Buy on Amazon"
+            description={amazonPriceDescription}
+            backgroundClass="bg-[#ffd814] hover:bg-[#ffd814]/70"
+            textColorClass="text-black"
+            logo={<FaAmazon className="h-8 w-8" />}
+            onClick={() =>
+              void track("gear_link_click", {
+                slug,
+                linkType: "amazon",
+              })
+            }
+          />
+        )}
+        {bhRedirectHref && (
+          <AffiliateLinkCard
+            href={bhRedirectHref}
+            title="Buy at B&H Photo"
+            description={bhPriceDescription}
+            backgroundClass="bg-[#b03734] hover:bg-[#b03734]/80"
+            textColorClass="text-white"
+            logo={<></>}
+            onClick={() =>
+              void track("gear_link_click", {
+                slug,
+                linkType: "bhphoto",
+              })
+            }
+          />
+        )}
       </div>
 
-      {linkManufacturer && (
-        <AffiliateLinkCard
-          href={linkManufacturer}
-          title={manufacturerStyles.title}
-          description="Official site"
-          backgroundClass={manufacturerStyles.backgroundClass}
-          textColorClass={manufacturerStyles.textColorClass}
-          logo={manufacturerStyles.logo}
-          onClick={() =>
-            void track("gear_link_click", {
-              slug,
-              linkType: "manufacturer",
-            })
-          }
-        />
-      )}
-      {linkMpb && (
-        <AffiliateLinkCard
-          href={mpbOutLink ?? linkMpb}
-          title="See on MPB"
-          description={mpbPriceDescription}
-          backgroundClass="bg-[#0b002b] hover:bg-[#0b002b]/80"
-          textColorClass="text-white"
-          logo={<MpbLogo className="h-8 w-8 text-[#ff18bd]" />}
-          onClick={() =>
-            void track("gear_link_click", {
-              slug,
-              linkType: "mpb",
-            })
-          }
-        />
-      )}
-      {amazonAsin && amazonRedirectHref && (
-        <AffiliateLinkCard
-          href={amazonRedirectHref}
-          title="Buy on Amazon"
-          description={amazonPriceDescription}
-          backgroundClass="bg-[#ffd814] hover:bg-[#ffd814]/70"
-          textColorClass="text-black"
-          logo={<FaAmazon className="h-8 w-8" />}
-          onClick={() =>
-            void track("gear_link_click", {
-              slug,
-              linkType: "amazon",
-            })
-          }
-        />
-      )}
-      {bhRedirectHref && (
-        <AffiliateLinkCard
-          href={bhRedirectHref}
-          title="Buy at B&H Photo"
-          description={bhPriceDescription}
-          backgroundClass="bg-[#b03734] hover:bg-[#b03734]/80"
-          textColorClass="text-white"
-          logo={<></>}
-          onClick={() =>
-            void track("gear_link_click", {
-              slug,
-              linkType: "bhphoto",
-            })
-          }
-        />
-      )}
-    </div>
+      <Dialog open={isMpbDialogOpen} onOpenChange={setIsMpbDialogOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Choose MPB Mount</DialogTitle>
+            <DialogDescription>
+              This item has multiple MPB mount listings. Pick the mount you want
+              to open.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2">
+            {mpbMountOptions.map((mount) => (
+              <Button
+                key={mount.id}
+                type="button"
+                variant="outline"
+                className="w-full justify-start"
+                disabled={!mount.supported}
+                onClick={() => handleMpbMountSelection(mount.id)}
+              >
+                {mount.label}
+                {!mount.supported ? " (Unavailable)" : ""}
+              </Button>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 
 export default GearLinks;
 
 interface AffiliateLinkCardProps {
-  href: string;
+  href?: string;
   title: string;
   description: string;
   backgroundClass: string;
   textColorClass?: string;
   logo: ReactNode;
+  disabled?: boolean;
   onClick?: () => void;
 }
 
@@ -184,23 +319,81 @@ function AffiliateLinkCard({
   backgroundClass,
   textColorClass = "text-white",
   logo,
+  disabled = false,
   onClick,
 }: AffiliateLinkCardProps) {
+  const className = `flex w-full items-center justify-between rounded px-6 py-2 transition-all ${backgroundClass} ${textColorClass} ${
+    disabled ? "cursor-not-allowed opacity-60" : ""
+  }`;
+
+  if (href && !disabled) {
+    return (
+      <Link
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer sponsored"
+        className={className}
+        onClick={onClick}
+      >
+        <AffiliateLinkCardContent
+          title={title}
+          description={description}
+          logo={logo}
+        />
+      </Link>
+    );
+  }
+
   return (
-    <Link
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer sponsored"
-      className={`flex w-full items-center justify-between rounded px-6 py-2 transition-all ${backgroundClass} ${textColorClass}`}
-      onClick={onClick}
+    <button
+      type="button"
+      className={className}
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
     >
+      <AffiliateLinkCardContent
+        title={title}
+        description={description}
+        logo={logo}
+      />
+    </button>
+  );
+}
+
+function AffiliateLinkCardContent({
+  title,
+  description,
+  logo,
+}: Pick<AffiliateLinkCardProps, "title" | "description" | "logo">) {
+  return (
+    <>
       <div className="flex flex-1 flex-col text-left">
         <span className="text-sm font-semibold">{title}</span>
         <span className="text-xs opacity-90">{description}</span>
       </div>
       <span className="flex items-center justify-center">{logo}</span>
-    </Link>
+    </>
   );
+}
+
+function buildMpbOutHref(
+  linkMpb: string,
+  market: string | null,
+  mountId: string | null,
+) {
+  const params = new URLSearchParams({
+    destinationPath: linkMpb,
+  });
+
+  if (market) {
+    params.set("market", market);
+  }
+
+  if (mountId) {
+    params.set("mountId", mountId);
+  }
+
+  return `/api/out/mpb?${params.toString()}`;
 }
 
 function getManufacturerStyles(brandSlug: string): {

--- a/src/app/(app)/(pages)/lists/under-construction/_components/under-construction-client.tsx
+++ b/src/app/(app)/(pages)/lists/under-construction/_components/under-construction-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { Progress } from "~/components/ui/progress";
 import {
   Select,
   SelectContent,
@@ -29,15 +30,23 @@ type Row = {
 };
 
 type Option = { value: string; label: string };
+type Summary = {
+  totalCount: number;
+  underConstructionCount: number;
+  completedCount: number;
+  completedPercent: number;
+};
 
 export default function UnderConstructionClient({
   canToggleAutoSubmit = false,
   items,
+  summary,
   brands,
   types,
 }: {
   canToggleAutoSubmit?: boolean;
   items: Row[];
+  summary: Summary;
   brands: Option[];
   types: readonly string[];
 }) {
@@ -56,6 +65,25 @@ export default function UnderConstructionClient({
 
   return (
     <>
+      <div className="bg-card mb-6 rounded-lg border p-4">
+        <div className="mb-2 flex items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-medium">Catalog completion</p>
+            <p className="text-muted-foreground text-xs">
+              {summary.completedCount} completed •{" "}
+              {summary.underConstructionCount} under construction •{" "}
+              {summary.totalCount} total
+            </p>
+          </div>
+          <p className="text-sm font-semibold">{summary.completedPercent}%</p>
+        </div>
+        <Progress value={summary.completedPercent} className="h-2.5" />
+        <p className="text-muted-foreground mt-2 text-xs">
+          {summary.underConstructionCount} under construction out of{" "}
+          {summary.totalCount} total items
+        </p>
+      </div>
+
       <div className="mb-3 flex flex-wrap items-center gap-4">
         <div className="flex items-center gap-2">
           <span className="text-muted-foreground text-xs">Brand</span>

--- a/src/app/(app)/(pages)/lists/under-construction/_components/under-construction-client.tsx
+++ b/src/app/(app)/(pages)/lists/under-construction/_components/under-construction-client.tsx
@@ -70,7 +70,6 @@ export default function UnderConstructionClient({
           <div>
             <p className="text-sm font-medium">Catalog completion</p>
             <p className="text-muted-foreground text-xs">
-              {summary.completedCount} completed •{" "}
               {summary.underConstructionCount} under construction •{" "}
               {summary.totalCount} total
             </p>
@@ -78,10 +77,7 @@ export default function UnderConstructionClient({
           <p className="text-sm font-semibold">{summary.completedPercent}%</p>
         </div>
         <Progress value={summary.completedPercent} className="h-2.5" />
-        <p className="text-muted-foreground mt-2 text-xs">
-          {summary.underConstructionCount} under construction out of{" "}
-          {summary.totalCount} total items
-        </p>
+
       </div>
 
       <div className="mb-3 flex flex-wrap items-center gap-4">

--- a/src/app/(app)/(pages)/lists/under-construction/page.tsx
+++ b/src/app/(app)/(pages)/lists/under-construction/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { listUnderConstruction } from "~/server/gear/service";
+import { fetchGearCount } from "~/server/metrics/service";
 import UnderConstructionClient from "./_components/under-construction-client";
 import { BRANDS } from "~/lib/generated";
 import { auth } from "~/auth";
@@ -16,11 +17,16 @@ export const metadata: Metadata = {
 };
 
 export default async function Page() {
-  // Include items with at least 1 missing key OR less than 20% completion overall
-  const [items, session] = await Promise.all([
+  // Include items with at least 1 missing key OR less than 40% completion overall
+  const [items, totalCount, session] = await Promise.all([
     listUnderConstruction(1, 40),
+    fetchGearCount(),
     auth.api.getSession({ headers: await headers() }),
   ]);
+  const underConstructionCount = items.length;
+  const completedCount = Math.max(totalCount - underConstructionCount, 0);
+  const completedPercent =
+    totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
 
   return (
     <div className="mx-auto mt-24 min-h-screen max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
@@ -47,6 +53,12 @@ export default async function Page() {
       <UnderConstructionClient
         canToggleAutoSubmit={requireRole(session?.user, ["EDITOR"])}
         items={items}
+        summary={{
+          totalCount,
+          underConstructionCount,
+          completedCount,
+          completedPercent,
+        }}
         brands={BRANDS.map((b) => ({ value: b.id, label: b.name }))}
         types={GEAR_TYPES}
       />

--- a/src/app/(app)/api/out/mpb/route.ts
+++ b/src/app/(app)/api/out/mpb/route.ts
@@ -4,7 +4,11 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { headers } from "next/headers";
 
-import { getMpbDestinationUrl, type Market } from "~/lib/links/mpb";
+import {
+  getMpbDestinationUrl,
+  isMpbSearchInput,
+  type Market,
+} from "~/lib/links/mpb";
 import { resolveGearLinkMpb } from "~/server/gear/service";
 
 const EU_COUNTRIES = new Set([
@@ -73,6 +77,7 @@ export async function GET(request: NextRequest) {
   console.log("MPB out request received", { url: request.url });
   const marketParam = parseMarketParam(params.get("market"));
   const destinationPathParam = params.get("destinationPath");
+  const mountId = params.get("mountId");
   const gearSlug = params.get("gearSlug");
   const gearId = params.get("gearId");
 
@@ -112,13 +117,36 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  if (isMpbSearchInput(destinationPath)) {
+    try {
+      const redirectUrl = getMpbDestinationUrl({
+        market,
+        destinationPath,
+      });
+      return NextResponse.redirect(redirectUrl, 307);
+    } catch (error) {
+      console.error("MPB out rejected legacy search destinationPath", {
+        destinationPath,
+        error,
+      });
+      return NextResponse.json(
+        {
+          message: "Invalid MPB destinationPath.",
+        },
+        { status: 400 },
+      );
+    }
+  }
+
   try {
     const redirectUrl = getMpbDestinationUrl({
       market,
       destinationPath,
+      mountId,
     });
     console.log("MPB out redirecting", {
       destinationPath,
+      mountId,
       redirectUrl,
     });
 

--- a/src/lib/links/mpb.ts
+++ b/src/lib/links/mpb.ts
@@ -1,3 +1,5 @@
+import { MOUNTS } from "~/lib/constants";
+
 export type Market = "US" | "UK" | "EU";
 
 const MPB_HOSTNAME = "www.mpb.com";
@@ -8,19 +10,164 @@ const MPB_MARKET_PATH_SEGMENT: Record<Market, string> = {
   EU: "en-eu",
 };
 
+export const MPB_MOUNT_PATHS_MAP: Record<string, string> = {
+  "ef-canon": "-canon-fit",
+  "rf-canon": "-canon-rf-fit",
+  "ef-m-canon": "-canon-ef-m-fit",
+  "fl-canon": "-canon-fl-fit",
+  "fd-canon": "-canon-fd-fit",
+  "f-nikon": "-nikon-fit",
+  "z-nikon": "-nikon-z-fit",
+  "nikon1-nikon": "-nikon-1-fit",
+  "e-sony": "-sony-e-fit",
+  "a-sony": "-sony-a-fit",
+  "l-leica": "-l-fit",
+  "m-leica": "-leica-m-fit",
+  "ltm-leica": "-leica-ltm-fit",
+  "s-leica": "-leica-s-fit",
+  "m43-panasonic": "-micro-four-thirds-fit",
+  "43-olympus": "-four-thirds-fit",
+  "x-fujifilm": "-fujifilm-x-fit",
+  "g-fujifilm": "-fujifilm-g-fit",
+  "k-pentax": "-pentax-k-fit",
+  "q-pentax": "-pentax-q-fit",
+  "x-hasselblad": "-hasselblad-x-fit",
+  "h-hasselblad": "-hasselblad-h-fit",
+  "v-hasselblad": "-hasselblad-v-fit",
+  "sa-sigma": "-sigma-sa-fit",
+};
+
+const MOUNT_VALUE_BY_ID = new Map(
+  (MOUNTS as Array<{ id: string; value: string }>).map((mount) => [
+    mount.id,
+    mount.value,
+  ]),
+);
+
+const MPB_KNOWN_MOUNT_SUFFIXES = Array.from(
+  new Set([...Object.values(MPB_MOUNT_PATHS_MAP), "-sony-fe-fit"]),
+).sort((a, b) => b.length - a.length);
+
+export type NormalizeMpbLinkResult =
+  | { kind: "empty"; normalizedPath: null }
+  | {
+      kind: "product";
+      normalizedPath: string;
+      originalPath: string;
+      wasNormalized: boolean;
+    }
+  | { kind: "search"; originalPath: string }
+  | { kind: "invalid"; originalPath: string };
+
 interface GetMpbDestinationUrlInput {
   market: Market;
   destinationPath: string;
+  mountId?: string | null;
 }
 
 /**
  * Build a direct MPB destination URL using the requested storefront path prefix.
  */
 export function getMpbDestinationUrl(input: GetMpbDestinationUrlInput) {
-  return buildDestinationAddress(input.destinationPath, input.market);
+  return buildDestinationAddress(
+    input.destinationPath,
+    input.market,
+    input.mountId ?? null,
+  );
 }
 
-function buildDestinationAddress(destinationPath: string, market: Market) {
+export function normalizeMpbLinkInput(
+  input?: string | null,
+): NormalizeMpbLinkResult {
+  const trimmed = (input ?? "").trim();
+
+  if (!trimmed) {
+    return { kind: "empty", normalizedPath: null };
+  }
+
+  const parsed = parseMpbInput(trimmed);
+  if (!parsed) {
+    return { kind: "invalid", originalPath: trimmed };
+  }
+
+  if (parsed.kind === "absolute" && !isMpbHostname(parsed.url.hostname)) {
+    return { kind: "invalid", originalPath: trimmed };
+  }
+
+  const originalPath = stripMarketSegmentFromPath(parsed.url.pathname);
+  if (isMpbSearchPath(parsed.url.pathname)) {
+    return {
+      kind: "search",
+      originalPath: withSearch(originalPath, parsed.url),
+    };
+  }
+  if (!isMpbProductPath(originalPath)) {
+    return { kind: "invalid", originalPath };
+  }
+
+  const normalizedPath = stripKnownMountSuffixFromPath(originalPath);
+
+  return {
+    kind: "product",
+    normalizedPath,
+    originalPath,
+    wasNormalized: normalizedPath !== originalPath,
+  };
+}
+
+export function normalizeMpbLinkForStorage(
+  input?: string | null,
+): string | null {
+  const result = normalizeMpbLinkInput(input);
+
+  if (result.kind === "empty") return null;
+  if (result.kind === "product") return result.normalizedPath;
+  if (result.kind === "search") {
+    throw new Error(
+      "MPB search URLs are no longer supported. Paste a product link instead.",
+    );
+  }
+
+  throw new Error("Invalid MPB URL.");
+}
+
+export function getMpbMountSuffix(mountId?: string | null): string | null {
+  if (!mountId) return null;
+  const mountValue = MOUNT_VALUE_BY_ID.get(mountId);
+  if (!mountValue) return null;
+  return MPB_MOUNT_PATHS_MAP[mountValue] ?? null;
+}
+
+export function hasKnownMpbMountSuffix(
+  destinationPath?: string | null,
+): boolean {
+  const result = normalizeMpbLinkInput(destinationPath);
+  return result.kind === "product" && result.wasNormalized;
+}
+
+export function buildMpbPathForMount(
+  destinationPath: string,
+  mountId?: string | null,
+): string | null {
+  const result = normalizeMpbLinkInput(destinationPath);
+  if (result.kind !== "product") return null;
+  if (!mountId) return result.originalPath;
+
+  const suffix = getMpbMountSuffix(mountId);
+  if (!suffix) return null;
+
+  return appendMountSuffixToPath(result.normalizedPath, suffix);
+}
+
+export function isMpbSearchInput(input?: string | null) {
+  return normalizeMpbLinkInput(input).kind === "search";
+}
+
+function buildDestinationAddress(
+  destinationPath: string,
+  market: Market,
+  mountId: string | null,
+) {
   const cleanedDestinationPath = destinationPath.trim();
 
   if (cleanedDestinationPath === "") {
@@ -28,17 +175,25 @@ function buildDestinationAddress(destinationPath: string, market: Market) {
   }
 
   if (isHttpAddress(cleanedDestinationPath)) {
-    return buildDestinationAddressFromAbsolute(cleanedDestinationPath, market);
+    return buildDestinationAddressFromAbsolute(
+      cleanedDestinationPath,
+      market,
+      mountId,
+    );
   }
 
-  return buildDestinationAddressFromRelative(cleanedDestinationPath, market);
+  return buildDestinationAddressFromRelative(
+    cleanedDestinationPath,
+    market,
+    mountId,
+  );
 }
 
-function isHttpAddress(value: string) {
-  return value.startsWith("http://") || value.startsWith("https://");
-}
-
-function buildDestinationAddressFromAbsolute(address: string, market: Market) {
+function buildDestinationAddressFromAbsolute(
+  address: string,
+  market: Market,
+  mountId: string | null,
+) {
   const parsedAddress = new URL(address);
   if (!isMpbHostname(parsedAddress.hostname)) {
     throw new Error("MPB destination must use an MPB hostname.");
@@ -47,26 +202,138 @@ function buildDestinationAddressFromAbsolute(address: string, market: Market) {
   parsedAddress.protocol = "https:";
   parsedAddress.hostname = MPB_HOSTNAME;
   parsedAddress.port = "";
-  parsedAddress.pathname = buildMarketPath(parsedAddress.pathname, market);
+  parsedAddress.pathname = buildMarketPath(
+    parsedAddress.pathname,
+    market,
+    mountId,
+  );
   return parsedAddress.toString();
 }
 
-function buildDestinationAddressFromRelative(address: string, market: Market) {
+function buildDestinationAddressFromRelative(
+  address: string,
+  market: Market,
+  mountId: string | null,
+) {
   const parsedAddress = new URL(
     ensureLeadingSlash(address),
     `https://${MPB_HOSTNAME}`,
   );
-  parsedAddress.pathname = buildMarketPath(parsedAddress.pathname, market);
+  parsedAddress.pathname = buildMarketPath(
+    parsedAddress.pathname,
+    market,
+    mountId,
+  );
   return parsedAddress.toString();
 }
 
-function buildMarketPath(pathname: string, market: Market) {
+function buildMarketPath(
+  pathname: string,
+  market: Market,
+  mountId: string | null,
+) {
   const normalizedSegment = stripMarketSegmentFromPath(pathname);
-  return `/${MPB_MARKET_PATH_SEGMENT[market]}${normalizedSegment}`;
+  if (isMpbSearchPath(normalizedSegment)) {
+    if (mountId) {
+      throw new Error(
+        "MPB search destinations do not support mount selection.",
+      );
+    }
+    return `/${MPB_MARKET_PATH_SEGMENT[market]}${normalizedSegment}`;
+  }
+  if (!isMpbProductPath(normalizedSegment)) {
+    throw new Error("MPB destination must be a product path.");
+  }
+  const mountedSegment = mountId
+    ? buildMountedPathOrThrow(normalizedSegment, mountId)
+    : normalizedSegment;
+  return `/${MPB_MARKET_PATH_SEGMENT[market]}${mountedSegment}`;
+}
+
+function buildMountedPathOrThrow(pathname: string, mountId: string) {
+  const mountedPath = buildMpbPathForMount(pathname, mountId);
+  if (!mountedPath) {
+    throw new Error("MPB destination mount is unsupported.");
+  }
+  return mountedPath;
+}
+
+function stripKnownMountSuffixFromPath(pathname: string) {
+  const parts = stripMarketSegmentFromPath(pathname).split("/").filter(Boolean);
+  if (parts.length === 0) return "/";
+
+  const lastSegment = parts[parts.length - 1] ?? "";
+  parts[parts.length - 1] = stripKnownMountSuffixFromSlug(lastSegment);
+  return `/${parts.join("/")}`;
+}
+
+function stripKnownMountSuffixFromSlug(slug: string) {
+  for (const suffix of MPB_KNOWN_MOUNT_SUFFIXES) {
+    if (slug.toLowerCase().endsWith(suffix.toLowerCase())) {
+      return slug.slice(0, -suffix.length);
+    }
+  }
+
+  return slug;
+}
+
+function appendMountSuffixToPath(pathname: string, suffix: string) {
+  const parts = stripMarketSegmentFromPath(pathname).split("/").filter(Boolean);
+  if (parts.length === 0) {
+    throw new Error("MPB destination path must include a product slug.");
+  }
+
+  parts[parts.length - 1] = `${parts[parts.length - 1]}${suffix}`;
+  return `/${parts.join("/")}`;
+}
+
+function parseMpbInput(value: string) {
+  if (
+    isHttpAddress(value) ||
+    /^www\./i.test(value) ||
+    /^mpb\.com/i.test(value)
+  ) {
+    try {
+      const withScheme = isHttpAddress(value) ? value : `https://${value}`;
+      return { kind: "absolute" as const, url: new URL(withScheme) };
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    return {
+      kind: "relative" as const,
+      url: new URL(ensureLeadingSlash(value), `https://${MPB_HOSTNAME}`),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function withSearch(pathname: string, url: URL) {
+  return `${pathname}${url.search}`;
+}
+
+function isHttpAddress(value: string) {
+  return value.startsWith("http://") || value.startsWith("https://");
+}
+
+function isMpbSearchPath(pathname: string) {
+  return /^\/(?:en-[^/]+\/)?search(?:\/|$)/i.test(ensureLeadingSlash(pathname));
+}
+
+function isMpbProductPath(pathname: string) {
+  const normalizedPath = stripMarketSegmentFromPath(pathname);
+  return (
+    /^\/product\/[^/]+\/?$/i.test(normalizedPath) ||
+    /^\/buy\/used\/[^/]+\/?$/i.test(normalizedPath)
+  );
 }
 
 function stripMarketSegmentFromPath(path: string) {
-  return ensureLeadingSlash(path).replace(/^\/en-[^/]+/i, "");
+  const stripped = ensureLeadingSlash(path).replace(/^\/en-[^/]+/i, "");
+  return stripped === "" ? "/" : stripped;
 }
 
 function ensureLeadingSlash(value: string) {
@@ -75,5 +342,7 @@ function ensureLeadingSlash(value: string) {
 
 function isMpbHostname(hostname: string) {
   const normalizedHostname = hostname.toLowerCase();
-  return normalizedHostname === MPB_HOSTNAME || normalizedHostname === "mpb.com";
+  return (
+    normalizedHostname === MPB_HOSTNAME || normalizedHostname === "mpb.com"
+  );
 }

--- a/src/lib/specs/registry.tsx
+++ b/src/lib/specs/registry.tsx
@@ -1648,6 +1648,51 @@ export const specDictionary: SpecSectionDef[] = [
   },
 
   // ==========================================================================
+  // LENS: TILT-SHIFT
+  // ==========================================================================
+  {
+    id: "lens-tilt-shift",
+    title: "Tilt-Shift",
+    sectionAnchor: "lens-section",
+    condition: (item) => item.gearType === "LENS",
+    fields: [
+      {
+        key: "isTiltShift",
+        label: "Is Tilt-Shift",
+        getRawValue: (item) => item.lensSpecs?.isTiltShift,
+        formatDisplay: (raw) =>
+          typeof raw === "boolean" ? yesNoNull(raw, true) : undefined,
+      },
+      {
+        key: "tiltDegrees",
+        label: "Tilt Range",
+        getRawValue: (item) => item.lensSpecs?.tiltDegrees,
+        formatDisplay: (raw) => {
+          if (raw == null) return undefined;
+          const n = Number(raw);
+          return Number.isFinite(n)
+            ? `±${Number.isInteger(n) ? n : n.toFixed(1)}°`
+            : undefined;
+        },
+        condition: (item) => item.lensSpecs?.isTiltShift === true,
+      },
+      {
+        key: "shiftMm",
+        label: "Shift Range",
+        getRawValue: (item) => item.lensSpecs?.shiftMm,
+        formatDisplay: (raw) => {
+          if (raw == null) return undefined;
+          const n = Number(raw);
+          return Number.isFinite(n)
+            ? `±${Number.isInteger(n) ? n : n.toFixed(1)}mm`
+            : undefined;
+        },
+        condition: (item) => item.lensSpecs?.isTiltShift === true,
+      },
+    ],
+  },
+
+  // ==========================================================================
   // ANALOG CAMERAS
   // ==========================================================================
   {

--- a/src/server/admin/gear/data.ts
+++ b/src/server/admin/gear/data.ts
@@ -14,15 +14,14 @@ import {
   recommendationItems,
 } from "~/server/db/schema";
 import { buildGearSearchName } from "~/lib/gear/naming";
+import { normalizeMpbLinkForStorage } from "~/lib/links/mpb";
 import { normalizeFuzzyTokens } from "~/lib/utils/fuzzy";
 import type { GearType } from "~/types/gear";
 
 type DbTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
 type DbLike = typeof db | DbTx;
 
-function isForeignKeyViolation(
-  error: unknown,
-): error is {
+function isForeignKeyViolation(error: unknown): error is {
   code: string;
   constraint?: string;
   constraint_name?: string;
@@ -225,6 +224,8 @@ export async function createGearData(
     linkAmazon,
   } = params;
 
+  const normalizedLinkMpb = normalizeMpbLinkForStorage(linkMpb);
+
   // Validate brand exists
   const b = await db
     .select()
@@ -301,7 +302,7 @@ export async function createGearData(
         brandId,
         modelNumber: modelNumber || null,
         linkManufacturer: linkManufacturer || null,
-        linkMpb: linkMpb || null,
+        linkMpb: normalizedLinkMpb,
         linkAmazon: linkAmazon || null,
         mountId: normalizedMountIds[0] ?? null,
         searchName: buildGearSearchName({ name: displayName, brandName }),
@@ -599,14 +600,18 @@ export async function deleteGearData(
 ): Promise<DeleteGearResult> {
   try {
     if (conn === db) {
-      return await db.transaction(async (tx) => deleteGearDataWithConn(tx, gearId));
+      return await db.transaction(async (tx) =>
+        deleteGearDataWithConn(tx, gearId),
+      );
     }
 
     return await deleteGearDataWithConn(conn, gearId);
   } catch (error) {
     if (isForeignKeyViolation(error)) {
       throw Object.assign(
-        new Error("Cannot delete gear because related records still reference it"),
+        new Error(
+          "Cannot delete gear because related records still reference it",
+        ),
         {
           status: 409,
           constraint: error.constraint_name ?? error.constraint ?? null,

--- a/src/server/db/normalizers.ts
+++ b/src/server/db/normalizers.ts
@@ -1251,6 +1251,27 @@ export function normalizeProposalPayloadForDb(
           z.boolean().nullable().optional(),
         )
         .optional(),
+      isTiltShift: z
+        .preprocess(
+          (value) =>
+            value === null ? null : (coerceBoolean(value) ?? undefined),
+          z.boolean().nullable().optional(),
+        )
+        .optional(),
+      tiltDegrees: z
+        .preprocess((value) => {
+          if (value === null) return null;
+          const num = coerceNumber(value);
+          return num === null ? undefined : Math.round(num * 10) / 10;
+        }, z.number().nullable().optional())
+        .optional(),
+      shiftMm: z
+        .preprocess((value) => {
+          if (value === null) return null;
+          const num = coerceNumber(value);
+          return num === null ? undefined : Math.round(num * 10) / 10;
+        }, z.number().nullable().optional())
+        .optional(),
     })
     .catchall(z.unknown())
     .transform((lens) => {

--- a/src/server/db/normalizers.ts
+++ b/src/server/db/normalizers.ts
@@ -1,5 +1,6 @@
 import { SENSOR_FORMATS, ENUMS } from "~/lib/constants";
 import { normalizeBhProductLink } from "~/lib/validation/bhphoto";
+import { normalizeMpbLinkForStorage } from "~/lib/links/mpb";
 import {
   videoModeInputSchema,
   normalizeVideoModes,
@@ -264,8 +265,7 @@ export function normalizeProposalPayloadForDb(
         .preprocess((value) => {
           if (value === null) return null;
           if (typeof value === "string") {
-            const trimmed = value.trim();
-            return trimmed.length > 0 ? trimmed : null;
+            return normalizeMpbLinkForStorage(value);
           }
           return undefined;
         }, z.string().nullable().optional())
@@ -1354,20 +1354,21 @@ export function normalizeProposalPayloadForDb(
             return num === null ? undefined : num;
           }, z.number().nullable().optional())
           .optional(),
-      imageCircleSizeId: z
-        .preprocess((value) => {
-          if (value === null) return null;
-          if (typeof value !== "string") return undefined;
-          if (isUuid(value)) return value;
-          const match = SENSOR_FORMATS.find(
-            (format) =>
-              format &&
-              typeof format === "object" &&
-              ((format as any).slug === value || (format as any).id === value),
-          ) as { id?: string } | undefined;
-          return match?.id ?? undefined;
-        }, z.string().uuid().nullable().optional())
-        .optional(),
+        imageCircleSizeId: z
+          .preprocess((value) => {
+            if (value === null) return null;
+            if (typeof value !== "string") return undefined;
+            if (isUuid(value)) return value;
+            const match = SENSOR_FORMATS.find(
+              (format) =>
+                format &&
+                typeof format === "object" &&
+                ((format as any).slug === value ||
+                  (format as any).id === value),
+            ) as { id?: string } | undefined;
+            return match?.id ?? undefined;
+          }, z.string().uuid().nullable().optional())
+          .optional(),
         maxApertureWide: z
           .preprocess((value) => {
             if (value === null) return null;

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1015,6 +1015,10 @@ export const lensSpecs = appSchema.table(
     hasBuiltInTeleconverter: boolean("has_built_in_teleconverter"),
     hasLensHood: boolean("has_lens_hood"),
     hasTripodCollar: boolean("has_tripod_collar"),
+    // tilt-shift
+    isTiltShift: boolean("is_tilt_shift"),
+    tiltDegrees: decimal("tilt_degrees", { precision: 4, scale: 1 }),
+    shiftMm: decimal("shift_mm", { precision: 5, scale: 1 }),
     extra: jsonb("extra"),
     createdAt,
     updatedAt,

--- a/tests/unit/mpb-links.test.ts
+++ b/tests/unit/mpb-links.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import { getMpbDestinationUrl } from "~/lib/links/mpb";
+import { MOUNTS } from "~/lib/constants";
+import {
+  buildMpbPathForMount,
+  getMpbDestinationUrl,
+  MPB_MOUNT_PATHS_MAP,
+  normalizeMpbLinkInput,
+} from "~/lib/links/mpb";
 
-describe("getMpbDestinationUrl", () => {
+const NIKON_F_MOUNT_ID = "1e930c0c-aadb-4dd3-93ae-7f691cc93296";
+
+describe("MPB link helpers", () => {
   it("rewrites relative paths into the selected market storefront", () => {
     expect(
       getMpbDestinationUrl({
@@ -19,8 +27,75 @@ describe("getMpbDestinationUrl", () => {
         destinationPath:
           "https://www.mpb.com/en-us/product/nikon-z6-iii?sort=price#details",
       }),
+    ).toBe("https://www.mpb.com/en-uk/product/nikon-z6-iii?sort=price#details");
+  });
+
+  it("normalizes mount-specific product URLs to a base path", () => {
+    expect(
+      normalizeMpbLinkInput(
+        "https://www.mpb.com/en-us/product/sigma-24-70mm-f-2-8-dg-dn-art-sony-fe-fit",
+      ),
+    ).toEqual({
+      kind: "product",
+      normalizedPath: "/product/sigma-24-70mm-f-2-8-dg-dn-art",
+      originalPath: "/product/sigma-24-70mm-f-2-8-dg-dn-art-sony-fe-fit",
+      wasNormalized: true,
+    });
+  });
+
+  it("normalizes market-prefixed relative URLs to a base path", () => {
+    expect(
+      normalizeMpbLinkInput("/en-us/product/nikon-af-s-50mm-f-1-8g-nikon-fit"),
+    ).toEqual({
+      kind: "product",
+      normalizedPath: "/product/nikon-af-s-50mm-f-1-8g",
+      originalPath: "/product/nikon-af-s-50mm-f-1-8g-nikon-fit",
+      wasNormalized: true,
+    });
+  });
+
+  it("rejects MPB search URLs during normalization", () => {
+    expect(
+      normalizeMpbLinkInput("https://www.mpb.com/en-us/search?q=canon+ef+50mm"),
+    ).toEqual({
+      kind: "search",
+      originalPath: "/search?q=canon+ef+50mm",
+    });
+  });
+
+  it("rejects non-product MPB paths during normalization", () => {
+    expect(
+      normalizeMpbLinkInput("https://www.mpb.com/en-us/help/shipping"),
+    ).toEqual({
+      kind: "invalid",
+      originalPath: "/help/shipping",
+    });
+  });
+
+  it("appends a mapped mount suffix to the base path", () => {
+    expect(
+      buildMpbPathForMount("/product/nikon-af-s-50mm-f-1-8g", NIKON_F_MOUNT_ID),
+    ).toBe("/product/nikon-af-s-50mm-f-1-8g-nikon-fit");
+  });
+
+  it("returns null when no suffix exists for the requested mount", () => {
+    expect(
+      buildMpbPathForMount(
+        "/product/nikon-af-s-50mm-f-1-8g",
+        "00000000-0000-0000-0000-000000000000",
+      ),
+    ).toBeNull();
+  });
+
+  it("builds a market-aware URL for a selected mount", () => {
+    expect(
+      getMpbDestinationUrl({
+        market: "EU",
+        destinationPath: "/product/nikon-af-s-50mm-f-1-8g",
+        mountId: NIKON_F_MOUNT_ID,
+      }),
     ).toBe(
-      "https://www.mpb.com/en-uk/product/nikon-z6-iii?sort=price#details",
+      "https://www.mpb.com/en-eu/product/nikon-af-s-50mm-f-1-8g-nikon-fit",
     );
   });
 
@@ -31,5 +106,35 @@ describe("getMpbDestinationUrl", () => {
         destinationPath: "https://example.com/product/nikon-z6-iii",
       }),
     ).toThrow("MPB destination must use an MPB hostname.");
+  });
+
+  it("fails when a mapped mount value is not present in generated mounts", () => {
+    const mountValues = new Set(
+      (MOUNTS as Array<{ value: string }>).map((mount) => mount.value),
+    );
+    const unknownMappedValues = Object.keys(MPB_MOUNT_PATHS_MAP).filter(
+      (value) => !mountValues.has(value),
+    );
+
+    expect(unknownMappedValues).toEqual([]);
+  });
+
+  it("tracks unmapped generated mount values", () => {
+    const mappedValues = new Set(Object.keys(MPB_MOUNT_PATHS_MAP));
+    const unmappedMountValues = (MOUNTS as Array<{ value: string }>)
+      .map((mount) => mount.value)
+      .filter((value) => !mappedValues.has(value))
+      .sort();
+
+    expect(unmappedMountValues).toMatchInlineSnapshot(`
+      [
+        "a-minolta",
+        "fixed-lens",
+        "m42-zeiss",
+        "m645-mamiya",
+        "s-nikon",
+        "sr-minolta",
+      ]
+    `);
   });
 });

--- a/tests/unit/mpb-out-route.test.ts
+++ b/tests/unit/mpb-out-route.test.ts
@@ -14,6 +14,8 @@ vi.mock("server-only", () => ({}));
 
 import { GET } from "../../src/app/(app)/api/out/mpb/route";
 
+const NIKON_F_MOUNT_ID = "1e930c0c-aadb-4dd3-93ae-7f691cc93296";
+
 describe("MPB out route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -102,6 +104,19 @@ describe("MPB out route", () => {
     );
   });
 
+  it("builds a mount-specific redirect from the stored base path", async () => {
+    const response = await GET(
+      new Request(
+        `http://localhost/api/out/mpb?destinationPath=%2Fproduct%2Fnikon-af-s-50mm-f-1-8g&mountId=${encodeURIComponent(NIKON_F_MOUNT_ID)}&market=EU`,
+      ) as any,
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://www.mpb.com/en-eu/product/nikon-af-s-50mm-f-1-8g-nikon-fit",
+    );
+  });
+
   it("returns 400 when no destination can be resolved", async () => {
     const response = await GET(
       new Request("http://localhost/api/out/mpb?gearSlug=nikon-z6-iii") as any,
@@ -110,7 +125,8 @@ describe("MPB out route", () => {
 
     expect(response.status).toBe(400);
     expect(payload).toEqual({
-      message: "Missing destinationPath or gear reference with a valid MPB link.",
+      message:
+        "Missing destinationPath or gear reference with a valid MPB link.",
     });
   });
 
@@ -118,6 +134,33 @@ describe("MPB out route", () => {
     const response = await GET(
       new Request(
         "http://localhost/api/out/mpb?destinationPath=https%3A%2F%2Fexample.com%2Fproduct%2Fnikon-z6-iii",
+      ) as any,
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload).toEqual({
+      message: "Invalid MPB destinationPath.",
+    });
+  });
+
+  it("keeps legacy MPB search URLs working", async () => {
+    const response = await GET(
+      new Request(
+        "http://localhost/api/out/mpb?destinationPath=https%3A%2F%2Fwww.mpb.com%2Fen-us%2Fsearch%3Fq%3Dcanon",
+      ) as any,
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://www.mpb.com/en-us/search?q=canon",
+    );
+  });
+
+  it("returns 400 for non-product MPB paths", async () => {
+    const response = await GET(
+      new Request(
+        "http://localhost/api/out/mpb?destinationPath=https%3A%2F%2Fwww.mpb.com%2Fen-us%2Fhelp%2Fshipping",
       ) as any,
     );
     const payload = await response.json();

--- a/tests/unit/under-construction-page.test.ts
+++ b/tests/unit/under-construction-page.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const gearServiceMocks = vi.hoisted(() => ({
+  listUnderConstruction: vi.fn(),
+}));
+
+const metricsMocks = vi.hoisted(() => ({
+  fetchGearCount: vi.fn(),
+}));
+
+const authMocks = vi.hoisted(() => ({
+  auth: {
+    api: {
+      getSession: vi.fn(),
+    },
+  },
+}));
+
+const headerMocks = vi.hoisted(() => ({
+  headers: vi.fn(),
+}));
+
+const authHelperMocks = vi.hoisted(() => ({
+  requireRole: vi.fn(),
+}));
+
+const clientComponentMock = vi.hoisted(() => vi.fn((_props: unknown) => null));
+
+vi.mock("~/server/gear/service", () => gearServiceMocks);
+vi.mock("~/server/metrics/service", () => metricsMocks);
+vi.mock("~/auth", () => authMocks);
+vi.mock("next/headers", () => headerMocks);
+vi.mock("~/lib/auth/auth-helpers", () => authHelperMocks);
+vi.mock(
+  "~/app/(app)/(pages)/lists/under-construction/_components/under-construction-client",
+  () => ({
+    default: clientComponentMock,
+  }),
+);
+
+import Page from "~/app/(app)/(pages)/lists/under-construction/page";
+
+type ClientProps = {
+  canToggleAutoSubmit: boolean;
+  items: unknown[];
+  summary: {
+    totalCount: number;
+    underConstructionCount: number;
+    completedCount: number;
+    completedPercent: number;
+  };
+};
+
+function getClientProps() {
+  const firstCall = clientComponentMock.mock.calls.at(0);
+  if (!firstCall) {
+    throw new Error("Expected UnderConstructionClient to render");
+  }
+  return firstCall[0] as unknown as ClientProps;
+}
+
+describe("under construction page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    headerMocks.headers.mockResolvedValue(new Headers());
+    authMocks.auth.api.getSession.mockResolvedValue({ user: { id: "user-1" } });
+    authHelperMocks.requireRole.mockReturnValue(true);
+  });
+
+  it("passes the computed catalog summary to the client", async () => {
+    const items = [
+      { id: "1", slug: "alpha", name: "Alpha", createdAt: new Date() },
+      { id: "2", slug: "beta", name: "Beta", createdAt: new Date() },
+    ];
+    gearServiceMocks.listUnderConstruction.mockResolvedValue(items);
+    metricsMocks.fetchGearCount.mockResolvedValue(10);
+
+    renderToStaticMarkup(await Page());
+    const props = getClientProps();
+
+    expect(gearServiceMocks.listUnderConstruction).toHaveBeenCalledWith(1, 40);
+    expect(metricsMocks.fetchGearCount).toHaveBeenCalledTimes(1);
+    expect(props.canToggleAutoSubmit).toBe(true);
+    expect(props.items).toBe(items);
+    expect(props.summary).toEqual({
+      totalCount: 10,
+      underConstructionCount: 2,
+      completedCount: 8,
+      completedPercent: 80,
+    });
+  });
+
+  it("handles an empty catalog without dividing by zero", async () => {
+    gearServiceMocks.listUnderConstruction.mockResolvedValue([]);
+    metricsMocks.fetchGearCount.mockResolvedValue(0);
+
+    renderToStaticMarkup(await Page());
+    const props = getClientProps();
+
+    expect(props.summary).toEqual({
+      totalCount: 0,
+      underConstructionCount: 0,
+      completedCount: 0,
+      completedPercent: 0,
+    });
+  });
+
+  it("clamps completed items at zero when the backlog matches the total", async () => {
+    gearServiceMocks.listUnderConstruction.mockResolvedValue([
+      { id: "1", slug: "alpha", name: "Alpha", createdAt: new Date() },
+      { id: "2", slug: "beta", name: "Beta", createdAt: new Date() },
+      { id: "3", slug: "gamma", name: "Gamma", createdAt: new Date() },
+    ]);
+    metricsMocks.fetchGearCount.mockResolvedValue(3);
+
+    renderToStaticMarkup(await Page());
+    const props = getClientProps();
+
+    expect(props.summary).toEqual({
+      totalCount: 3,
+      underConstructionCount: 3,
+      completedCount: 0,
+      completedPercent: 0,
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,8 +7,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   resolve: {
     alias: {
+      "@": path.resolve(__dirname, "src"),
       "~": path.resolve(__dirname, "src"),
     },
+  },
+  esbuild: {
+    jsx: "automatic",
+    jsxImportSource: "react",
   },
   test: {
     environment: "node",


### PR DESCRIPTION
Compute and pass a catalog summary (total, underConstruction, completed, completedPercent) to UnderConstructionClient. Page now fetches total gear count via fetchGearCount, computes completedCount (clamped at 0) and completedPercent (rounded, handles divide-by-zero), and updates the under-construction threshold to 40%. The client component imports a Progress bar, accepts a Summary prop, and renders a progress UI block. Added unit tests to verify summary calculation and edge cases.