### PR TITLE
Development

### DIFF
--- a/docs/affiliate-links/mpb.md
+++ b/docs/affiliate-links/mpb.md
@@ -1,20 +1,38 @@
 ## MPB Link Flow
 
-- Gear records store an optional `linkMpb` column containing the relative or absolute path to the product on MPB (e.g., `/buy/used/canon-eos-r5/`).
-- The link generation logic in `src/lib/links/mpb.ts` handles market-specific path segments (e.g., `en-us`, `en-uk`, `en-eu`) and constructs the final direct MPB destination URL.
-- The gear page renders an MPB button that points to `/api/out/mpb?destinationPath=<encodedPath>&market=<marketCode>`.
+- Gear records store an optional `linkMpb` column containing a normalized MPB base product path (for example, `/product/canon-rf-24-70mm-f-2-8l-is-usm`).
+- Editors can paste any MPB product URL with any supported mount. The input is normalized before save by stripping the market segment and the known `-...-fit` suffix from the final slug segment.
+- MPB search URLs such as `/search?q=...` are no longer valid saved inputs and are rejected in the UI and route layer.
+- The link generation logic in `src/lib/links/mpb.ts` handles:
+  - market-specific storefront prefixes (`en-us`, `en-uk`, `en-eu`)
+  - mount-suffix normalization for storage
+  - mount-suffix reconstruction for outbound clicks
+- The gear page renders an MPB button that points to `/api/out/mpb?destinationPath=<basePath>&market=<marketCode>` and, when needed, appends `mountId=<mountId>`.
 - `src/app/(app)/api/out/mpb/route.ts` handles the redirection:
   - It resolves the `market` by prioritizing the query parameter (manually selected by the user), then falling back to server-side IP detection via Vercel edge headers.
   - If `destinationPath` is missing but a `gearSlug` or `gearId` is provided, it attempts to resolve the link from the database.
-  - It normalizes the destination into the selected MPB storefront and returns a 307 redirect.
-  - It rejects non-MPB absolute URLs with a 400 response so `/api/out/mpb` cannot be used as a generic redirect endpoint.
+  - If `mountId` is provided, it rebuilds the final MPB slug with the mapped `-...-fit` suffix before redirecting.
+  - It rejects MPB search URLs and non-MPB absolute URLs with a `400` response so `/api/out/mpb` cannot be used as a generic redirect endpoint.
+
+### Multi-Mount Lens Flow
+
+- For lenses with multiple mounts, the gear page checks the item’s `mountIds` against `MPB_MOUNT_PATHS_MAP`.
+- If more than one supported mount suffix is available, clicking the MPB card opens a modal so the user can choose the mount they want.
+- If a mount exists on the gear item but does not yet have an MPB suffix mapping, it is shown in the chooser as unavailable instead of redirecting to a broken URL.
+- If only one supported mount is available, the MPB card still opens directly without a modal.
 
 ### Market Detection & Internationalization
 
 - The system currently supports **US**, **UK**, and **EU** markets.
 - User selection is managed via a global `CountryProvider` and persisted in Local Storage.
-- **Future I18n Note**: This implementation is designed to integrate with a broader internationalization strategy. We plan to use "Method 2: Intelligent Mapping," where the user's language selection (e.g., German) automatically maps to the appropriate affiliate market (e.g., EU) while allowing for manual overrides in the footer.
+- **Future I18n Note**: This implementation is designed to integrate with a broader internationalization strategy. We plan to use "Method 2: Intelligent Mapping," where the user's language selection (for example, German) automatically maps to the appropriate affiliate market (for example, EU) while allowing for manual overrides in the footer.
 
 ```text
-linkMpb input --> GearLinks (with market param) --> /api/out/mpb?destinationPath=<path>&market=<market> --> getMpbDestinationUrl() --> 307 redirect
+MPB product link input
+  -> normalize to stored base path
+  -> GearLinks
+  -> optional mount picker for multi-mount lenses
+  -> /api/out/mpb?destinationPath=<basePath>&market=<market>&mountId=<mountId?>
+  -> getMpbDestinationUrl()
+  -> 307 redirect
 ```

--- a/drizzle/0015_moaning_angel.sql
+++ b/drizzle/0015_moaning_angel.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "app"."lens_specs" ADD COLUMN "is_tilt_shift" boolean;--> statement-breakpoint
+ALTER TABLE "app"."lens_specs" ADD COLUMN "tilt_degrees" numeric(4, 1);--> statement-breakpoint
+ALTER TABLE "app"."lens_specs" ADD COLUMN "shift_mm" numeric(5, 1);

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,8278 @@
+{
+  "id": "00d87eeb-ee4a-4884-93ce-70c01924ba6a",
+  "prevId": "82b120dc-a0d6-439e-9391-5480e5723c9c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app.af_area_modes": {
+      "name": "af_area_modes",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_name": {
+          "name": "search_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "af_area_modes_brand_idx": {
+          "name": "af_area_modes_brand_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "af_area_modes_name_idx": {
+          "name": "af_area_modes_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "af_area_modes_search_name_idx": {
+          "name": "af_area_modes_search_name_idx",
+          "columns": [
+            {
+              "expression": "search_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "af_area_modes_brand_id_brands_id_fk": {
+          "name": "af_area_modes_brand_id_brands_id_fk",
+          "tableFrom": "af_area_modes",
+          "tableTo": "brands",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.analog_camera_specs": {
+      "name": "analog_camera_specs",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "camera_type": {
+          "name": "camera_type",
+          "type": "analog_types_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_medium": {
+          "name": "capture_medium",
+          "type": "analog_medium_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "film_transport_type": {
+          "name": "film_transport_type",
+          "type": "film_transport_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_auto_film_advance": {
+          "name": "has_auto_film_advance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_optional_motorized_drive": {
+          "name": "has_optional_motorized_drive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewfinder_type": {
+          "name": "viewfinder_type",
+          "type": "analog_viewfinder_types_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_type": {
+          "name": "shutter_type",
+          "type": "shutter_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_max": {
+          "name": "shutter_speed_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_min": {
+          "name": "shutter_speed_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flash_sync_speed": {
+          "name": "flash_sync_speed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_bulb_mode": {
+          "name": "has_bulb_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_metering": {
+          "name": "has_metering",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metering_modes": {
+          "name": "metering_modes",
+          "type": "metering_mode_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exposure_modes": {
+          "name": "exposure_modes",
+          "type": "exposure_modes_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metering_display_types": {
+          "name": "metering_display_types",
+          "type": "metering_display_type_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_exposure_compensation": {
+          "name": "has_exposure_compensation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso_setting_method": {
+          "name": "iso_setting_method",
+          "type": "iso_setting_method_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso_min": {
+          "name": "iso_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso_max": {
+          "name": "iso_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_auto_focus": {
+          "name": "has_auto_focus",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focus_aid_types": {
+          "name": "focus_aid_types",
+          "type": "focus_aid_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_battery_for_shutter": {
+          "name": "requires_battery_for_shutter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_battery_for_metering": {
+          "name": "requires_battery_for_metering",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_batteries": {
+          "name": "supported_batteries",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_continuous_drive": {
+          "name": "has_continuous_drive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_continuous_fps": {
+          "name": "max_continuous_fps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_hot_shoe": {
+          "name": "has_hot_shoe",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_self_timer": {
+          "name": "has_self_timer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_intervalometer": {
+          "name": "has_intervalometer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analog_camera_specs_gear_idx": {
+          "name": "analog_camera_specs_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analog_camera_specs_gear_id_gear_id_fk": {
+          "name": "analog_camera_specs_gear_id_gear_id_fk",
+          "tableFrom": "analog_camera_specs",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.approved_creators": {
+      "name": "approved_creators",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "creator_video_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_url": {
+          "name": "channel_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "internal_notes": {
+          "name": "internal_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approved_creators_name_idx": {
+          "name": "approved_creators_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approved_creators_platform_active_idx": {
+          "name": "approved_creators_platform_active_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.audit_logs": {
+      "name": "audit_logs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "action": {
+          "name": "action",
+          "type": "audit_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gear_edit_id": {
+          "name": "gear_edit_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_created_idx": {
+          "name": "audit_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_action_idx": {
+          "name": "audit_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_actor_idx": {
+          "name": "audit_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_gear_idx": {
+          "name": "audit_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_edit_idx": {
+          "name": "audit_edit_idx",
+          "columns": [
+            {
+              "expression": "gear_edit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_actor_user_id_user_id_fk": {
+          "name": "audit_logs_actor_user_id_user_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "audit_logs_gear_id_gear_id_fk": {
+          "name": "audit_logs_gear_id_gear_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_logs_gear_edit_id_gear_edits_id_fk": {
+          "name": "audit_logs_gear_edit_id_gear_edits_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "gear_edits",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_edit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.auth_accounts": {
+      "name": "auth_accounts",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_accounts_userId_idx": {
+          "name": "auth_accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_accounts_user_id_user_id_fk": {
+          "name": "auth_accounts_user_id_user_id_fk",
+          "tableFrom": "auth_accounts",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_sessions_userId_idx": {
+          "name": "auth_sessions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_sessions_user_id_user_id_fk": {
+          "name": "auth_sessions_user_id_user_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_sessions_token_unique": {
+          "name": "auth_sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.auth_verifications": {
+      "name": "auth_verifications",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_verifications_identifier_idx": {
+          "name": "auth_verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.badge_awards_log": {
+      "name": "badge_awards_log",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "badgeKey": {
+          "name": "badgeKey",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "badge_award_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awardedAt": {
+          "name": "awardedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "badge_awards_log_user_idx": {
+          "name": "badge_awards_log_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "badge_awards_log_awarded_idx": {
+          "name": "badge_awards_log_awarded_idx",
+          "columns": [
+            {
+              "expression": "awardedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "badge_awards_log_badge_idx": {
+          "name": "badge_awards_log_badge_idx",
+          "columns": [
+            {
+              "expression": "badgeKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "badge_awards_log_userId_user_id_fk": {
+          "name": "badge_awards_log_userId_user_id_fk",
+          "tableFrom": "badge_awards_log",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.bingo_board_tiles": {
+      "name": "bingo_board_tiles",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_free_tile": {
+          "name": "is_free_tile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_by_user_id": {
+          "name": "completed_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_submission_id": {
+          "name": "completed_submission_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bingo_board_tiles_board_position_uq": {
+          "name": "bingo_board_tiles_board_position_uq",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bingo_board_tiles_board_completed_idx": {
+          "name": "bingo_board_tiles_board_completed_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bingo_board_tiles_board_id_bingo_boards_id_fk": {
+          "name": "bingo_board_tiles_board_id_bingo_boards_id_fk",
+          "tableFrom": "bingo_board_tiles",
+          "tableTo": "bingo_boards",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bingo_board_tiles_completed_by_user_id_user_id_fk": {
+          "name": "bingo_board_tiles_completed_by_user_id_user_id_fk",
+          "tableFrom": "bingo_board_tiles",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "completed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bingo_board_tiles_completed_submission_id_bingo_submissions_id_fk": {
+          "name": "bingo_board_tiles_completed_submission_id_bingo_submissions_id_fk",
+          "tableFrom": "bingo_board_tiles",
+          "tableTo": "bingo_submissions",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "completed_submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.bingo_boards": {
+      "name": "bingo_boards",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "status": {
+          "name": "status",
+          "type": "bingo_board_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "inactivity_duration_seconds": {
+          "name": "inactivity_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14400
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_completed_at": {
+          "name": "first_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bingo_boards_status_idx": {
+          "name": "bingo_boards_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bingo_boards_created_idx": {
+          "name": "bingo_boards_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bingo_boards_created_by_user_id_user_id_fk": {
+          "name": "bingo_boards_created_by_user_id_user_id_fk",
+          "tableFrom": "bingo_boards",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.bingo_events": {
+      "name": "bingo_events",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "bingo_events_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "type": {
+          "name": "type",
+          "type": "bingo_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_tile_id": {
+          "name": "board_tile_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bingo_events_board_idx": {
+          "name": "bingo_events_board_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bingo_events_board_id_idx": {
+          "name": "bingo_events_board_id_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bingo_events_created_idx": {
+          "name": "bingo_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bingo_events_board_id_bingo_boards_id_fk": {
+          "name": "bingo_events_board_id_bingo_boards_id_fk",
+          "tableFrom": "bingo_events",
+          "tableTo": "bingo_boards",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bingo_events_board_tile_id_bingo_board_tiles_id_fk": {
+          "name": "bingo_events_board_tile_id_bingo_board_tiles_id_fk",
+          "tableFrom": "bingo_events",
+          "tableTo": "bingo_board_tiles",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "board_tile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bingo_events_submission_id_bingo_submissions_id_fk": {
+          "name": "bingo_events_submission_id_bingo_submissions_id_fk",
+          "tableFrom": "bingo_events",
+          "tableTo": "bingo_submissions",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bingo_events_user_id_user_id_fk": {
+          "name": "bingo_events_user_id_user_id_fk",
+          "tableFrom": "bingo_events",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.bingo_scores": {
+      "name": "bingo_scores",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bingo_scores_board_user_uq": {
+          "name": "bingo_scores_board_user_uq",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bingo_scores_board_points_idx": {
+          "name": "bingo_scores_board_points_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "points",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bingo_scores_board_id_bingo_boards_id_fk": {
+          "name": "bingo_scores_board_id_bingo_boards_id_fk",
+          "tableFrom": "bingo_scores",
+          "tableTo": "bingo_boards",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bingo_scores_user_id_user_id_fk": {
+          "name": "bingo_scores_user_id_user_id_fk",
+          "tableFrom": "bingo_scores",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.bingo_submissions": {
+      "name": "bingo_submissions",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_tile_id": {
+          "name": "board_tile_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_message_url": {
+          "name": "discord_message_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_guild_id": {
+          "name": "discord_guild_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_channel_id": {
+          "name": "discord_channel_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validation_passed": {
+          "name": "validation_passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "validation_metadata": {
+          "name": "validation_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bingo_submissions_board_idx": {
+          "name": "bingo_submissions_board_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bingo_submissions_user_idx": {
+          "name": "bingo_submissions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bingo_submissions_tile_idx": {
+          "name": "bingo_submissions_tile_idx",
+          "columns": [
+            {
+              "expression": "board_tile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bingo_submissions_created_idx": {
+          "name": "bingo_submissions_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bingo_submissions_board_id_bingo_boards_id_fk": {
+          "name": "bingo_submissions_board_id_bingo_boards_id_fk",
+          "tableFrom": "bingo_submissions",
+          "tableTo": "bingo_boards",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bingo_submissions_board_tile_id_bingo_board_tiles_id_fk": {
+          "name": "bingo_submissions_board_tile_id_bingo_board_tiles_id_fk",
+          "tableFrom": "bingo_submissions",
+          "tableTo": "bingo_board_tiles",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "board_tile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bingo_submissions_user_id_user_id_fk": {
+          "name": "bingo_submissions_user_id_user_id_fk",
+          "tableFrom": "bingo_submissions",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.brands": {
+      "name": "brands",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "brands_name_unique": {
+          "name": "brands_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "brands_slug_unique": {
+          "name": "brands_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.camera_af_area_specs": {
+      "name": "camera_af_area_specs",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "af_area_mode_id": {
+          "name": "af_area_mode_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "camera_af_area_specs_af_area_mode_idx": {
+          "name": "camera_af_area_specs_af_area_mode_idx",
+          "columns": [
+            {
+              "expression": "af_area_mode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "camera_af_area_specs_gear_idx": {
+          "name": "camera_af_area_specs_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "camera_af_area_specs_gear_id_gear_id_fk": {
+          "name": "camera_af_area_specs_gear_id_gear_id_fk",
+          "tableFrom": "camera_af_area_specs",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "camera_af_area_specs_af_area_mode_id_af_area_modes_id_fk": {
+          "name": "camera_af_area_specs_af_area_mode_id_af_area_modes_id_fk",
+          "tableFrom": "camera_af_area_specs",
+          "tableTo": "af_area_modes",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "af_area_mode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "camera_af_area_specs_gear_id_af_area_mode_id_pk": {
+          "name": "camera_af_area_specs_gear_id_af_area_mode_id_pk",
+          "columns": [
+            "gear_id",
+            "af_area_mode_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.camera_card_slots": {
+      "name": "camera_card_slots",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_index": {
+          "name": "slot_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_form_factors": {
+          "name": "supported_form_factors",
+          "type": "card_form_factor_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_buses": {
+          "name": "supported_buses",
+          "type": "card_bus_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_speed_classes": {
+          "name": "supported_speed_classes",
+          "type": "card_speed_class_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_camera_card_slot": {
+          "name": "uniq_camera_card_slot",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slot_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.camera_specs": {
+      "name": "camera_specs",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sensor_format_id": {
+          "name": "sensor_format_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_mp": {
+          "name": "resolution_mp",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sensor_stacking_type": {
+          "name": "sensor_stacking_type",
+          "type": "sensor_stacking_types_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sensor_tech_type": {
+          "name": "sensor_tech_type",
+          "type": "sensor_tech_types_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_back_side_illuminated": {
+          "name": "is_back_side_illuminated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso_min": {
+          "name": "iso_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso_max": {
+          "name": "iso_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sensor_readout_speed_ms": {
+          "name": "sensor_readout_speed_ms",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_raw_bit_depth": {
+          "name": "max_raw_bit_depth",
+          "type": "raw_bit_depth_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_ibis": {
+          "name": "has_ibis",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_electronic_vibration_reduction": {
+          "name": "has_electronic_vibration_reduction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cipa_stabilization_rating_stops": {
+          "name": "cipa_stabilization_rating_stops",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_pixel_shift_shooting": {
+          "name": "has_pixel_shift_shooting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_anti_aliasing_filter": {
+          "name": "has_anti_aliasing_filter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "precapture_support_level": {
+          "name": "precapture_support_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_type": {
+          "name": "camera_type",
+          "type": "camera_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processor_name": {
+          "name": "processor_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_weather_sealing": {
+          "name": "has_weather_sealing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focus_points": {
+          "name": "focus_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "af_subject_categories": {
+          "name": "af_subject_categories",
+          "type": "camera_af_subject_categories_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_focus_peaking": {
+          "name": "has_focus_peaking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_focus_bracketing": {
+          "name": "has_focus_bracketing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_max": {
+          "name": "shutter_speed_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_min": {
+          "name": "shutter_speed_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_fps_raw": {
+          "name": "max_fps_raw",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_fps_jpg": {
+          "name": "max_fps_jpg",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_fps_by_shutter": {
+          "name": "max_fps_by_shutter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flash_sync_speed": {
+          "name": "flash_sync_speed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_silent_shooting_available": {
+          "name": "has_silent_shooting_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_shutter_types": {
+          "name": "available_shutter_types",
+          "type": "shutter_types_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_storage_gb": {
+          "name": "internal_storage_gb",
+          "type": "numeric(6, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cipa_battery_shots_per_charge": {
+          "name": "cipa_battery_shots_per_charge",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_batteries": {
+          "name": "supported_batteries",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usb_power_delivery": {
+          "name": "usb_power_delivery",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usb_charging": {
+          "name": "usb_charging",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_log_color_profile": {
+          "name": "has_log_color_profile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_10_bit_video": {
+          "name": "has_10_bit_video",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_12_bit_video": {
+          "name": "has_12_bit_video",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_open_gate_video": {
+          "name": "has_open_gate_video",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supports_external_recording": {
+          "name": "supports_external_recording",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supports_record_to_drive": {
+          "name": "supports_record_to_drive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_intervalometer": {
+          "name": "has_intervalometer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_self_timer": {
+          "name": "has_self_timer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_built_in_flash": {
+          "name": "has_built_in_flash",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_hot_shoe": {
+          "name": "has_hot_shoe",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_usb_file_transfer": {
+          "name": "has_usb_file_transfer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rear_display_type": {
+          "name": "rear_display_type",
+          "type": "rear_display_types_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rear_display_resolution_million_dots": {
+          "name": "rear_display_resolution_million_dots",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rear_display_size_inches": {
+          "name": "rear_display_size_inches",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_rear_touchscreen": {
+          "name": "has_rear_touchscreen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewfinder_type": {
+          "name": "viewfinder_type",
+          "type": "viewfinder_types_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewfinder_magnification": {
+          "name": "viewfinder_magnification",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewfinder_resolution_million_dots": {
+          "name": "viewfinder_resolution_million_dots",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_top_display": {
+          "name": "has_top_display",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "camera_specs_sensor_idx": {
+          "name": "camera_specs_sensor_idx",
+          "columns": [
+            {
+              "expression": "sensor_format_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "camera_specs_gear_id_gear_id_fk": {
+          "name": "camera_specs_gear_id_gear_id_fk",
+          "tableFrom": "camera_specs",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "camera_specs_sensor_format_id_sensor_formats_id_fk": {
+          "name": "camera_specs_sensor_format_id_sensor_formats_id_fk",
+          "tableFrom": "camera_specs",
+          "tableTo": "sensor_formats",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "sensor_format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.camera_video_modes": {
+      "name": "camera_video_modes",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution_key": {
+          "name": "resolution_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution_label": {
+          "name": "resolution_label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution_horizontal": {
+          "name": "resolution_horizontal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_vertical": {
+          "name": "resolution_vertical",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fps": {
+          "name": "fps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codec_label": {
+          "name": "codec_label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bit_depth": {
+          "name": "bit_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_factor": {
+          "name": "crop_factor",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "camera_video_modes_gear_idx": {
+          "name": "camera_video_modes_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "camera_video_modes_gear_id_gear_id_fk": {
+          "name": "camera_video_modes_gear_id_gear_id_fk",
+          "tableFrom": "camera_video_modes",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.compare_pair_counts": {
+      "name": "compare_pair_counts",
+      "schema": "app",
+      "columns": {
+        "pair_key": {
+          "name": "pair_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_a_id": {
+          "name": "gear_a_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_b_id": {
+          "name": "gear_b_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pair_counts_gear_a_idx": {
+          "name": "pair_counts_gear_a_idx",
+          "columns": [
+            {
+              "expression": "gear_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pair_counts_gear_b_idx": {
+          "name": "pair_counts_gear_b_idx",
+          "columns": [
+            {
+              "expression": "gear_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pair_counts_count_idx": {
+          "name": "pair_counts_count_idx",
+          "columns": [
+            {
+              "expression": "count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compare_pair_counts_gear_a_id_gear_id_fk": {
+          "name": "compare_pair_counts_gear_a_id_gear_id_fk",
+          "tableFrom": "compare_pair_counts",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "compare_pair_counts_gear_b_id_gear_id_fk": {
+          "name": "compare_pair_counts_gear_b_id_gear_id_fk",
+          "tableFrom": "compare_pair_counts",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "compare_pair_counts_gear_a_id_gear_b_id_pk": {
+          "name": "compare_pair_counts_gear_a_id_gear_b_id_pk",
+          "columns": [
+            "gear_a_id",
+            "gear_b_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.fixed_lens_specs": {
+      "name": "fixed_lens_specs",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_prime": {
+          "name": "is_prime",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_min_mm": {
+          "name": "focal_length_min_mm",
+          "type": "numeric(5, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_max_mm": {
+          "name": "focal_length_max_mm",
+          "type": "numeric(5, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_circle_size_id": {
+          "name": "image_circle_size_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_aperture_wide": {
+          "name": "max_aperture_wide",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_aperture_tele": {
+          "name": "max_aperture_tele",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_aperture_wide": {
+          "name": "min_aperture_wide",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_aperture_tele": {
+          "name": "min_aperture_tele",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_autofocus": {
+          "name": "has_autofocus",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minimum_focus_distance_mm": {
+          "name": "minimum_focus_distance_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "front_element_rotates": {
+          "name": "front_element_rotates",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "front_filter_thread_size_mm": {
+          "name": "front_filter_thread_size_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_lens_hood": {
+          "name": "has_lens_hood",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fixed_lens_specs_focal_idx": {
+          "name": "fixed_lens_specs_focal_idx",
+          "columns": [
+            {
+              "expression": "focal_length_min_mm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "focal_length_max_mm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fixed_lens_specs_gear_id_gear_id_fk": {
+          "name": "fixed_lens_specs_gear_id_gear_id_fk",
+          "tableFrom": "fixed_lens_specs",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fixed_lens_specs_image_circle_size_id_sensor_formats_id_fk": {
+          "name": "fixed_lens_specs_image_circle_size_id_sensor_formats_id_fk",
+          "tableFrom": "fixed_lens_specs",
+          "tableTo": "sensor_formats",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "image_circle_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear": {
+      "name": "gear",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(220)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_name": {
+          "name": "search_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_number": {
+          "name": "model_number",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gear_type": {
+          "name": "gear_type",
+          "type": "gear_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mount_id": {
+          "name": "mount_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "announced_date": {
+          "name": "announced_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "announce_date_precision": {
+          "name": "announce_date_precision",
+          "type": "date_precision_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'DAY'"
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date_precision": {
+          "name": "release_date_precision",
+          "type": "date_precision_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'DAY'"
+        },
+        "msrp_now_usd_cents": {
+          "name": "msrp_now_usd_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "msrp_at_launch_usd_cents": {
+          "name": "msrp_at_launch_usd_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mpb_max_price_usd_cents": {
+          "name": "mpb_max_price_usd_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_view_url": {
+          "name": "top_view_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_grams": {
+          "name": "weight_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width_mm": {
+          "name": "width_mm",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height_mm": {
+          "name": "height_mm",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth_mm": {
+          "name": "depth_mm",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_manufacturer": {
+          "name": "link_manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_mpb": {
+          "name": "link_mpb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_bh": {
+          "name": "link_bh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_amazon": {
+          "name": "link_amazon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_search_idx": {
+          "name": "gear_search_idx",
+          "columns": [
+            {
+              "expression": "search_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_type_brand_idx": {
+          "name": "gear_type_brand_idx",
+          "columns": [
+            {
+              "expression": "gear_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_brand_mount_idx": {
+          "name": "gear_brand_mount_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mount_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_brand_id_brands_id_fk": {
+          "name": "gear_brand_id_brands_id_fk",
+          "tableFrom": "gear",
+          "tableTo": "brands",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "gear_mount_id_mounts_id_fk": {
+          "name": "gear_mount_id_mounts_id_fk",
+          "tableFrom": "gear",
+          "tableTo": "mounts",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "mount_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gear_slug_unique": {
+          "name": "gear_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "gear_name_unique": {
+          "name": "gear_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "gear_model_number_unique": {
+          "name": "gear_model_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "model_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_aliases": {
+      "name": "gear_aliases",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "gear_region",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_aliases_gear_idx": {
+          "name": "gear_aliases_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_aliases_region_idx": {
+          "name": "gear_aliases_region_idx",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_aliases_gear_id_gear_id_fk": {
+          "name": "gear_aliases_gear_id_gear_id_fk",
+          "tableFrom": "gear_aliases",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_aliases_gear_id_region_pk": {
+          "name": "gear_aliases_gear_id_region_pk",
+          "columns": [
+            "gear_id",
+            "region"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_alternatives": {
+      "name": "gear_alternatives",
+      "schema": "app",
+      "columns": {
+        "gear_a_id": {
+          "name": "gear_a_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_b_id": {
+          "name": "gear_b_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_competitor": {
+          "name": "is_competitor",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_alternatives_gear_a_idx": {
+          "name": "gear_alternatives_gear_a_idx",
+          "columns": [
+            {
+              "expression": "gear_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_alternatives_gear_b_idx": {
+          "name": "gear_alternatives_gear_b_idx",
+          "columns": [
+            {
+              "expression": "gear_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_alternatives_gear_a_id_gear_id_fk": {
+          "name": "gear_alternatives_gear_a_id_gear_id_fk",
+          "tableFrom": "gear_alternatives",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_alternatives_gear_b_id_gear_id_fk": {
+          "name": "gear_alternatives_gear_b_id_gear_id_fk",
+          "tableFrom": "gear_alternatives",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_alternatives_gear_a_id_gear_b_id_pk": {
+          "name": "gear_alternatives_gear_a_id_gear_b_id_pk",
+          "columns": [
+            "gear_a_id",
+            "gear_b_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_creator_videos": {
+      "name": "gear_creator_videos",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_url": {
+          "name": "normalized_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embed_url": {
+          "name": "embed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "creator_video_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_video_id": {
+          "name": "external_video_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_note": {
+          "name": "editor_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_creator_videos_gear_active_idx": {
+          "name": "gear_creator_videos_gear_active_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_creator_videos_creator_idx": {
+          "name": "gear_creator_videos_creator_idx",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_creator_videos_platform_external_idx": {
+          "name": "gear_creator_videos_platform_external_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_video_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_creator_videos_gear_platform_external_uidx": {
+          "name": "gear_creator_videos_gear_platform_external_uidx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_video_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_creator_videos_gear_id_gear_id_fk": {
+          "name": "gear_creator_videos_gear_id_gear_id_fk",
+          "tableFrom": "gear_creator_videos",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_creator_videos_creator_id_approved_creators_id_fk": {
+          "name": "gear_creator_videos_creator_id_approved_creators_id_fk",
+          "tableFrom": "gear_creator_videos",
+          "tableTo": "approved_creators",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "gear_creator_videos_created_by_user_id_user_id_fk": {
+          "name": "gear_creator_videos_created_by_user_id_user_id_fk",
+          "tableFrom": "gear_creator_videos",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gear_creator_videos_updated_by_user_id_user_id_fk": {
+          "name": "gear_creator_videos_updated_by_user_id_user_id_fk",
+          "tableFrom": "gear_creator_videos",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_edits": {
+      "name": "gear_edits",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_edits_status_idx": {
+          "name": "gear_edits_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_edits_gear_idx": {
+          "name": "gear_edits_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_edits_created_by_idx": {
+          "name": "gear_edits_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_edits_gear_id_gear_id_fk": {
+          "name": "gear_edits_gear_id_gear_id_fk",
+          "tableFrom": "gear_edits",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_edits_created_by_id_user_id_fk": {
+          "name": "gear_edits_created_by_id_user_id_fk",
+          "tableFrom": "gear_edits",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_genres": {
+      "name": "gear_genres",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_genres_gear_idx": {
+          "name": "gear_genres_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_genres_genre_idx": {
+          "name": "gear_genres_genre_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_genres_gear_id_gear_id_fk": {
+          "name": "gear_genres_gear_id_gear_id_fk",
+          "tableFrom": "gear_genres",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_genres_genre_id_genres_id_fk": {
+          "name": "gear_genres_genre_id_genres_id_fk",
+          "tableFrom": "gear_genres",
+          "tableTo": "genres",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_genres_gear_id_genre_id_pk": {
+          "name": "gear_genres_gear_id_genre_id_pk",
+          "columns": [
+            "gear_id",
+            "genre_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_mounts": {
+      "name": "gear_mounts",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mount_id": {
+          "name": "mount_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_mounts_gear_idx": {
+          "name": "gear_mounts_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_mounts_mount_idx": {
+          "name": "gear_mounts_mount_idx",
+          "columns": [
+            {
+              "expression": "mount_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_mounts_gear_id_gear_id_fk": {
+          "name": "gear_mounts_gear_id_gear_id_fk",
+          "tableFrom": "gear_mounts",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_mounts_mount_id_mounts_id_fk": {
+          "name": "gear_mounts_mount_id_mounts_id_fk",
+          "tableFrom": "gear_mounts",
+          "tableTo": "mounts",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "mount_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_mounts_gear_id_mount_id_pk": {
+          "name": "gear_mounts_gear_id_mount_id_pk",
+          "columns": [
+            "gear_id",
+            "mount_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_popularity_daily": {
+      "name": "gear_popularity_daily",
+      "schema": "app",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wishlist_adds": {
+          "name": "wishlist_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "owner_adds": {
+          "name": "owner_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compare_adds": {
+          "name": "compare_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "review_submits": {
+          "name": "review_submits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "api_fetches": {
+          "name": "api_fetches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gpd_gear_idx": {
+          "name": "gpd_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gpd_date_idx": {
+          "name": "gpd_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_popularity_daily_gear_id_gear_id_fk": {
+          "name": "gear_popularity_daily_gear_id_gear_id_fk",
+          "tableFrom": "gear_popularity_daily",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_popularity_daily_date_gear_id_pk": {
+          "name": "gear_popularity_daily_date_gear_id_pk",
+          "columns": [
+            "date",
+            "gear_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_popularity_intraday": {
+      "name": "gear_popularity_intraday",
+      "schema": "app",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wishlist_adds": {
+          "name": "wishlist_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "owner_adds": {
+          "name": "owner_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compare_adds": {
+          "name": "compare_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "review_submits": {
+          "name": "review_submits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "api_fetches": {
+          "name": "api_fetches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gpi_gear_idx": {
+          "name": "gpi_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gpi_date_idx": {
+          "name": "gpi_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_popularity_intraday_gear_id_gear_id_fk": {
+          "name": "gear_popularity_intraday_gear_id_gear_id_fk",
+          "tableFrom": "gear_popularity_intraday",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_popularity_intraday_date_gear_id_pk": {
+          "name": "gear_popularity_intraday_date_gear_id_pk",
+          "columns": [
+            "date",
+            "gear_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_popularity_lifetime": {
+      "name": "gear_popularity_lifetime",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "views_lifetime": {
+          "name": "views_lifetime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wishlist_lifetime_adds": {
+          "name": "wishlist_lifetime_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "owner_lifetime_adds": {
+          "name": "owner_lifetime_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compare_lifetime_adds": {
+          "name": "compare_lifetime_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "review_lifetime_submits": {
+          "name": "review_lifetime_submits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "api_fetch_lifetime": {
+          "name": "api_fetch_lifetime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gpl_gear_idx": {
+          "name": "gpl_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_popularity_lifetime_gear_id_gear_id_fk": {
+          "name": "gear_popularity_lifetime_gear_id_gear_id_fk",
+          "tableFrom": "gear_popularity_lifetime",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_popularity_windows": {
+      "name": "gear_popularity_windows",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeframe": {
+          "name": "timeframe",
+          "type": "popularity_timeframe",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of_date": {
+          "name": "as_of_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "views_sum": {
+          "name": "views_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wishlist_adds_sum": {
+          "name": "wishlist_adds_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "owner_adds_sum": {
+          "name": "owner_adds_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compare_adds_sum": {
+          "name": "compare_adds_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "review_submits_sum": {
+          "name": "review_submits_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "api_fetches_sum": {
+          "name": "api_fetches_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gpw_timeframe_idx": {
+          "name": "gpw_timeframe_idx",
+          "columns": [
+            {
+              "expression": "timeframe",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_popularity_windows_gear_id_gear_id_fk": {
+          "name": "gear_popularity_windows_gear_id_gear_id_fk",
+          "tableFrom": "gear_popularity_windows",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_popularity_windows_gear_id_timeframe_pk": {
+          "name": "gear_popularity_windows_gear_id_timeframe_pk",
+          "columns": [
+            "gear_id",
+            "timeframe"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_raw_samples": {
+      "name": "gear_raw_samples",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_sample_id": {
+          "name": "raw_sample_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_raw_samples_gear_idx": {
+          "name": "gear_raw_samples_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_raw_samples_sample_idx": {
+          "name": "gear_raw_samples_sample_idx",
+          "columns": [
+            {
+              "expression": "raw_sample_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_raw_samples_gear_id_gear_id_fk": {
+          "name": "gear_raw_samples_gear_id_gear_id_fk",
+          "tableFrom": "gear_raw_samples",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_raw_samples_raw_sample_id_raw_samples_id_fk": {
+          "name": "gear_raw_samples_raw_sample_id_raw_samples_id_fk",
+          "tableFrom": "gear_raw_samples",
+          "tableTo": "raw_samples",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "raw_sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_raw_samples_gear_id_raw_sample_id_pk": {
+          "name": "gear_raw_samples_gear_id_raw_sample_id_pk",
+          "columns": [
+            "gear_id",
+            "raw_sample_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.genres": {
+      "name": "genres",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applies_to": {
+          "name": "applies_to",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genres_name_unique": {
+          "name": "genres_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "genres_slug_unique": {
+          "name": "genres_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.image_requests": {
+      "name": "image_requests",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "image_request_gear_idx": {
+          "name": "image_request_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "image_requests_user_id_user_id_fk": {
+          "name": "image_requests_user_id_user_id_fk",
+          "tableFrom": "image_requests",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "image_requests_gear_id_gear_id_fk": {
+          "name": "image_requests_gear_id_gear_id_fk",
+          "tableFrom": "image_requests",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "image_requests_user_id_gear_id_pk": {
+          "name": "image_requests_user_id_gear_id_pk",
+          "columns": [
+            "user_id",
+            "gear_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.invites": {
+      "name": "invites",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "inviteeName": {
+          "name": "inviteeName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_used": {
+          "name": "is_used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "usedByUserId": {
+          "name": "usedByUserId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invites_created_by_idx": {
+          "name": "invites_created_by_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_is_used_idx": {
+          "name": "invites_is_used_idx",
+          "columns": [
+            {
+              "expression": "is_used",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_used_by_idx": {
+          "name": "invites_used_by_idx",
+          "columns": [
+            {
+              "expression": "usedByUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_createdById_user_id_fk": {
+          "name": "invites_createdById_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "createdById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "invites_usedByUserId_user_id_fk": {
+          "name": "invites_usedByUserId_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "usedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.lens_specs": {
+      "name": "lens_specs",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_prime": {
+          "name": "is_prime",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_min_mm": {
+          "name": "focal_length_min_mm",
+          "type": "numeric(5, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_max_mm": {
+          "name": "focal_length_max_mm",
+          "type": "numeric(5, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_circle_size_id": {
+          "name": "image_circle_size_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_aperture_wide": {
+          "name": "max_aperture_wide",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_aperture_tele": {
+          "name": "max_aperture_tele",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_aperture_wide": {
+          "name": "min_aperture_wide",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_aperture_tele": {
+          "name": "min_aperture_tele",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_stabilization": {
+          "name": "has_stabilization",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cipa_stabilization_rating_stops": {
+          "name": "cipa_stabilization_rating_stops",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_stabilization_switch": {
+          "name": "has_stabilization_switch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_autofocus": {
+          "name": "has_autofocus",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_macro": {
+          "name": "is_macro",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "magnification": {
+          "name": "magnification",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minimum_focus_distance_mm": {
+          "name": "minimum_focus_distance_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_focus_ring": {
+          "name": "has_focus_ring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focus_motor_type": {
+          "name": "focus_motor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focus_throw_degrees": {
+          "name": "focus_throw_degrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_af_mf_switch": {
+          "name": "has_af_mf_switch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_focus_limiter": {
+          "name": "has_focus_limiter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_focus_recall_button": {
+          "name": "has_focus_recall_button",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_elements": {
+          "name": "number_elements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_element_groups": {
+          "name": "number_element_groups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_diffractive_optics": {
+          "name": "has_diffractive_optics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lens_zoom_type": {
+          "name": "lens_zoom_type",
+          "type": "lens_zoom_types_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_diaphragm_blades": {
+          "name": "number_diaphragm_blades",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_rounded_diaphragm_blades": {
+          "name": "has_rounded_diaphragm_blades",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_internal_zoom": {
+          "name": "has_internal_zoom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_internal_focus": {
+          "name": "has_internal_focus",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "front_element_rotates": {
+          "name": "front_element_rotates",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mount_material": {
+          "name": "mount_material",
+          "type": "mount_material_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_weather_sealing": {
+          "name": "has_weather_sealing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_aperture_ring": {
+          "name": "has_aperture_ring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_custom_control_rings": {
+          "name": "number_custom_control_rings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_function_buttons": {
+          "name": "number_function_buttons",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepts_filter_types": {
+          "name": "accepts_filter_types",
+          "type": "lens_filter_types_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "front_filter_thread_size_mm": {
+          "name": "front_filter_thread_size_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rear_filter_thread_size_mm": {
+          "name": "rear_filter_thread_size_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drop_in_filter_size_mm": {
+          "name": "drop_in_filter_size_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_built_in_teleconverter": {
+          "name": "has_built_in_teleconverter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_lens_hood": {
+          "name": "has_lens_hood",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_tripod_collar": {
+          "name": "has_tripod_collar",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_tilt_shift": {
+          "name": "is_tilt_shift",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tilt_degrees": {
+          "name": "tilt_degrees",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shift_mm": {
+          "name": "shift_mm",
+          "type": "numeric(5, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lens_specs_focal_idx": {
+          "name": "lens_specs_focal_idx",
+          "columns": [
+            {
+              "expression": "focal_length_min_mm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "focal_length_max_mm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lens_specs_gear_id_gear_id_fk": {
+          "name": "lens_specs_gear_id_gear_id_fk",
+          "tableFrom": "lens_specs",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lens_specs_image_circle_size_id_sensor_formats_id_fk": {
+          "name": "lens_specs_image_circle_size_id_sensor_formats_id_fk",
+          "tableFrom": "lens_specs",
+          "tableTo": "sensor_formats",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "image_circle_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.mounts": {
+      "name": "mounts",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mounts_brand_id_brands_id_fk": {
+          "name": "mounts_brand_id_brands_id_fk",
+          "tableFrom": "mounts",
+          "tableTo": "brands",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mounts_value_unique": {
+          "name": "mounts_value_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.notifications": {
+      "name": "notifications",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_archived_idx": {
+          "name": "notifications_user_archived_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.ownerships": {
+      "name": "ownerships",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ownership_gear_idx": {
+          "name": "ownership_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ownerships_user_id_user_id_fk": {
+          "name": "ownerships_user_id_user_id_fk",
+          "tableFrom": "ownerships",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ownerships_gear_id_gear_id_fk": {
+          "name": "ownerships_gear_id_gear_id_fk",
+          "tableFrom": "ownerships",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ownerships_user_id_gear_id_pk": {
+          "name": "ownerships_user_id_gear_id_pk",
+          "columns": [
+            "user_id",
+            "gear_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.passkeys": {
+      "name": "passkeys",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "passkeys_user_idx": {
+          "name": "passkeys_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkeys_user_id_user_id_fk": {
+          "name": "passkeys_user_id_user_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.popularity_events": {
+      "name": "popularity_events",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitor_id": {
+          "name": "visitor_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "popularity_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pop_events_gear_idx": {
+          "name": "pop_events_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pop_events_gear_type_idx": {
+          "name": "pop_events_gear_type_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pop_events_created_idx": {
+          "name": "pop_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pop_events_visitor_idx": {
+          "name": "pop_events_visitor_idx",
+          "columns": [
+            {
+              "expression": "visitor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pop_events_gear_visitor_created_idx": {
+          "name": "pop_events_gear_visitor_created_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visitor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "popularity_events_gear_id_gear_id_fk": {
+          "name": "popularity_events_gear_id_gear_id_fk",
+          "tableFrom": "popularity_events",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "popularity_events_user_id_user_id_fk": {
+          "name": "popularity_events_user_id_user_id_fk",
+          "tableFrom": "popularity_events",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.raw_samples": {
+      "name": "raw_samples",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by_user_id": {
+          "name": "uploaded_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "raw_samples_file_url_idx": {
+          "name": "raw_samples_file_url_idx",
+          "columns": [
+            {
+              "expression": "file_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raw_samples_user_idx": {
+          "name": "raw_samples_user_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.recommendation_charts": {
+      "name": "recommendation_charts",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(800)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rec_brand_slug": {
+          "name": "rec_brand_slug",
+          "columns": [
+            {
+              "expression": "brand",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.recommendation_items": {
+      "name": "recommendation_items",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "chart_id": {
+          "name": "chart_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "rec_rating",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_override": {
+          "name": "group_override",
+          "type": "rec_group",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_column": {
+          "name": "custom_column",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_min_override": {
+          "name": "price_min_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_max_override": {
+          "name": "price_max_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rec_items_chart_idx": {
+          "name": "rec_items_chart_idx",
+          "columns": [
+            {
+              "expression": "chart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rec_items_gear_idx": {
+          "name": "rec_items_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recommendation_items_chart_id_recommendation_charts_id_fk": {
+          "name": "recommendation_items_chart_id_recommendation_charts_id_fk",
+          "tableFrom": "recommendation_items",
+          "tableTo": "recommendation_charts",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "chart_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recommendation_items_gear_id_gear_id_fk": {
+          "name": "recommendation_items_gear_id_gear_id_fk",
+          "tableFrom": "recommendation_items",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.review_flags": {
+      "name": "review_flags",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_user_id": {
+          "name": "reporter_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "review_flag_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_flags_status_idx": {
+          "name": "review_flags_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_flags_review_status_idx": {
+          "name": "review_flags_review_status_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_flags_reporter_status_idx": {
+          "name": "review_flags_reporter_status_idx",
+          "columns": [
+            {
+              "expression": "reporter_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_flags_review_id_reviews_id_fk": {
+          "name": "review_flags_review_id_reviews_id_fk",
+          "tableFrom": "review_flags",
+          "tableTo": "reviews",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_flags_reporter_user_id_user_id_fk": {
+          "name": "review_flags_reporter_user_id_user_id_fk",
+          "tableFrom": "review_flags",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "reporter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_flags_resolved_by_user_id_user_id_fk": {
+          "name": "review_flags_resolved_by_user_id_user_id_fk",
+          "tableFrom": "review_flags",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.review_summaries": {
+      "name": "review_summaries",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "summary_text": {
+          "name": "summary_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_summaries_updated_idx": {
+          "name": "review_summaries_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_summaries_gear_id_gear_id_fk": {
+          "name": "review_summaries_gear_id_gear_id_fk",
+          "tableFrom": "review_summaries",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.reviews": {
+      "name": "reviews",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "review_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommend": {
+          "name": "recommend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reviews_status_idx": {
+          "name": "reviews_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_gear_idx": {
+          "name": "reviews_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_created_by_idx": {
+          "name": "reviews_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_created_by_created_at_idx": {
+          "name": "reviews_created_by_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_gear_id_gear_id_fk": {
+          "name": "reviews_gear_id_gear_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_created_by_id_user_id_fk": {
+          "name": "reviews_created_by_id_user_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.rollup_runs": {
+      "name": "rollup_runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "as_of_date": {
+          "name": "as_of_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_date": {
+          "name": "corrected_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_rows": {
+          "name": "daily_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "late_arrivals": {
+          "name": "late_arrivals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "windows_rows": {
+          "name": "windows_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifetime_total_rows": {
+          "name": "lifetime_total_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rollup_runs_created_idx": {
+          "name": "rollup_runs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.sensor_formats": {
+      "name": "sensor_formats",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_factor": {
+          "name": "crop_factor",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width_mm": {
+          "name": "width_mm",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height_mm": {
+          "name": "height_mm",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_mm_2": {
+          "name": "area_mm_2",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sensor_formats_name_unique": {
+          "name": "sensor_formats_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "sensor_formats_slug_unique": {
+          "name": "sensor_formats_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.shared_lists": {
+      "name": "shared_lists",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(180)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "unpublished_at": {
+          "name": "unpublished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shared_lists_list_uq": {
+          "name": "shared_lists_list_uq",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shared_lists_public_id_uq": {
+          "name": "shared_lists_public_id_uq",
+          "columns": [
+            {
+              "expression": "public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shared_lists_slug_idx": {
+          "name": "shared_lists_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shared_lists_list_id_user_lists_id_fk": {
+          "name": "shared_lists_list_id_user_lists_id_fk",
+          "tableFrom": "shared_lists",
+          "tableTo": "user_lists",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.staff_verdicts": {
+      "name": "staff_verdicts",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pros": {
+          "name": "pros",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cons": {
+          "name": "cons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "who_for": {
+          "name": "who_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_for": {
+          "name": "not_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alternatives": {
+          "name": "alternatives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "staff_verdicts_author_idx": {
+          "name": "staff_verdicts_author_idx",
+          "columns": [
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_verdicts_gear_id_gear_id_fk": {
+          "name": "staff_verdicts_gear_id_gear_id_fk",
+          "tableFrom": "staff_verdicts",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staff_verdicts_author_user_id_user_id_fk": {
+          "name": "staff_verdicts_author_user_id_user_id_fk",
+          "tableFrom": "staff_verdicts",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.use_case_ratings": {
+      "name": "use_case_ratings",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ucr_gear_idx": {
+          "name": "ucr_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ucr_genre_idx": {
+          "name": "ucr_genre_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "use_case_ratings_gear_id_gear_id_fk": {
+          "name": "use_case_ratings_gear_id_gear_id_fk",
+          "tableFrom": "use_case_ratings",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "use_case_ratings_genre_id_genres_id_fk": {
+          "name": "use_case_ratings_genre_id_genres_id_fk",
+          "tableFrom": "use_case_ratings",
+          "tableTo": "genres",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "use_case_ratings_gear_id_genre_id_pk": {
+          "name": "use_case_ratings_gear_id_genre_id_pk",
+          "columns": [
+            "gear_id",
+            "genre_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.user_badges": {
+      "name": "user_badges",
+      "schema": "app",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badgeKey": {
+          "name": "badgeKey",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awardedAt": {
+          "name": "awardedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "source": {
+          "name": "source",
+          "type": "badge_award_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_override": {
+          "name": "sort_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_badges_userId_user_id_fk": {
+          "name": "user_badges_userId_user_id_fk",
+          "tableFrom": "user_badges",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_badges_userId_badgeKey_pk": {
+          "name": "user_badges_userId_badgeKey_pk",
+          "columns": [
+            "userId",
+            "badgeKey"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.user_list_items": {
+      "name": "user_list_items",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_list_items_list_gear_uq": {
+          "name": "user_list_items_list_gear_uq",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_list_items_list_position_idx": {
+          "name": "user_list_items_list_position_idx",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_list_items_gear_idx": {
+          "name": "user_list_items_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_list_items_list_id_user_lists_id_fk": {
+          "name": "user_list_items_list_id_user_lists_id_fk",
+          "tableFrom": "user_list_items",
+          "tableTo": "user_lists",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_list_items_gear_id_gear_id_fk": {
+          "name": "user_list_items_gear_id_gear_id_fk",
+          "tableFrom": "user_list_items",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.user_lists": {
+      "name": "user_lists",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(140)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_lists_user_idx": {
+          "name": "user_lists_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_lists_user_created_idx": {
+          "name": "user_lists_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_lists_user_id_user_id_fk": {
+          "name": "user_lists_user_id_user_id_fk",
+          "tableFrom": "user_lists",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.user": {
+      "name": "user",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "member_number": {
+          "name": "member_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "user_member_number_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "invite_id": {
+          "name": "invite_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_handle_unique": {
+          "name": "user_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        },
+        "user_member_number_unique": {
+          "name": "user_member_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.wishlists": {
+      "name": "wishlists",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wishlist_gear_idx": {
+          "name": "wishlist_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wishlists_user_id_user_id_fk": {
+          "name": "wishlists_user_id_user_id_fk",
+          "tableFrom": "wishlists",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wishlists_gear_id_gear_id_fk": {
+          "name": "wishlists_gear_id_gear_id_fk",
+          "tableFrom": "wishlists",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "wishlists_user_id_gear_id_pk": {
+          "name": "wishlists_user_id_gear_id_pk",
+          "columns": [
+            "user_id",
+            "gear_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.camera_af_subject_categories_enum": {
+      "name": "camera_af_subject_categories_enum",
+      "schema": "public",
+      "values": [
+        "people",
+        "animals",
+        "vehicles",
+        "birds",
+        "aircraft"
+      ]
+    },
+    "public.analog_medium_enum": {
+      "name": "analog_medium_enum",
+      "schema": "public",
+      "values": [
+        "35mm",
+        "half-frame",
+        "panoramic-35mm",
+        "aps",
+        "110",
+        "126-instamatic",
+        "828",
+        "120",
+        "220",
+        "127",
+        "620",
+        "large-format-4x5",
+        "large-format-5x7",
+        "large-format-8x10",
+        "ultra-large-format",
+        "sheet-film",
+        "metal-plate",
+        "glass-plate",
+        "experimental-other"
+      ]
+    },
+    "public.analog_types_enum": {
+      "name": "analog_types_enum",
+      "schema": "public",
+      "values": [
+        "single-lens-reflex-slr",
+        "rangefinder",
+        "twin-lens-reflex-tlr",
+        "point-and-shoot",
+        "large-format",
+        "instant-film",
+        "disposable",
+        "toy",
+        "stereo",
+        "panoramic",
+        "folding",
+        "box",
+        "pinhole",
+        "press"
+      ]
+    },
+    "public.analog_viewfinder_types_enum": {
+      "name": "analog_viewfinder_types_enum",
+      "schema": "public",
+      "values": [
+        "none",
+        "pentaprism",
+        "pentamirror",
+        "waist-level",
+        "sports-finder",
+        "rangefinder-style",
+        "ground-glass",
+        "other"
+      ]
+    },
+    "public.audit_action": {
+      "name": "audit_action",
+      "schema": "public",
+      "values": [
+        "GEAR_CREATE",
+        "GEAR_RENAME",
+        "GEAR_DELETE",
+        "GEAR_IMAGE_UPLOAD",
+        "GEAR_IMAGE_REPLACE",
+        "GEAR_IMAGE_REMOVE",
+        "GEAR_TOP_VIEW_UPLOAD",
+        "GEAR_TOP_VIEW_REPLACE",
+        "GEAR_TOP_VIEW_REMOVE",
+        "GEAR_EDIT_PROPOSE",
+        "GEAR_EDIT_APPROVE",
+        "GEAR_EDIT_REJECT",
+        "GEAR_EDIT_MERGE",
+        "REVIEW_APPROVE",
+        "REVIEW_REJECT"
+      ]
+    },
+    "public.badge_award_source": {
+      "name": "badge_award_source",
+      "schema": "public",
+      "values": [
+        "auto",
+        "manual"
+      ]
+    },
+    "public.bingo_board_status": {
+      "name": "bingo_board_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "COMPLETED",
+        "EXPIRED",
+        "ARCHIVED"
+      ]
+    },
+    "public.bingo_event_type": {
+      "name": "bingo_event_type",
+      "schema": "public",
+      "values": [
+        "tile_completed",
+        "submission_created",
+        "score_updated",
+        "board_completed",
+        "board_expired",
+        "board_created",
+        "inactivity_timer_started",
+        "inactivity_timer_extended"
+      ]
+    },
+    "public.camera_type_enum": {
+      "name": "camera_type_enum",
+      "schema": "public",
+      "values": [
+        "dslr",
+        "mirrorless",
+        "slr",
+        "action",
+        "cinema"
+      ]
+    },
+    "public.card_bus_enum": {
+      "name": "card_bus_enum",
+      "schema": "public",
+      "values": [
+        "sd_default",
+        "uhs_i",
+        "uhs_ii",
+        "uhs_iii",
+        "sd_express",
+        "cfexpress_pcie_gen3x1",
+        "cfexpress_pcie_gen3x2",
+        "cfexpress_pcie_gen4x1",
+        "cfexpress_pcie_gen4x2",
+        "xqd_1_0",
+        "xqd_2_0",
+        "cfast_sata_ii",
+        "cfast_sata_iii",
+        "cf_udma4",
+        "cf_udma5",
+        "cf_udma6",
+        "cf_udma7",
+        "sxs_pcie_gen1",
+        "sxs_pcie_gen2",
+        "p2_pci"
+      ]
+    },
+    "public.card_form_factor_enum": {
+      "name": "card_form_factor_enum",
+      "schema": "public",
+      "values": [
+        "sd",
+        "micro_sd",
+        "cfexpress_type_a",
+        "cfexpress_type_b",
+        "cfexpress_type_c",
+        "xqd",
+        "cfast",
+        "compactflash_type_i",
+        "compactflash_type_ii",
+        "memory_stick_pro_duo",
+        "memory_stick_pro_hg_duo",
+        "xd_picture_card",
+        "smartmedia",
+        "sxs",
+        "p2"
+      ]
+    },
+    "public.card_speed_class_enum": {
+      "name": "card_speed_class_enum",
+      "schema": "public",
+      "values": [
+        "c2",
+        "c4",
+        "c6",
+        "c10",
+        "u1",
+        "u3",
+        "v6",
+        "v10",
+        "v30",
+        "v60",
+        "v90",
+        "vpg_20",
+        "vpg_65",
+        "vpg_130"
+      ]
+    },
+    "public.creator_video_platform": {
+      "name": "creator_video_platform",
+      "schema": "public",
+      "values": [
+        "YOUTUBE"
+      ]
+    },
+    "public.date_precision_enum": {
+      "name": "date_precision_enum",
+      "schema": "public",
+      "values": [
+        "YEAR",
+        "MONTH",
+        "DAY"
+      ]
+    },
+    "public.metering_mode_enum": {
+      "name": "metering_mode_enum",
+      "schema": "public",
+      "values": [
+        "average",
+        "center-weighted",
+        "spot",
+        "other"
+      ]
+    },
+    "public.exposure_modes_enum": {
+      "name": "exposure_modes_enum",
+      "schema": "public",
+      "values": [
+        "manual",
+        "aperture-priority",
+        "shutter-priority",
+        "program",
+        "auto",
+        "other"
+      ]
+    },
+    "public.film_transport_enum": {
+      "name": "film_transport_enum",
+      "schema": "public",
+      "values": [
+        "not-applicable",
+        "manual-lever",
+        "manual-knob",
+        "manual-other",
+        "motorized",
+        "other"
+      ]
+    },
+    "public.focus_aid_enum": {
+      "name": "focus_aid_enum",
+      "schema": "public",
+      "values": [
+        "none",
+        "split-prism",
+        "microprism",
+        "rangefinder-patch",
+        "electronic-confirm",
+        "electronic-directional",
+        "af-point"
+      ]
+    },
+    "public.gear_region": {
+      "name": "gear_region",
+      "schema": "public",
+      "values": [
+        "GLOBAL",
+        "EU",
+        "JP"
+      ]
+    },
+    "public.gear_type": {
+      "name": "gear_type",
+      "schema": "public",
+      "values": [
+        "CAMERA",
+        "ANALOG_CAMERA",
+        "LENS"
+      ]
+    },
+    "public.iso_setting_method_enum": {
+      "name": "iso_setting_method_enum",
+      "schema": "public",
+      "values": [
+        "manual",
+        "dx-only",
+        "dx-with-override",
+        "fixed",
+        "other"
+      ]
+    },
+    "public.lens_filter_types_enum": {
+      "name": "lens_filter_types_enum",
+      "schema": "public",
+      "values": [
+        "none",
+        "front-screw-on",
+        "rear-screw-on",
+        "rear-bayonet",
+        "rear-gel-slot",
+        "rear-drop-in",
+        "internal-rotary"
+      ]
+    },
+    "public.lens_zoom_types_enum": {
+      "name": "lens_zoom_types_enum",
+      "schema": "public",
+      "values": [
+        "two-ring",
+        "push-pull",
+        "power-zoom",
+        "zoom-by-wire",
+        "collar-zoom",
+        "other"
+      ]
+    },
+    "public.metering_display_type_enum": {
+      "name": "metering_display_type_enum",
+      "schema": "public",
+      "values": [
+        "needle-middle",
+        "needle-match",
+        "led-indicators",
+        "led-scale",
+        "lcd-viewfinder",
+        "lcd-top-panel",
+        "none",
+        "other"
+      ]
+    },
+    "public.mount_material_enum": {
+      "name": "mount_material_enum",
+      "schema": "public",
+      "values": [
+        "metal",
+        "plastic"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "gear_spec_approved",
+        "badge_awarded",
+        "prompt_handle_setup"
+      ]
+    },
+    "public.popularity_event_type": {
+      "name": "popularity_event_type",
+      "schema": "public",
+      "values": [
+        "view",
+        "wishlist_add",
+        "owner_add",
+        "compare_add",
+        "review_submit",
+        "api_fetch"
+      ]
+    },
+    "public.popularity_timeframe": {
+      "name": "popularity_timeframe",
+      "schema": "public",
+      "values": [
+        "7d",
+        "30d"
+      ]
+    },
+    "public.proposal_status": {
+      "name": "proposal_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED",
+        "MERGED"
+      ]
+    },
+    "public.raw_bit_depth_enum": {
+      "name": "raw_bit_depth_enum",
+      "schema": "public",
+      "values": [
+        "10",
+        "12",
+        "14",
+        "16"
+      ]
+    },
+    "public.rear_display_types_enum": {
+      "name": "rear_display_types_enum",
+      "schema": "public",
+      "values": [
+        "none",
+        "fixed",
+        "single_axis_tilt",
+        "dual_axis_tilt",
+        "fully_articulated",
+        "four_axis_tilt_flip",
+        "other"
+      ]
+    },
+    "public.rec_group": {
+      "name": "rec_group",
+      "schema": "public",
+      "values": [
+        "prime",
+        "zoom"
+      ]
+    },
+    "public.rec_rating": {
+      "name": "rec_rating",
+      "schema": "public",
+      "values": [
+        "best value",
+        "best performance",
+        "situational",
+        "balanced"
+      ]
+    },
+    "public.review_flag_status": {
+      "name": "review_flag_status",
+      "schema": "public",
+      "values": [
+        "OPEN",
+        "RESOLVED_KEEP",
+        "RESOLVED_REJECTED",
+        "RESOLVED_DELETED"
+      ]
+    },
+    "public.review_status": {
+      "name": "review_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED"
+      ]
+    },
+    "public.sensor_stacking_types_enum": {
+      "name": "sensor_stacking_types_enum",
+      "schema": "public",
+      "values": [
+        "unstacked",
+        "partially-stacked",
+        "fully-stacked"
+      ]
+    },
+    "public.sensor_tech_types_enum": {
+      "name": "sensor_tech_types_enum",
+      "schema": "public",
+      "values": [
+        "cmos",
+        "ccd"
+      ]
+    },
+    "public.shutter_type_enum": {
+      "name": "shutter_type_enum",
+      "schema": "public",
+      "values": [
+        "focal-plane-cloth",
+        "focal-plane-metal",
+        "focal-plane-electronic",
+        "leaf",
+        "rotary",
+        "none",
+        "other"
+      ]
+    },
+    "public.shutter_types_enum": {
+      "name": "shutter_types_enum",
+      "schema": "public",
+      "values": [
+        "mechanical",
+        "efc",
+        "electronic"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "USER",
+        "MODERATOR",
+        "EDITOR",
+        "ADMIN",
+        "SUPERADMIN"
+      ]
+    },
+    "public.viewfinder_types_enum": {
+      "name": "viewfinder_types_enum",
+      "schema": "public",
+      "values": [
+        "none",
+        "optical",
+        "electronic"
+      ]
+    }
+  },
+  "schemas": {
+    "app": "app"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1775404342138,
       "tag": "0014_gray_paibok",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1775663751545,
+      "tag": "0015_moaning_angel",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/(admin)/admin/gear-create.tsx
+++ b/src/app/(app)/(admin)/admin/gear-create.tsx
@@ -5,6 +5,11 @@ import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "~/components/ui/tooltip";
+import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
@@ -27,6 +32,8 @@ import type { GearType } from "~/types/gear";
 import { ENUMS } from "~/lib/constants";
 import { humanizeKey } from "~/lib/utils";
 import { splitBrandsWithPriority } from "~/lib/brands";
+import { normalizeMpbLinkInput } from "~/lib/links/mpb";
+import { InfoIcon } from "lucide-react";
 
 type Brand = { id: string; name: string };
 type FuzzyItem = { id: string; slug: string; name: string };
@@ -37,6 +44,9 @@ export function GearCreateCard() {
   const [linkManufacturer, setLinkManufacturer] = useState("");
   const [linkMpb, setLinkMpb] = useState("");
   const [linkAmazon, setLinkAmazon] = useState("");
+  const [mpbNoticeUrl, setMpbNoticeUrl] = useState<string | null>(null);
+  const [mpbPreviewUrl, setMpbPreviewUrl] = useState<string | null>(null);
+  const [mpbError, setMpbError] = useState<string | null>(null);
   const [brandId, setBrandId] = useState<string>("");
   const [gearType, setGearType] = useState<GearType | "">("");
   const [brands, setBrands] = useState<Brand[]>([]);
@@ -91,6 +101,9 @@ export function GearCreateCard() {
     setLinkManufacturer("");
     setLinkMpb("");
     setLinkAmazon("");
+    setMpbNoticeUrl(null);
+    setMpbPreviewUrl(null);
+    setMpbError(null);
     setSlugPreview("");
     setProceedAnyway(false);
     setHardSlugConflict(false);
@@ -132,6 +145,18 @@ export function GearCreateCard() {
 
   const onSubmit = async () => {
     try {
+      const normalizedMpbResult = normalizeMpbLinkInput(linkMpb);
+      if (normalizedMpbResult.kind === "search") {
+        setMpbError(
+          "MPB search URLs are no longer supported. Paste the MPB link with any fit instead.",
+        );
+        return;
+      }
+      if (normalizedMpbResult.kind === "invalid") {
+        setMpbError("Paste an MPB product link or relative product path.");
+        return;
+      }
+
       setLoading(true);
       setCreatedSlug(null);
       const { actionCreateGear } = await import("~/server/admin/gear/actions");
@@ -141,7 +166,10 @@ export function GearCreateCard() {
         gearType: gearType as "CAMERA" | "LENS",
         modelNumber: modelNumber.trim() || undefined,
         linkManufacturer: linkManufacturer.trim() || undefined,
-        linkMpb: linkMpb.trim() || undefined,
+        linkMpb:
+          normalizedMpbResult.kind === "product"
+            ? normalizedMpbResult.normalizedPath
+            : undefined,
         linkAmazon: linkAmazon.trim() || undefined,
         force: proceedAnyway,
       });
@@ -153,6 +181,9 @@ export function GearCreateCard() {
       setLinkManufacturer("");
       setLinkMpb("");
       setLinkAmazon("");
+      setMpbNoticeUrl(null);
+      setMpbPreviewUrl(null);
+      setMpbError(null);
       setSlugPreview("");
       setHardSlugConflict(false);
       setHardModelConflict(false);
@@ -163,6 +194,48 @@ export function GearCreateCard() {
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleMpbLinkInputChange = (value: string) => {
+    setLinkMpb(value);
+    setMpbNoticeUrl(null);
+    setMpbError(null);
+
+    const result = normalizeMpbLinkInput(value);
+    if (result.kind === "product" && result.wasNormalized) {
+      setMpbPreviewUrl(result.normalizedPath);
+      return;
+    }
+
+    setMpbPreviewUrl(null);
+  };
+
+  const handleMpbLinkBlur = (value: string) => {
+    const result = normalizeMpbLinkInput(value);
+
+    if (result.kind === "empty") {
+      setLinkMpb("");
+      setMpbNoticeUrl(null);
+      setMpbPreviewUrl(null);
+      setMpbError(null);
+      return;
+    }
+
+    if (result.kind === "product") {
+      setLinkMpb(result.normalizedPath);
+      setMpbNoticeUrl(result.wasNormalized ? result.normalizedPath : null);
+      setMpbPreviewUrl(null);
+      setMpbError(null);
+      return;
+    }
+
+    setMpbNoticeUrl(null);
+    setMpbPreviewUrl(null);
+    setMpbError(
+      result.kind === "search"
+        ? "MPB search URLs are no longer supported. Paste the MPB link with any fit instead."
+        : "Paste an MPB product link or relative product path.",
+    );
   };
 
   // Debounced preflight check
@@ -361,15 +434,65 @@ export function GearCreateCard() {
             />
           </div>
           <div className="space-y-1 md:col-span-3">
-            <Label htmlFor="link-mpb">MPB Link</Label>
+            <div className="flex items-center gap-2">
+              <Label htmlFor="link-mpb">MPB Link</Label>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="text-muted-foreground hover:text-foreground inline-flex"
+                    aria-label="How MPB link saving works"
+                  >
+                    <InfoIcon className="size-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs text-xs">
+                  We trim the fit from the pasted MPB link, store the base path,
+                  then rebuild the fit-specific destination later based on the
+                  mount the user wants to visit.
+                </TooltipContent>
+              </Tooltip>
+            </div>
             <Input
               id="link-mpb"
-              type="url"
+              type="text"
               value={linkMpb}
-              onChange={(e) => setLinkMpb(e.target.value)}
-              placeholder="https://www.mpb.com/..."
+              onChange={(e) => handleMpbLinkInputChange(e.target.value)}
+              onBlur={(e) => handleMpbLinkBlur(e.target.value)}
+              placeholder="paste the mpb link with any fit"
               disabled={!brandId || !gearType}
             />
+            {mpbError ? (
+              <p className="text-xs text-red-600">{mpbError}</p>
+            ) : mpbNoticeUrl ? (
+              <p className="text-muted-foreground mt-1 text-xs">
+                This link will be saved as{" "}
+                <a
+                  href={mpbNoticeUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline"
+                >
+                  {mpbNoticeUrl}
+                </a>
+                .
+              </p>
+            ) : (
+              mpbPreviewUrl && (
+                <p className="text-muted-foreground mt-1 text-xs">
+                  This link will be saved as{" "}
+                  <a
+                    href={mpbPreviewUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    {mpbPreviewUrl}
+                  </a>
+                  .
+                </p>
+              )
+            )}
           </div>
           <div className="space-y-1 md:col-span-3">
             <Label htmlFor="link-amazon">Amazon Link</Label>

--- a/src/app/(app)/(pages)/gear/[slug]/page.tsx
+++ b/src/app/(app)/(pages)/gear/[slug]/page.tsx
@@ -265,8 +265,8 @@ export default async function GearPage({
     hasCreatorVideos: creatorVideos.length > 0,
     hasRawSamples: Boolean(
       item.gearType === "CAMERA" &&
-        item.rawSamples &&
-        item.rawSamples.length > 0,
+      item.rawSamples &&
+      item.rawSamples.length > 0,
     ),
     hasAlternatives: alternatives.length > 0,
     hasRelatedArticles: relatedNews.length > 0,
@@ -412,7 +412,7 @@ export default async function GearPage({
           {item.gearType === "CAMERA" &&
             item.rawSamples &&
             item.rawSamples.length > 0 && (
-              <section id="raw-samples" className="space-y-3 scroll-mt-24">
+              <section id="raw-samples" className="scroll-mt-24 space-y-3">
                 <h3 className="text-lg font-semibold">Raw Samples</h3>
                 <div className="space-y-2">
                   {item.rawSamples.map((sample) => (
@@ -468,6 +468,8 @@ export default async function GearPage({
           <div className="mb-8">
             <GearLinks
               slug={item.slug}
+              gearType={item.gearType}
+              mountIds={item.mountIds ?? null}
               brandName={item.brands?.name ?? brand?.name ?? null}
               linkManufacturer={item.linkManufacturer ?? null}
               linkMpb={item.linkMpb ?? null}

--- a/src/app/(app)/(pages)/gear/_components/edit-gear/edit-gear-form.tsx
+++ b/src/app/(app)/(pages)/gear/_components/edit-gear/edit-gear-form.tsx
@@ -459,6 +459,9 @@ function EditGearForm({
         "hasBuiltInTeleconverter",
         "hasLensHood",
         "hasTripodCollar",
+        "isTiltShift",
+        "tiltDegrees",
+        "shiftMm",
       ] as const;
 
       // Submit-time safeguard: if focal-length min and max are equal, treat as prime

--- a/src/app/(app)/(pages)/gear/_components/edit-gear/fields-core.tsx
+++ b/src/app/(app)/(pages)/gear/_components/edit-gear/fields-core.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, memo, useMemo, useState } from "react";
+import { useCallback, useEffect, memo, useMemo, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Label } from "~/components/ui/label";
 import { DateInput } from "~/components/custom-inputs";
@@ -22,6 +22,7 @@ import {
   toDisplayAmazonProductLink,
 } from "~/lib/validation/amazon";
 import { normalizeBhProductLink } from "~/lib/validation/bhphoto";
+import { normalizeMpbLinkInput } from "~/lib/links/mpb";
 import { useSession } from "~/lib/auth/auth-client";
 import { requireRole } from "~/lib/auth/auth-helpers";
 
@@ -165,6 +166,16 @@ function CoreFieldsComponent({
 
   const [amazonNoticeUrl, setAmazonNoticeUrl] = useState<string | null>(null);
   const [amazonPreviewUrl, setAmazonPreviewUrl] = useState<string | null>(null);
+  const [mpbInputValue, setMpbInputValue] = useState(
+    currentSpecs.linkMpb || "",
+  );
+  const [mpbNoticeUrl, setMpbNoticeUrl] = useState<string | null>(null);
+  const [mpbPreviewUrl, setMpbPreviewUrl] = useState<string | null>(null);
+  const [mpbError, setMpbError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setMpbInputValue(currentSpecs.linkMpb || "");
+  }, [currentSpecs.linkMpb]);
 
   const handleAmazonLinkInputChange = useCallback(
     (value: string) => {
@@ -212,6 +223,53 @@ function CoreFieldsComponent({
         return;
       }
       onChange("linkBh", trimmed.length ? trimmed : null);
+    },
+    [onChange],
+  );
+
+  const handleMpbLinkInputChange = useCallback((value: string) => {
+    setMpbInputValue(value);
+    setMpbNoticeUrl(null);
+    setMpbError(null);
+
+    const result = normalizeMpbLinkInput(value);
+    if (result.kind === "product" && result.wasNormalized) {
+      setMpbPreviewUrl(result.normalizedPath);
+      return;
+    }
+
+    setMpbPreviewUrl(null);
+  }, []);
+
+  const handleMpbLinkBlur = useCallback(
+    (value: string) => {
+      const result = normalizeMpbLinkInput(value);
+
+      if (result.kind === "empty") {
+        setMpbInputValue("");
+        setMpbNoticeUrl(null);
+        setMpbPreviewUrl(null);
+        setMpbError(null);
+        onChange("linkMpb", null);
+        return;
+      }
+
+      if (result.kind === "product") {
+        setMpbInputValue(result.normalizedPath);
+        setMpbNoticeUrl(result.wasNormalized ? result.normalizedPath : null);
+        setMpbPreviewUrl(null);
+        setMpbError(null);
+        onChange("linkMpb", result.normalizedPath);
+        return;
+      }
+
+      setMpbNoticeUrl(null);
+      setMpbPreviewUrl(null);
+      setMpbError(
+        result.kind === "search"
+          ? "MPB search URLs are no longer supported. Paste the MPB link with any fit instead."
+          : "Paste an MPB product link or relative product path.",
+      );
     },
     [onChange],
   );
@@ -688,15 +746,65 @@ function CoreFieldsComponent({
 
           {showWhenMissing((initialSpecs as any)?.linkMpb) && (
             <div className="space-y-2 md:col-span-2">
-              <Label htmlFor="linkMpb">MPB Link</Label>
+              <div className="flex items-center gap-2">
+                <Label htmlFor="linkMpb">MPB Link</Label>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className="text-muted-foreground hover:text-foreground inline-flex"
+                      aria-label="How MPB link saving works"
+                    >
+                      <InfoIcon className="size-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs text-xs">
+                    We trim the fit from the pasted MPB link, store the base
+                    path, then rebuild the fit-specific destination later based
+                    on the mount the user wants to visit.
+                  </TooltipContent>
+                </Tooltip>
+              </div>
               <input
                 id="linkMpb"
-                type="url"
-                value={currentSpecs.linkMpb || ""}
-                onChange={(e) => handleLinkChange("linkMpb", e.target.value)}
+                type="text"
+                value={mpbInputValue}
+                onChange={(e) => handleMpbLinkInputChange(e.target.value)}
+                onBlur={(e) => handleMpbLinkBlur(e.target.value)}
                 className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-                placeholder="https://www.mpb.com/..."
+                placeholder="paste the mpb link with any fit"
               />
+              {mpbError ? (
+                <p className="mt-1 text-xs text-red-600">{mpbError}</p>
+              ) : mpbNoticeUrl ? (
+                <p className="text-muted-foreground mt-1 text-xs">
+                  This link will be saved as{" "}
+                  <a
+                    href={mpbNoticeUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    {mpbNoticeUrl}
+                  </a>
+                  .
+                </p>
+              ) : (
+                mpbPreviewUrl && (
+                  <p className="text-muted-foreground mt-1 text-xs">
+                    This link will be saved as{" "}
+                    <a
+                      href={mpbPreviewUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline"
+                    >
+                      {mpbPreviewUrl}
+                    </a>
+                    .
+                  </p>
+                )
+              )}
             </div>
           )}
 

--- a/src/app/(app)/(pages)/gear/_components/edit-gear/fields-lenses.tsx
+++ b/src/app/(app)/(pages)/gear/_components/edit-gear/fields-lenses.tsx
@@ -76,6 +76,7 @@ function LensFieldsComponent({
   const isPrimeLens = currentSpecs?.isPrime === true;
   const hasStabilization = currentSpecs?.hasStabilization === true;
   const hasAutofocus = currentSpecs?.hasAutofocus === true;
+  const isTiltShift = currentSpecs?.isTiltShift === true;
   const CLEAR_SENSOR_FORMAT_VALUE = "none";
   const sensorFormatOptions = useMemo(
     () =>
@@ -676,6 +677,53 @@ function LensFieldsComponent({
               allowNull
               showStateText
               onChange={(value) => handleFieldChange("hasTripodCollar", value)}
+            />
+          )}
+
+          {/* Is Tilt-Shift */}
+          {showWhenMissing((initialSpecs as any)?.isTiltShift) && (
+            <BooleanInput
+              id="isTiltShift"
+              label="Is Tilt-Shift"
+              checked={currentSpecs?.isTiltShift ?? null}
+              allowNull
+              showStateText
+              onChange={(value) => {
+                handleFieldChange("isTiltShift", value);
+                if (value !== true) {
+                  // Clear dependent fields when not a tilt-shift lens
+                  handleFieldChange("tiltDegrees", null);
+                  handleFieldChange("shiftMm", null);
+                }
+              }}
+            />
+          )}
+
+          {/* Tilt Degrees */}
+          {showWhenMissing((initialSpecs as any)?.tiltDegrees) && (
+            <NumberInput
+              id="tiltDegrees"
+              label="Tilt"
+              suffix="°"
+              disabled={!isTiltShift}
+              value={isTiltShift ? numOrNull(currentSpecs?.tiltDegrees) : null}
+              onChange={(value) => handleFieldChange("tiltDegrees", value)}
+              step={0.1}
+              min={0}
+            />
+          )}
+
+          {/* Shift mm */}
+          {showWhenMissing((initialSpecs as any)?.shiftMm) && (
+            <NumberInput
+              id="shiftMm"
+              label="Shift"
+              suffix="mm"
+              disabled={!isTiltShift}
+              value={isTiltShift ? numOrNull(currentSpecs?.shiftMm) : null}
+              onChange={(value) => handleFieldChange("shiftMm", value)}
+              step={0.1}
+              min={0}
             />
           )}
         </div>

--- a/src/app/(app)/(pages)/gear/_components/gear-links.tsx
+++ b/src/app/(app)/(pages)/gear/_components/gear-links.tsx
@@ -2,19 +2,37 @@
 
 import { track } from "@vercel/analytics";
 import Link from "next/link";
+import { useMemo, useState, type ReactNode } from "react";
+import { FaAmazon } from "react-icons/fa";
+import { SiFujifilm, SiLeica, SiNikon, SiSony } from "react-icons/si";
+import { CircleQuestionMark } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "~/components/ui/dialog";
+import { useCountry } from "~/lib/hooks/useCountry";
+import {
+  getMpbMountSuffix,
+  hasKnownMpbMountSuffix,
+  isMpbSearchInput,
+} from "~/lib/links/mpb";
+import { getMountLongNameById } from "~/lib/mapping/mounts-map";
 import { formatPrice } from "~/lib/mapping";
 import { parseAmazonAsin } from "~/lib/validation/amazon";
-import { FaAmazon } from "react-icons/fa";
-import { SiNikon, SiSony, SiFujifilm, SiLeica } from "react-icons/si";
-import MpbLogo from "public/mpb-logo";
-import type { ReactNode } from "react";
 import { BRANDS } from "~/lib/generated";
+import type { GearType } from "~/types/gear";
 import { CanonLogo } from "public/canon-logo";
-import { CircleQuestionMark } from "lucide-react";
-import { useCountry } from "~/lib/hooks/useCountry";
+import MpbLogo from "public/mpb-logo";
 
 interface GearLinksProps {
   slug: string;
+  gearType: GearType;
+  mountIds?: string[] | null;
   linkManufacturer: string | null;
   linkMpb: string | null;
   linkAmazon: string | null;
@@ -24,8 +42,16 @@ interface GearLinksProps {
   msrpNowUsdCents?: number | null;
 }
 
+type MpbMountOption = {
+  id: string;
+  label: string;
+  supported: boolean;
+};
+
 export function GearLinks({
   slug,
+  gearType,
+  mountIds,
   brandName,
   linkManufacturer,
   linkMpb,
@@ -34,7 +60,9 @@ export function GearLinks({
   mpbMaxPriceUsdCents,
   msrpNowUsdCents,
 }: GearLinksProps) {
-  const { countryCode, locale } = useCountry();
+  const { locale } = useCountry();
+  const [isMpbDialogOpen, setIsMpbDialogOpen] = useState(false);
+
   const amazonAsin = parseAmazonAsin(linkAmazon) ?? null;
   const amazonRedirectHref = amazonAsin
     ? `/api/out/amazon?asin=${encodeURIComponent(
@@ -73,107 +101,214 @@ export function GearLinks({
       : "New";
   const normalizedBrandName =
     typeof brandName === "string" ? brandName.trim() : "";
-  const brandSlug =
-    normalizedBrandName
-      ? (BRANDS.find(
-          (brand) =>
-            brand.name.toLowerCase() === normalizedBrandName.toLowerCase(),
-        )?.slug ?? "")
-      : "";
+  const brandSlug = normalizedBrandName
+    ? (BRANDS.find(
+        (brand) =>
+          brand.name.toLowerCase() === normalizedBrandName.toLowerCase(),
+      )?.slug ?? "")
+    : "";
   const manufacturerStyles = getManufacturerStyles(brandSlug);
+
+  const mpbMarket = locale.affiliate.mpbMarket;
+  const isLegacyMpbSearchLink = isMpbSearchInput(linkMpb);
+  const uniqueMountIds = useMemo(
+    () => Array.from(new Set((mountIds ?? []).filter(Boolean))),
+    [mountIds],
+  );
+  const mpbMountOptions = useMemo<MpbMountOption[]>(
+    () =>
+      uniqueMountIds.map((mountId) => ({
+        id: mountId,
+        label: getMountLongNameById(mountId),
+        supported: Boolean(getMpbMountSuffix(mountId)),
+      })),
+    [uniqueMountIds],
+  );
+  const supportedMpbMounts = mpbMountOptions.filter((mount) => mount.supported);
+  const hasLegacyMountedLink = hasKnownMpbMountSuffix(linkMpb);
+  const shouldShowMpbChooser =
+    !isLegacyMpbSearchLink &&
+    gearType === "LENS" &&
+    mpbMountOptions.length > 1 &&
+    supportedMpbMounts.length > 1;
+  const directMpbMountId =
+    gearType === "LENS" ? (supportedMpbMounts[0]?.id ?? null) : null;
+  const directMpbHref = useMemo(() => {
+    if (!linkMpb) return undefined;
+    if (shouldShowMpbChooser) return undefined;
+
+    if (isLegacyMpbSearchLink) {
+      return buildMpbOutHref(linkMpb, mpbMarket, null);
+    }
+
+    if (gearType !== "LENS") {
+      return buildMpbOutHref(linkMpb, mpbMarket, null);
+    }
+
+    if (supportedMpbMounts.length === 1 && directMpbMountId) {
+      return buildMpbOutHref(linkMpb, mpbMarket, directMpbMountId);
+    }
+
+    if (hasLegacyMountedLink) {
+      return buildMpbOutHref(linkMpb, mpbMarket, null);
+    }
+
+    return undefined;
+  }, [
+    directMpbMountId,
+    gearType,
+    hasLegacyMountedLink,
+    isLegacyMpbSearchLink,
+    linkMpb,
+    mpbMarket,
+    shouldShowMpbChooser,
+    supportedMpbMounts.length,
+  ]);
+  const isMpbUnavailable =
+    Boolean(linkMpb) && !shouldShowMpbChooser && !directMpbHref;
 
   if (!hasAny) return null;
 
-  const mpbMarket = locale.affiliate.mpbMarket;
-  const mpbOutLink = linkMpb
-    ? `/api/out/mpb?destinationPath=${encodeURIComponent(linkMpb)}${
-        mpbMarket ? `&market=${encodeURIComponent(mpbMarket)}` : ""
-      }`
-    : undefined;
+  function handleMpbMountSelection(mountId: string) {
+    if (!linkMpb) return;
+    const href = buildMpbOutHref(linkMpb, mpbMarket, mountId);
+    if (!href) return;
+
+    void track("gear_link_click", {
+      slug,
+      linkType: "mpb",
+      mountId,
+    });
+
+    window.open(href, "_blank", "noopener,noreferrer");
+    setIsMpbDialogOpen(false);
+  }
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold">Links</h2>
+    <>
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Links</h2>
+        </div>
+
+        {linkManufacturer && (
+          <AffiliateLinkCard
+            href={linkManufacturer}
+            title={manufacturerStyles.title}
+            description="Official site"
+            backgroundClass={manufacturerStyles.backgroundClass}
+            textColorClass={manufacturerStyles.textColorClass}
+            logo={manufacturerStyles.logo}
+            onClick={() =>
+              void track("gear_link_click", {
+                slug,
+                linkType: "manufacturer",
+              })
+            }
+          />
+        )}
+        {linkMpb && (
+          <AffiliateLinkCard
+            href={directMpbHref}
+            title="See on MPB"
+            description={
+              isMpbUnavailable
+                ? "Used • Mount-specific MPB link unavailable"
+                : mpbPriceDescription
+            }
+            backgroundClass="bg-[#0b002b] hover:bg-[#0b002b]/80"
+            textColorClass="text-white"
+            logo={<MpbLogo className="h-8 w-8 text-[#ff18bd]" />}
+            disabled={isMpbUnavailable}
+            onClick={() => {
+              if (shouldShowMpbChooser) {
+                setIsMpbDialogOpen(true);
+                return;
+              }
+
+              void track("gear_link_click", {
+                slug,
+                linkType: "mpb",
+                mountId: directMpbMountId,
+              });
+            }}
+          />
+        )}
+        {amazonAsin && amazonRedirectHref && (
+          <AffiliateLinkCard
+            href={amazonRedirectHref}
+            title="Buy on Amazon"
+            description={amazonPriceDescription}
+            backgroundClass="bg-[#ffd814] hover:bg-[#ffd814]/70"
+            textColorClass="text-black"
+            logo={<FaAmazon className="h-8 w-8" />}
+            onClick={() =>
+              void track("gear_link_click", {
+                slug,
+                linkType: "amazon",
+              })
+            }
+          />
+        )}
+        {bhRedirectHref && (
+          <AffiliateLinkCard
+            href={bhRedirectHref}
+            title="Buy at B&H Photo"
+            description={bhPriceDescription}
+            backgroundClass="bg-[#b03734] hover:bg-[#b03734]/80"
+            textColorClass="text-white"
+            logo={<></>}
+            onClick={() =>
+              void track("gear_link_click", {
+                slug,
+                linkType: "bhphoto",
+              })
+            }
+          />
+        )}
       </div>
 
-      {linkManufacturer && (
-        <AffiliateLinkCard
-          href={linkManufacturer}
-          title={manufacturerStyles.title}
-          description="Official site"
-          backgroundClass={manufacturerStyles.backgroundClass}
-          textColorClass={manufacturerStyles.textColorClass}
-          logo={manufacturerStyles.logo}
-          onClick={() =>
-            void track("gear_link_click", {
-              slug,
-              linkType: "manufacturer",
-            })
-          }
-        />
-      )}
-      {linkMpb && (
-        <AffiliateLinkCard
-          href={mpbOutLink ?? linkMpb}
-          title="See on MPB"
-          description={mpbPriceDescription}
-          backgroundClass="bg-[#0b002b] hover:bg-[#0b002b]/80"
-          textColorClass="text-white"
-          logo={<MpbLogo className="h-8 w-8 text-[#ff18bd]" />}
-          onClick={() =>
-            void track("gear_link_click", {
-              slug,
-              linkType: "mpb",
-            })
-          }
-        />
-      )}
-      {amazonAsin && amazonRedirectHref && (
-        <AffiliateLinkCard
-          href={amazonRedirectHref}
-          title="Buy on Amazon"
-          description={amazonPriceDescription}
-          backgroundClass="bg-[#ffd814] hover:bg-[#ffd814]/70"
-          textColorClass="text-black"
-          logo={<FaAmazon className="h-8 w-8" />}
-          onClick={() =>
-            void track("gear_link_click", {
-              slug,
-              linkType: "amazon",
-            })
-          }
-        />
-      )}
-      {bhRedirectHref && (
-        <AffiliateLinkCard
-          href={bhRedirectHref}
-          title="Buy at B&H Photo"
-          description={bhPriceDescription}
-          backgroundClass="bg-[#b03734] hover:bg-[#b03734]/80"
-          textColorClass="text-white"
-          logo={<></>}
-          onClick={() =>
-            void track("gear_link_click", {
-              slug,
-              linkType: "bhphoto",
-            })
-          }
-        />
-      )}
-    </div>
+      <Dialog open={isMpbDialogOpen} onOpenChange={setIsMpbDialogOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Choose MPB Mount</DialogTitle>
+            <DialogDescription>
+              This item has multiple MPB mount listings. Pick the mount you want
+              to open.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2">
+            {mpbMountOptions.map((mount) => (
+              <Button
+                key={mount.id}
+                type="button"
+                variant="outline"
+                className="w-full justify-start"
+                disabled={!mount.supported}
+                onClick={() => handleMpbMountSelection(mount.id)}
+              >
+                {mount.label}
+                {!mount.supported ? " (Unavailable)" : ""}
+              </Button>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 
 export default GearLinks;
 
 interface AffiliateLinkCardProps {
-  href: string;
+  href?: string;
   title: string;
   description: string;
   backgroundClass: string;
   textColorClass?: string;
   logo: ReactNode;
+  disabled?: boolean;
   onClick?: () => void;
 }
 
@@ -184,23 +319,81 @@ function AffiliateLinkCard({
   backgroundClass,
   textColorClass = "text-white",
   logo,
+  disabled = false,
   onClick,
 }: AffiliateLinkCardProps) {
+  const className = `flex w-full items-center justify-between rounded px-6 py-2 transition-all ${backgroundClass} ${textColorClass} ${
+    disabled ? "cursor-not-allowed opacity-60" : ""
+  }`;
+
+  if (href && !disabled) {
+    return (
+      <Link
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer sponsored"
+        className={className}
+        onClick={onClick}
+      >
+        <AffiliateLinkCardContent
+          title={title}
+          description={description}
+          logo={logo}
+        />
+      </Link>
+    );
+  }
+
   return (
-    <Link
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer sponsored"
-      className={`flex w-full items-center justify-between rounded px-6 py-2 transition-all ${backgroundClass} ${textColorClass}`}
-      onClick={onClick}
+    <button
+      type="button"
+      className={className}
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
     >
+      <AffiliateLinkCardContent
+        title={title}
+        description={description}
+        logo={logo}
+      />
+    </button>
+  );
+}
+
+function AffiliateLinkCardContent({
+  title,
+  description,
+  logo,
+}: Pick<AffiliateLinkCardProps, "title" | "description" | "logo">) {
+  return (
+    <>
       <div className="flex flex-1 flex-col text-left">
         <span className="text-sm font-semibold">{title}</span>
         <span className="text-xs opacity-90">{description}</span>
       </div>
       <span className="flex items-center justify-center">{logo}</span>
-    </Link>
+    </>
   );
+}
+
+function buildMpbOutHref(
+  linkMpb: string,
+  market: string | null,
+  mountId: string | null,
+) {
+  const params = new URLSearchParams({
+    destinationPath: linkMpb,
+  });
+
+  if (market) {
+    params.set("market", market);
+  }
+
+  if (mountId) {
+    params.set("mountId", mountId);
+  }
+
+  return `/api/out/mpb?${params.toString()}`;
 }
 
 function getManufacturerStyles(brandSlug: string): {

--- a/src/app/(app)/(pages)/lists/under-construction/_components/under-construction-client.tsx
+++ b/src/app/(app)/(pages)/lists/under-construction/_components/under-construction-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { Progress } from "~/components/ui/progress";
 import {
   Select,
   SelectContent,
@@ -29,15 +30,23 @@ type Row = {
 };
 
 type Option = { value: string; label: string };
+type Summary = {
+  totalCount: number;
+  underConstructionCount: number;
+  completedCount: number;
+  completedPercent: number;
+};
 
 export default function UnderConstructionClient({
   canToggleAutoSubmit = false,
   items,
+  summary,
   brands,
   types,
 }: {
   canToggleAutoSubmit?: boolean;
   items: Row[];
+  summary: Summary;
   brands: Option[];
   types: readonly string[];
 }) {
@@ -56,6 +65,25 @@ export default function UnderConstructionClient({
 
   return (
     <>
+      <div className="bg-card mb-6 rounded-lg border p-4">
+        <div className="mb-2 flex items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-medium">Catalog completion</p>
+            <p className="text-muted-foreground text-xs">
+              {summary.completedCount} completed •{" "}
+              {summary.underConstructionCount} under construction •{" "}
+              {summary.totalCount} total
+            </p>
+          </div>
+          <p className="text-sm font-semibold">{summary.completedPercent}%</p>
+        </div>
+        <Progress value={summary.completedPercent} className="h-2.5" />
+        <p className="text-muted-foreground mt-2 text-xs">
+          {summary.underConstructionCount} under construction out of{" "}
+          {summary.totalCount} total items
+        </p>
+      </div>
+
       <div className="mb-3 flex flex-wrap items-center gap-4">
         <div className="flex items-center gap-2">
           <span className="text-muted-foreground text-xs">Brand</span>

--- a/src/app/(app)/(pages)/lists/under-construction/_components/under-construction-client.tsx
+++ b/src/app/(app)/(pages)/lists/under-construction/_components/under-construction-client.tsx
@@ -70,7 +70,6 @@ export default function UnderConstructionClient({
           <div>
             <p className="text-sm font-medium">Catalog completion</p>
             <p className="text-muted-foreground text-xs">
-              {summary.completedCount} completed •{" "}
               {summary.underConstructionCount} under construction •{" "}
               {summary.totalCount} total
             </p>
@@ -78,10 +77,7 @@ export default function UnderConstructionClient({
           <p className="text-sm font-semibold">{summary.completedPercent}%</p>
         </div>
         <Progress value={summary.completedPercent} className="h-2.5" />
-        <p className="text-muted-foreground mt-2 text-xs">
-          {summary.underConstructionCount} under construction out of{" "}
-          {summary.totalCount} total items
-        </p>
+
       </div>
 
       <div className="mb-3 flex flex-wrap items-center gap-4">

--- a/src/app/(app)/(pages)/lists/under-construction/page.tsx
+++ b/src/app/(app)/(pages)/lists/under-construction/page.tsx
@@ -18,10 +18,12 @@ export const metadata: Metadata = {
 
 export default async function Page() {
   // Include items with at least 1 missing key OR less than 40% completion overall
-  const [items, totalCount, session] = await Promise.all([
+  // fetchGearCount is non-critical: fall back to 0 so a metrics failure never
+  // breaks the whole route.
+  const [items, session, totalCount] = await Promise.all([
     listUnderConstruction(1, 40),
-    fetchGearCount(),
     auth.api.getSession({ headers: await headers() }),
+    fetchGearCount().catch(() => 0),
   ]);
   const underConstructionCount = items.length;
   const completedCount = Math.max(totalCount - underConstructionCount, 0);

--- a/src/app/(app)/(pages)/lists/under-construction/page.tsx
+++ b/src/app/(app)/(pages)/lists/under-construction/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { listUnderConstruction } from "~/server/gear/service";
+import { fetchGearCount } from "~/server/metrics/service";
 import UnderConstructionClient from "./_components/under-construction-client";
 import { BRANDS } from "~/lib/generated";
 import { auth } from "~/auth";
@@ -16,11 +17,16 @@ export const metadata: Metadata = {
 };
 
 export default async function Page() {
-  // Include items with at least 1 missing key OR less than 20% completion overall
-  const [items, session] = await Promise.all([
+  // Include items with at least 1 missing key OR less than 40% completion overall
+  const [items, totalCount, session] = await Promise.all([
     listUnderConstruction(1, 40),
+    fetchGearCount(),
     auth.api.getSession({ headers: await headers() }),
   ]);
+  const underConstructionCount = items.length;
+  const completedCount = Math.max(totalCount - underConstructionCount, 0);
+  const completedPercent =
+    totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
 
   return (
     <div className="mx-auto mt-24 min-h-screen max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
@@ -47,6 +53,12 @@ export default async function Page() {
       <UnderConstructionClient
         canToggleAutoSubmit={requireRole(session?.user, ["EDITOR"])}
         items={items}
+        summary={{
+          totalCount,
+          underConstructionCount,
+          completedCount,
+          completedPercent,
+        }}
         brands={BRANDS.map((b) => ({ value: b.id, label: b.name }))}
         types={GEAR_TYPES}
       />

--- a/src/app/(app)/api/out/mpb/route.ts
+++ b/src/app/(app)/api/out/mpb/route.ts
@@ -4,7 +4,11 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { headers } from "next/headers";
 
-import { getMpbDestinationUrl, type Market } from "~/lib/links/mpb";
+import {
+  getMpbDestinationUrl,
+  isMpbSearchInput,
+  type Market,
+} from "~/lib/links/mpb";
 import { resolveGearLinkMpb } from "~/server/gear/service";
 
 const EU_COUNTRIES = new Set([
@@ -73,6 +77,7 @@ export async function GET(request: NextRequest) {
   console.log("MPB out request received", { url: request.url });
   const marketParam = parseMarketParam(params.get("market"));
   const destinationPathParam = params.get("destinationPath");
+  const mountId = params.get("mountId");
   const gearSlug = params.get("gearSlug");
   const gearId = params.get("gearId");
 
@@ -112,13 +117,36 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  if (isMpbSearchInput(destinationPath)) {
+    try {
+      const redirectUrl = getMpbDestinationUrl({
+        market,
+        destinationPath,
+      });
+      return NextResponse.redirect(redirectUrl, 307);
+    } catch (error) {
+      console.error("MPB out rejected legacy search destinationPath", {
+        destinationPath,
+        error,
+      });
+      return NextResponse.json(
+        {
+          message: "Invalid MPB destinationPath.",
+        },
+        { status: 400 },
+      );
+    }
+  }
+
   try {
     const redirectUrl = getMpbDestinationUrl({
       market,
       destinationPath,
+      mountId,
     });
     console.log("MPB out redirecting", {
       destinationPath,
+      mountId,
       redirectUrl,
     });
 

--- a/src/lib/links/mpb.ts
+++ b/src/lib/links/mpb.ts
@@ -1,3 +1,5 @@
+import { MOUNTS } from "~/lib/constants";
+
 export type Market = "US" | "UK" | "EU";
 
 const MPB_HOSTNAME = "www.mpb.com";
@@ -8,19 +10,164 @@ const MPB_MARKET_PATH_SEGMENT: Record<Market, string> = {
   EU: "en-eu",
 };
 
+export const MPB_MOUNT_PATHS_MAP: Record<string, string> = {
+  "ef-canon": "-canon-fit",
+  "rf-canon": "-canon-rf-fit",
+  "ef-m-canon": "-canon-ef-m-fit",
+  "fl-canon": "-canon-fl-fit",
+  "fd-canon": "-canon-fd-fit",
+  "f-nikon": "-nikon-fit",
+  "z-nikon": "-nikon-z-fit",
+  "nikon1-nikon": "-nikon-1-fit",
+  "e-sony": "-sony-e-fit",
+  "a-sony": "-sony-a-fit",
+  "l-leica": "-l-fit",
+  "m-leica": "-leica-m-fit",
+  "ltm-leica": "-leica-ltm-fit",
+  "s-leica": "-leica-s-fit",
+  "m43-panasonic": "-micro-four-thirds-fit",
+  "43-olympus": "-four-thirds-fit",
+  "x-fujifilm": "-fujifilm-x-fit",
+  "g-fujifilm": "-fujifilm-g-fit",
+  "k-pentax": "-pentax-k-fit",
+  "q-pentax": "-pentax-q-fit",
+  "x-hasselblad": "-hasselblad-x-fit",
+  "h-hasselblad": "-hasselblad-h-fit",
+  "v-hasselblad": "-hasselblad-v-fit",
+  "sa-sigma": "-sigma-sa-fit",
+};
+
+const MOUNT_VALUE_BY_ID = new Map(
+  (MOUNTS as Array<{ id: string; value: string }>).map((mount) => [
+    mount.id,
+    mount.value,
+  ]),
+);
+
+const MPB_KNOWN_MOUNT_SUFFIXES = Array.from(
+  new Set([...Object.values(MPB_MOUNT_PATHS_MAP), "-sony-fe-fit"]),
+).sort((a, b) => b.length - a.length);
+
+export type NormalizeMpbLinkResult =
+  | { kind: "empty"; normalizedPath: null }
+  | {
+      kind: "product";
+      normalizedPath: string;
+      originalPath: string;
+      wasNormalized: boolean;
+    }
+  | { kind: "search"; originalPath: string }
+  | { kind: "invalid"; originalPath: string };
+
 interface GetMpbDestinationUrlInput {
   market: Market;
   destinationPath: string;
+  mountId?: string | null;
 }
 
 /**
  * Build a direct MPB destination URL using the requested storefront path prefix.
  */
 export function getMpbDestinationUrl(input: GetMpbDestinationUrlInput) {
-  return buildDestinationAddress(input.destinationPath, input.market);
+  return buildDestinationAddress(
+    input.destinationPath,
+    input.market,
+    input.mountId ?? null,
+  );
 }
 
-function buildDestinationAddress(destinationPath: string, market: Market) {
+export function normalizeMpbLinkInput(
+  input?: string | null,
+): NormalizeMpbLinkResult {
+  const trimmed = (input ?? "").trim();
+
+  if (!trimmed) {
+    return { kind: "empty", normalizedPath: null };
+  }
+
+  const parsed = parseMpbInput(trimmed);
+  if (!parsed) {
+    return { kind: "invalid", originalPath: trimmed };
+  }
+
+  if (parsed.kind === "absolute" && !isMpbHostname(parsed.url.hostname)) {
+    return { kind: "invalid", originalPath: trimmed };
+  }
+
+  const originalPath = stripMarketSegmentFromPath(parsed.url.pathname);
+  if (isMpbSearchPath(parsed.url.pathname)) {
+    return {
+      kind: "search",
+      originalPath: withSearch(originalPath, parsed.url),
+    };
+  }
+  if (!isMpbProductPath(originalPath)) {
+    return { kind: "invalid", originalPath };
+  }
+
+  const normalizedPath = stripKnownMountSuffixFromPath(originalPath);
+
+  return {
+    kind: "product",
+    normalizedPath,
+    originalPath,
+    wasNormalized: normalizedPath !== originalPath,
+  };
+}
+
+export function normalizeMpbLinkForStorage(
+  input?: string | null,
+): string | null {
+  const result = normalizeMpbLinkInput(input);
+
+  if (result.kind === "empty") return null;
+  if (result.kind === "product") return result.normalizedPath;
+  if (result.kind === "search") {
+    throw new Error(
+      "MPB search URLs are no longer supported. Paste a product link instead.",
+    );
+  }
+
+  throw new Error("Invalid MPB URL.");
+}
+
+export function getMpbMountSuffix(mountId?: string | null): string | null {
+  if (!mountId) return null;
+  const mountValue = MOUNT_VALUE_BY_ID.get(mountId);
+  if (!mountValue) return null;
+  return MPB_MOUNT_PATHS_MAP[mountValue] ?? null;
+}
+
+export function hasKnownMpbMountSuffix(
+  destinationPath?: string | null,
+): boolean {
+  const result = normalizeMpbLinkInput(destinationPath);
+  return result.kind === "product" && result.wasNormalized;
+}
+
+export function buildMpbPathForMount(
+  destinationPath: string,
+  mountId?: string | null,
+): string | null {
+  const result = normalizeMpbLinkInput(destinationPath);
+  if (result.kind !== "product") return null;
+  if (!mountId) return result.originalPath;
+
+  const suffix = getMpbMountSuffix(mountId);
+  if (!suffix) return null;
+
+  return appendMountSuffixToPath(result.normalizedPath, suffix);
+}
+
+export function isMpbSearchInput(input?: string | null) {
+  return normalizeMpbLinkInput(input).kind === "search";
+}
+
+function buildDestinationAddress(
+  destinationPath: string,
+  market: Market,
+  mountId: string | null,
+) {
   const cleanedDestinationPath = destinationPath.trim();
 
   if (cleanedDestinationPath === "") {
@@ -28,17 +175,25 @@ function buildDestinationAddress(destinationPath: string, market: Market) {
   }
 
   if (isHttpAddress(cleanedDestinationPath)) {
-    return buildDestinationAddressFromAbsolute(cleanedDestinationPath, market);
+    return buildDestinationAddressFromAbsolute(
+      cleanedDestinationPath,
+      market,
+      mountId,
+    );
   }
 
-  return buildDestinationAddressFromRelative(cleanedDestinationPath, market);
+  return buildDestinationAddressFromRelative(
+    cleanedDestinationPath,
+    market,
+    mountId,
+  );
 }
 
-function isHttpAddress(value: string) {
-  return value.startsWith("http://") || value.startsWith("https://");
-}
-
-function buildDestinationAddressFromAbsolute(address: string, market: Market) {
+function buildDestinationAddressFromAbsolute(
+  address: string,
+  market: Market,
+  mountId: string | null,
+) {
   const parsedAddress = new URL(address);
   if (!isMpbHostname(parsedAddress.hostname)) {
     throw new Error("MPB destination must use an MPB hostname.");
@@ -47,26 +202,138 @@ function buildDestinationAddressFromAbsolute(address: string, market: Market) {
   parsedAddress.protocol = "https:";
   parsedAddress.hostname = MPB_HOSTNAME;
   parsedAddress.port = "";
-  parsedAddress.pathname = buildMarketPath(parsedAddress.pathname, market);
+  parsedAddress.pathname = buildMarketPath(
+    parsedAddress.pathname,
+    market,
+    mountId,
+  );
   return parsedAddress.toString();
 }
 
-function buildDestinationAddressFromRelative(address: string, market: Market) {
+function buildDestinationAddressFromRelative(
+  address: string,
+  market: Market,
+  mountId: string | null,
+) {
   const parsedAddress = new URL(
     ensureLeadingSlash(address),
     `https://${MPB_HOSTNAME}`,
   );
-  parsedAddress.pathname = buildMarketPath(parsedAddress.pathname, market);
+  parsedAddress.pathname = buildMarketPath(
+    parsedAddress.pathname,
+    market,
+    mountId,
+  );
   return parsedAddress.toString();
 }
 
-function buildMarketPath(pathname: string, market: Market) {
+function buildMarketPath(
+  pathname: string,
+  market: Market,
+  mountId: string | null,
+) {
   const normalizedSegment = stripMarketSegmentFromPath(pathname);
-  return `/${MPB_MARKET_PATH_SEGMENT[market]}${normalizedSegment}`;
+  if (isMpbSearchPath(normalizedSegment)) {
+    if (mountId) {
+      throw new Error(
+        "MPB search destinations do not support mount selection.",
+      );
+    }
+    return `/${MPB_MARKET_PATH_SEGMENT[market]}${normalizedSegment}`;
+  }
+  if (!isMpbProductPath(normalizedSegment)) {
+    throw new Error("MPB destination must be a product path.");
+  }
+  const mountedSegment = mountId
+    ? buildMountedPathOrThrow(normalizedSegment, mountId)
+    : normalizedSegment;
+  return `/${MPB_MARKET_PATH_SEGMENT[market]}${mountedSegment}`;
+}
+
+function buildMountedPathOrThrow(pathname: string, mountId: string) {
+  const mountedPath = buildMpbPathForMount(pathname, mountId);
+  if (!mountedPath) {
+    throw new Error("MPB destination mount is unsupported.");
+  }
+  return mountedPath;
+}
+
+function stripKnownMountSuffixFromPath(pathname: string) {
+  const parts = stripMarketSegmentFromPath(pathname).split("/").filter(Boolean);
+  if (parts.length === 0) return "/";
+
+  const lastSegment = parts[parts.length - 1] ?? "";
+  parts[parts.length - 1] = stripKnownMountSuffixFromSlug(lastSegment);
+  return `/${parts.join("/")}`;
+}
+
+function stripKnownMountSuffixFromSlug(slug: string) {
+  for (const suffix of MPB_KNOWN_MOUNT_SUFFIXES) {
+    if (slug.toLowerCase().endsWith(suffix.toLowerCase())) {
+      return slug.slice(0, -suffix.length);
+    }
+  }
+
+  return slug;
+}
+
+function appendMountSuffixToPath(pathname: string, suffix: string) {
+  const parts = stripMarketSegmentFromPath(pathname).split("/").filter(Boolean);
+  if (parts.length === 0) {
+    throw new Error("MPB destination path must include a product slug.");
+  }
+
+  parts[parts.length - 1] = `${parts[parts.length - 1]}${suffix}`;
+  return `/${parts.join("/")}`;
+}
+
+function parseMpbInput(value: string) {
+  if (
+    isHttpAddress(value) ||
+    /^www\./i.test(value) ||
+    /^mpb\.com/i.test(value)
+  ) {
+    try {
+      const withScheme = isHttpAddress(value) ? value : `https://${value}`;
+      return { kind: "absolute" as const, url: new URL(withScheme) };
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    return {
+      kind: "relative" as const,
+      url: new URL(ensureLeadingSlash(value), `https://${MPB_HOSTNAME}`),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function withSearch(pathname: string, url: URL) {
+  return `${pathname}${url.search}`;
+}
+
+function isHttpAddress(value: string) {
+  return value.startsWith("http://") || value.startsWith("https://");
+}
+
+function isMpbSearchPath(pathname: string) {
+  return /^\/(?:en-[^/]+\/)?search(?:\/|$)/i.test(ensureLeadingSlash(pathname));
+}
+
+function isMpbProductPath(pathname: string) {
+  const normalizedPath = stripMarketSegmentFromPath(pathname);
+  return (
+    /^\/product\/[^/]+\/?$/i.test(normalizedPath) ||
+    /^\/buy\/used\/[^/]+\/?$/i.test(normalizedPath)
+  );
 }
 
 function stripMarketSegmentFromPath(path: string) {
-  return ensureLeadingSlash(path).replace(/^\/en-[^/]+/i, "");
+  const stripped = ensureLeadingSlash(path).replace(/^\/en-[^/]+/i, "");
+  return stripped === "" ? "/" : stripped;
 }
 
 function ensureLeadingSlash(value: string) {
@@ -75,5 +342,7 @@ function ensureLeadingSlash(value: string) {
 
 function isMpbHostname(hostname: string) {
   const normalizedHostname = hostname.toLowerCase();
-  return normalizedHostname === MPB_HOSTNAME || normalizedHostname === "mpb.com";
+  return (
+    normalizedHostname === MPB_HOSTNAME || normalizedHostname === "mpb.com"
+  );
 }

--- a/src/lib/specs/registry.tsx
+++ b/src/lib/specs/registry.tsx
@@ -1648,6 +1648,51 @@ export const specDictionary: SpecSectionDef[] = [
   },
 
   // ==========================================================================
+  // LENS: TILT-SHIFT
+  // ==========================================================================
+  {
+    id: "lens-tilt-shift",
+    title: "Tilt-Shift",
+    sectionAnchor: "lens-section",
+    condition: (item) => item.gearType === "LENS",
+    fields: [
+      {
+        key: "isTiltShift",
+        label: "Is Tilt-Shift",
+        getRawValue: (item) => item.lensSpecs?.isTiltShift,
+        formatDisplay: (raw) =>
+          typeof raw === "boolean" ? yesNoNull(raw, true) : undefined,
+      },
+      {
+        key: "tiltDegrees",
+        label: "Tilt Range",
+        getRawValue: (item) => item.lensSpecs?.tiltDegrees,
+        formatDisplay: (raw) => {
+          if (raw == null) return undefined;
+          const n = Number(raw);
+          return Number.isFinite(n)
+            ? `±${Number.isInteger(n) ? n : n.toFixed(1)}°`
+            : undefined;
+        },
+        condition: (item) => item.lensSpecs?.isTiltShift === true,
+      },
+      {
+        key: "shiftMm",
+        label: "Shift Range",
+        getRawValue: (item) => item.lensSpecs?.shiftMm,
+        formatDisplay: (raw) => {
+          if (raw == null) return undefined;
+          const n = Number(raw);
+          return Number.isFinite(n)
+            ? `±${Number.isInteger(n) ? n : n.toFixed(1)}mm`
+            : undefined;
+        },
+        condition: (item) => item.lensSpecs?.isTiltShift === true,
+      },
+    ],
+  },
+
+  // ==========================================================================
   // ANALOG CAMERAS
   // ==========================================================================
   {

--- a/src/server/admin/gear/data.ts
+++ b/src/server/admin/gear/data.ts
@@ -14,15 +14,14 @@ import {
   recommendationItems,
 } from "~/server/db/schema";
 import { buildGearSearchName } from "~/lib/gear/naming";
+import { normalizeMpbLinkForStorage } from "~/lib/links/mpb";
 import { normalizeFuzzyTokens } from "~/lib/utils/fuzzy";
 import type { GearType } from "~/types/gear";
 
 type DbTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
 type DbLike = typeof db | DbTx;
 
-function isForeignKeyViolation(
-  error: unknown,
-): error is {
+function isForeignKeyViolation(error: unknown): error is {
   code: string;
   constraint?: string;
   constraint_name?: string;
@@ -225,6 +224,8 @@ export async function createGearData(
     linkAmazon,
   } = params;
 
+  const normalizedLinkMpb = normalizeMpbLinkForStorage(linkMpb);
+
   // Validate brand exists
   const b = await db
     .select()
@@ -301,7 +302,7 @@ export async function createGearData(
         brandId,
         modelNumber: modelNumber || null,
         linkManufacturer: linkManufacturer || null,
-        linkMpb: linkMpb || null,
+        linkMpb: normalizedLinkMpb,
         linkAmazon: linkAmazon || null,
         mountId: normalizedMountIds[0] ?? null,
         searchName: buildGearSearchName({ name: displayName, brandName }),
@@ -599,14 +600,18 @@ export async function deleteGearData(
 ): Promise<DeleteGearResult> {
   try {
     if (conn === db) {
-      return await db.transaction(async (tx) => deleteGearDataWithConn(tx, gearId));
+      return await db.transaction(async (tx) =>
+        deleteGearDataWithConn(tx, gearId),
+      );
     }
 
     return await deleteGearDataWithConn(conn, gearId);
   } catch (error) {
     if (isForeignKeyViolation(error)) {
       throw Object.assign(
-        new Error("Cannot delete gear because related records still reference it"),
+        new Error(
+          "Cannot delete gear because related records still reference it",
+        ),
         {
           status: 409,
           constraint: error.constraint_name ?? error.constraint ?? null,

--- a/src/server/db/normalizers.ts
+++ b/src/server/db/normalizers.ts
@@ -1251,6 +1251,27 @@ export function normalizeProposalPayloadForDb(
           z.boolean().nullable().optional(),
         )
         .optional(),
+      isTiltShift: z
+        .preprocess(
+          (value) =>
+            value === null ? null : (coerceBoolean(value) ?? undefined),
+          z.boolean().nullable().optional(),
+        )
+        .optional(),
+      tiltDegrees: z
+        .preprocess((value) => {
+          if (value === null) return null;
+          const num = coerceNumber(value);
+          return num === null ? undefined : Math.round(num * 10) / 10;
+        }, z.number().nullable().optional())
+        .optional(),
+      shiftMm: z
+        .preprocess((value) => {
+          if (value === null) return null;
+          const num = coerceNumber(value);
+          return num === null ? undefined : Math.round(num * 10) / 10;
+        }, z.number().nullable().optional())
+        .optional(),
     })
     .catchall(z.unknown())
     .transform((lens) => {

--- a/src/server/db/normalizers.ts
+++ b/src/server/db/normalizers.ts
@@ -1,5 +1,6 @@
 import { SENSOR_FORMATS, ENUMS } from "~/lib/constants";
 import { normalizeBhProductLink } from "~/lib/validation/bhphoto";
+import { normalizeMpbLinkForStorage } from "~/lib/links/mpb";
 import {
   videoModeInputSchema,
   normalizeVideoModes,
@@ -264,8 +265,7 @@ export function normalizeProposalPayloadForDb(
         .preprocess((value) => {
           if (value === null) return null;
           if (typeof value === "string") {
-            const trimmed = value.trim();
-            return trimmed.length > 0 ? trimmed : null;
+            return normalizeMpbLinkForStorage(value);
           }
           return undefined;
         }, z.string().nullable().optional())
@@ -1354,20 +1354,21 @@ export function normalizeProposalPayloadForDb(
             return num === null ? undefined : num;
           }, z.number().nullable().optional())
           .optional(),
-      imageCircleSizeId: z
-        .preprocess((value) => {
-          if (value === null) return null;
-          if (typeof value !== "string") return undefined;
-          if (isUuid(value)) return value;
-          const match = SENSOR_FORMATS.find(
-            (format) =>
-              format &&
-              typeof format === "object" &&
-              ((format as any).slug === value || (format as any).id === value),
-          ) as { id?: string } | undefined;
-          return match?.id ?? undefined;
-        }, z.string().uuid().nullable().optional())
-        .optional(),
+        imageCircleSizeId: z
+          .preprocess((value) => {
+            if (value === null) return null;
+            if (typeof value !== "string") return undefined;
+            if (isUuid(value)) return value;
+            const match = SENSOR_FORMATS.find(
+              (format) =>
+                format &&
+                typeof format === "object" &&
+                ((format as any).slug === value ||
+                  (format as any).id === value),
+            ) as { id?: string } | undefined;
+            return match?.id ?? undefined;
+          }, z.string().uuid().nullable().optional())
+          .optional(),
         maxApertureWide: z
           .preprocess((value) => {
             if (value === null) return null;

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1015,6 +1015,10 @@ export const lensSpecs = appSchema.table(
     hasBuiltInTeleconverter: boolean("has_built_in_teleconverter"),
     hasLensHood: boolean("has_lens_hood"),
     hasTripodCollar: boolean("has_tripod_collar"),
+    // tilt-shift
+    isTiltShift: boolean("is_tilt_shift"),
+    tiltDegrees: decimal("tilt_degrees", { precision: 4, scale: 1 }),
+    shiftMm: decimal("shift_mm", { precision: 5, scale: 1 }),
     extra: jsonb("extra"),
     createdAt,
     updatedAt,

--- a/tests/unit/mpb-links.test.ts
+++ b/tests/unit/mpb-links.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import { getMpbDestinationUrl } from "~/lib/links/mpb";
+import { MOUNTS } from "~/lib/constants";
+import {
+  buildMpbPathForMount,
+  getMpbDestinationUrl,
+  MPB_MOUNT_PATHS_MAP,
+  normalizeMpbLinkInput,
+} from "~/lib/links/mpb";
 
-describe("getMpbDestinationUrl", () => {
+const NIKON_F_MOUNT_ID = "1e930c0c-aadb-4dd3-93ae-7f691cc93296";
+
+describe("MPB link helpers", () => {
   it("rewrites relative paths into the selected market storefront", () => {
     expect(
       getMpbDestinationUrl({
@@ -19,8 +27,75 @@ describe("getMpbDestinationUrl", () => {
         destinationPath:
           "https://www.mpb.com/en-us/product/nikon-z6-iii?sort=price#details",
       }),
+    ).toBe("https://www.mpb.com/en-uk/product/nikon-z6-iii?sort=price#details");
+  });
+
+  it("normalizes mount-specific product URLs to a base path", () => {
+    expect(
+      normalizeMpbLinkInput(
+        "https://www.mpb.com/en-us/product/sigma-24-70mm-f-2-8-dg-dn-art-sony-fe-fit",
+      ),
+    ).toEqual({
+      kind: "product",
+      normalizedPath: "/product/sigma-24-70mm-f-2-8-dg-dn-art",
+      originalPath: "/product/sigma-24-70mm-f-2-8-dg-dn-art-sony-fe-fit",
+      wasNormalized: true,
+    });
+  });
+
+  it("normalizes market-prefixed relative URLs to a base path", () => {
+    expect(
+      normalizeMpbLinkInput("/en-us/product/nikon-af-s-50mm-f-1-8g-nikon-fit"),
+    ).toEqual({
+      kind: "product",
+      normalizedPath: "/product/nikon-af-s-50mm-f-1-8g",
+      originalPath: "/product/nikon-af-s-50mm-f-1-8g-nikon-fit",
+      wasNormalized: true,
+    });
+  });
+
+  it("rejects MPB search URLs during normalization", () => {
+    expect(
+      normalizeMpbLinkInput("https://www.mpb.com/en-us/search?q=canon+ef+50mm"),
+    ).toEqual({
+      kind: "search",
+      originalPath: "/search?q=canon+ef+50mm",
+    });
+  });
+
+  it("rejects non-product MPB paths during normalization", () => {
+    expect(
+      normalizeMpbLinkInput("https://www.mpb.com/en-us/help/shipping"),
+    ).toEqual({
+      kind: "invalid",
+      originalPath: "/help/shipping",
+    });
+  });
+
+  it("appends a mapped mount suffix to the base path", () => {
+    expect(
+      buildMpbPathForMount("/product/nikon-af-s-50mm-f-1-8g", NIKON_F_MOUNT_ID),
+    ).toBe("/product/nikon-af-s-50mm-f-1-8g-nikon-fit");
+  });
+
+  it("returns null when no suffix exists for the requested mount", () => {
+    expect(
+      buildMpbPathForMount(
+        "/product/nikon-af-s-50mm-f-1-8g",
+        "00000000-0000-0000-0000-000000000000",
+      ),
+    ).toBeNull();
+  });
+
+  it("builds a market-aware URL for a selected mount", () => {
+    expect(
+      getMpbDestinationUrl({
+        market: "EU",
+        destinationPath: "/product/nikon-af-s-50mm-f-1-8g",
+        mountId: NIKON_F_MOUNT_ID,
+      }),
     ).toBe(
-      "https://www.mpb.com/en-uk/product/nikon-z6-iii?sort=price#details",
+      "https://www.mpb.com/en-eu/product/nikon-af-s-50mm-f-1-8g-nikon-fit",
     );
   });
 
@@ -31,5 +106,35 @@ describe("getMpbDestinationUrl", () => {
         destinationPath: "https://example.com/product/nikon-z6-iii",
       }),
     ).toThrow("MPB destination must use an MPB hostname.");
+  });
+
+  it("fails when a mapped mount value is not present in generated mounts", () => {
+    const mountValues = new Set(
+      (MOUNTS as Array<{ value: string }>).map((mount) => mount.value),
+    );
+    const unknownMappedValues = Object.keys(MPB_MOUNT_PATHS_MAP).filter(
+      (value) => !mountValues.has(value),
+    );
+
+    expect(unknownMappedValues).toEqual([]);
+  });
+
+  it("tracks unmapped generated mount values", () => {
+    const mappedValues = new Set(Object.keys(MPB_MOUNT_PATHS_MAP));
+    const unmappedMountValues = (MOUNTS as Array<{ value: string }>)
+      .map((mount) => mount.value)
+      .filter((value) => !mappedValues.has(value))
+      .sort();
+
+    expect(unmappedMountValues).toMatchInlineSnapshot(`
+      [
+        "a-minolta",
+        "fixed-lens",
+        "m42-zeiss",
+        "m645-mamiya",
+        "s-nikon",
+        "sr-minolta",
+      ]
+    `);
   });
 });

--- a/tests/unit/mpb-out-route.test.ts
+++ b/tests/unit/mpb-out-route.test.ts
@@ -14,6 +14,8 @@ vi.mock("server-only", () => ({}));
 
 import { GET } from "../../src/app/(app)/api/out/mpb/route";
 
+const NIKON_F_MOUNT_ID = "1e930c0c-aadb-4dd3-93ae-7f691cc93296";
+
 describe("MPB out route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -102,6 +104,19 @@ describe("MPB out route", () => {
     );
   });
 
+  it("builds a mount-specific redirect from the stored base path", async () => {
+    const response = await GET(
+      new Request(
+        `http://localhost/api/out/mpb?destinationPath=%2Fproduct%2Fnikon-af-s-50mm-f-1-8g&mountId=${encodeURIComponent(NIKON_F_MOUNT_ID)}&market=EU`,
+      ) as any,
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://www.mpb.com/en-eu/product/nikon-af-s-50mm-f-1-8g-nikon-fit",
+    );
+  });
+
   it("returns 400 when no destination can be resolved", async () => {
     const response = await GET(
       new Request("http://localhost/api/out/mpb?gearSlug=nikon-z6-iii") as any,
@@ -110,7 +125,8 @@ describe("MPB out route", () => {
 
     expect(response.status).toBe(400);
     expect(payload).toEqual({
-      message: "Missing destinationPath or gear reference with a valid MPB link.",
+      message:
+        "Missing destinationPath or gear reference with a valid MPB link.",
     });
   });
 
@@ -118,6 +134,33 @@ describe("MPB out route", () => {
     const response = await GET(
       new Request(
         "http://localhost/api/out/mpb?destinationPath=https%3A%2F%2Fexample.com%2Fproduct%2Fnikon-z6-iii",
+      ) as any,
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload).toEqual({
+      message: "Invalid MPB destinationPath.",
+    });
+  });
+
+  it("keeps legacy MPB search URLs working", async () => {
+    const response = await GET(
+      new Request(
+        "http://localhost/api/out/mpb?destinationPath=https%3A%2F%2Fwww.mpb.com%2Fen-us%2Fsearch%3Fq%3Dcanon",
+      ) as any,
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://www.mpb.com/en-us/search?q=canon",
+    );
+  });
+
+  it("returns 400 for non-product MPB paths", async () => {
+    const response = await GET(
+      new Request(
+        "http://localhost/api/out/mpb?destinationPath=https%3A%2F%2Fwww.mpb.com%2Fen-us%2Fhelp%2Fshipping",
       ) as any,
     );
     const payload = await response.json();

--- a/tests/unit/under-construction-page.test.ts
+++ b/tests/unit/under-construction-page.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const gearServiceMocks = vi.hoisted(() => ({
+  listUnderConstruction: vi.fn(),
+}));
+
+const metricsMocks = vi.hoisted(() => ({
+  fetchGearCount: vi.fn(),
+}));
+
+const authMocks = vi.hoisted(() => ({
+  auth: {
+    api: {
+      getSession: vi.fn(),
+    },
+  },
+}));
+
+const headerMocks = vi.hoisted(() => ({
+  headers: vi.fn(),
+}));
+
+const authHelperMocks = vi.hoisted(() => ({
+  requireRole: vi.fn(),
+}));
+
+const clientComponentMock = vi.hoisted(() => vi.fn((_props: unknown) => null));
+
+vi.mock("~/server/gear/service", () => gearServiceMocks);
+vi.mock("~/server/metrics/service", () => metricsMocks);
+vi.mock("~/auth", () => authMocks);
+vi.mock("next/headers", () => headerMocks);
+vi.mock("~/lib/auth/auth-helpers", () => authHelperMocks);
+vi.mock(
+  "~/app/(app)/(pages)/lists/under-construction/_components/under-construction-client",
+  () => ({
+    default: clientComponentMock,
+  }),
+);
+
+import Page from "~/app/(app)/(pages)/lists/under-construction/page";
+
+type ClientProps = {
+  canToggleAutoSubmit: boolean;
+  items: unknown[];
+  summary: {
+    totalCount: number;
+    underConstructionCount: number;
+    completedCount: number;
+    completedPercent: number;
+  };
+};
+
+function getClientProps() {
+  const firstCall = clientComponentMock.mock.calls.at(0);
+  if (!firstCall) {
+    throw new Error("Expected UnderConstructionClient to render");
+  }
+  return firstCall[0] as unknown as ClientProps;
+}
+
+describe("under construction page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    headerMocks.headers.mockResolvedValue(new Headers());
+    authMocks.auth.api.getSession.mockResolvedValue({ user: { id: "user-1" } });
+    authHelperMocks.requireRole.mockReturnValue(true);
+  });
+
+  it("passes the computed catalog summary to the client", async () => {
+    const items = [
+      { id: "1", slug: "alpha", name: "Alpha", createdAt: new Date() },
+      { id: "2", slug: "beta", name: "Beta", createdAt: new Date() },
+    ];
+    gearServiceMocks.listUnderConstruction.mockResolvedValue(items);
+    metricsMocks.fetchGearCount.mockResolvedValue(10);
+
+    renderToStaticMarkup(await Page());
+    const props = getClientProps();
+
+    expect(gearServiceMocks.listUnderConstruction).toHaveBeenCalledWith(1, 40);
+    expect(metricsMocks.fetchGearCount).toHaveBeenCalledTimes(1);
+    expect(props.canToggleAutoSubmit).toBe(true);
+    expect(props.items).toBe(items);
+    expect(props.summary).toEqual({
+      totalCount: 10,
+      underConstructionCount: 2,
+      completedCount: 8,
+      completedPercent: 80,
+    });
+  });
+
+  it("handles an empty catalog without dividing by zero", async () => {
+    gearServiceMocks.listUnderConstruction.mockResolvedValue([]);
+    metricsMocks.fetchGearCount.mockResolvedValue(0);
+
+    renderToStaticMarkup(await Page());
+    const props = getClientProps();
+
+    expect(props.summary).toEqual({
+      totalCount: 0,
+      underConstructionCount: 0,
+      completedCount: 0,
+      completedPercent: 0,
+    });
+  });
+
+  it("clamps completed items at zero when the backlog matches the total", async () => {
+    gearServiceMocks.listUnderConstruction.mockResolvedValue([
+      { id: "1", slug: "alpha", name: "Alpha", createdAt: new Date() },
+      { id: "2", slug: "beta", name: "Beta", createdAt: new Date() },
+      { id: "3", slug: "gamma", name: "Gamma", createdAt: new Date() },
+    ]);
+    metricsMocks.fetchGearCount.mockResolvedValue(3);
+
+    renderToStaticMarkup(await Page());
+    const props = getClientProps();
+
+    expect(props.summary).toEqual({
+      totalCount: 3,
+      underConstructionCount: 3,
+      completedCount: 0,
+      completedPercent: 0,
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,8 +7,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   resolve: {
     alias: {
+      "@": path.resolve(__dirname, "src"),
       "~": path.resolve(__dirname, "src"),
     },
+  },
+  esbuild: {
+    jsx: "automatic",
+    jsxImportSource: "react",
   },
   test: {
     environment: "node",


### PR DESCRIPTION
- MPB links are now saved as a normalized base product path with the fit stripped off, then when a user clicks later we rebuild the correct MPB destination for the mount they want, while still letting legacy stored search links continue to work. We no longer need to put search URL for multi-mount items
- Add a global spec progress completion bar at the top of the under construction page
- Add tilt shift specs to lenses