### PR TITLE
Development

### DIFF
--- a/src/components/home/animated-stat-counter-value.tsx
+++ b/src/components/home/animated-stat-counter-value.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import NumberFlow, { continuous } from "@number-flow/react";
+import { useInView, useReducedMotion } from "motion/react";
+import { useEffect, useRef, useState } from "react";
+
+type AnimatedStatCounterValueProps = {
+  value: number;
+  className?: string;
+  delayMs?: number;
+  seed?: number;
+  startRatio?: number;
+  randomnessRatio?: number;
+  transformDurationMs?: number;
+  spinDurationMs?: number;
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function getBaseStartValue(value: number, startRatio: number): number {
+  return Math.floor(value * startRatio);
+}
+
+function getDeterministicOffset(seed: number): number {
+  const normalizedSeed = seed >>> 0;
+  const hashedSeed = Math.imul(normalizedSeed ^ 0x9e3779b9, 0x85ebca6b);
+
+  return ((hashedSeed >>> 0) % 10_001) / 10_000;
+}
+
+function getRandomizedStartValue(
+  value: number,
+  seed: number,
+  startRatio: number,
+  randomnessRatio: number,
+): number {
+  if (value <= 1) {
+    return 0;
+  }
+
+  const baseStart = getBaseStartValue(value, startRatio);
+  const maxOffset = Math.max(1, Math.floor(value * randomnessRatio));
+  const randomOffset =
+    Math.floor(getDeterministicOffset(seed) * (maxOffset * 2 + 1)) - maxOffset;
+
+  return clamp(baseStart + randomOffset, 0, value - 1);
+}
+
+export function AnimatedStatCounterValue({
+  value,
+  className,
+  delayMs = 0,
+  seed = 0,
+  startRatio = 0.5,
+  randomnessRatio = 0.08,
+  transformDurationMs = 1_250,
+  spinDurationMs = 1_000,
+}: AnimatedStatCounterValueProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const reduceMotion = useReducedMotion();
+  const isInView = useInView(ref, { once: true, margin: "0px" });
+  const startValue = getRandomizedStartValue(
+    value,
+    seed ^ value,
+    startRatio,
+    randomnessRatio,
+  );
+  const [displayedValue, setDisplayedValue] = useState<number>(() =>
+    reduceMotion ? value : startValue,
+  );
+
+  useEffect(() => {
+    if (reduceMotion) {
+      setDisplayedValue(value);
+      return;
+    }
+
+    if (!isInView) {
+      setDisplayedValue(startValue);
+      return;
+    }
+
+    let frameId: number | null = null;
+    const timerId = window.setTimeout(() => {
+      frameId = window.requestAnimationFrame(() => {
+        setDisplayedValue(value);
+      });
+    }, delayMs);
+
+    return () => {
+      window.clearTimeout(timerId);
+
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
+    };
+  }, [delayMs, isInView, reduceMotion, startValue, value]);
+
+  return (
+    <span ref={ref} className="inline-block">
+      <NumberFlow
+        value={displayedValue}
+        className={className}
+        plugins={[continuous]}
+        format={{ useGrouping: true }}
+        transformTiming={{
+          duration: transformDurationMs,
+          easing: "cubic-bezier(0.22, 1, 0.36, 1)",
+        }}
+        spinTiming={{
+          duration: spinDurationMs,
+          easing:
+            "linear(0, 0.0012 0.47%, 0.0061 1.09%, 0.0264, 0.0581 3.59%, 0.1043 4.99%, 0.212 7.65%, 0.4614 13.11%, 0.5758, 0.6782, 0.7662, 0.8393, 0.8979 26.37%, 0.9454 29.18%, 0.9642 30.58%, 0.9816 32.14%, 1.0027 34.64%, 1.0183 37.45%, 1.0278 40.57%, 1.0314 44%, 1.0291 49%, 1.0105 62.89%, 1.0028 71.78%, 0.9994 82.55%, 0.9993 99.87%)",
+        }}
+        opacityTiming={{ duration: 420, easing: "ease-out" }}
+        willChange
+      />
+    </span>
+  );
+}

--- a/src/components/home/contribution-counter-value.tsx
+++ b/src/components/home/contribution-counter-value.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { AnimatedStatCounterValue } from "./animated-stat-counter-value";
+
+type ContributionCounterValueProps = {
+  value: number;
+  className?: string;
+};
+
+export function ContributionCounterValue({
+  value,
+  className,
+}: ContributionCounterValueProps) {
+  return (
+    <AnimatedStatCounterValue
+      value={value}
+      className={className}
+      delayMs={0}
+      seed={17}
+      startRatio={0.58}
+      randomnessRatio={0.05}
+      transformDurationMs={1_250}
+      spinDurationMs={1_800}
+    />
+  );
+}

--- a/src/components/home/contribution-counter.tsx
+++ b/src/components/home/contribution-counter.tsx
@@ -1,12 +1,15 @@
-import { NumberTicker } from "~/components/magicui/number-ticker";
 import { fetchContributionCount } from "~/server/metrics/service";
+import { ContributionCounterValue } from "./contribution-counter-value";
 
 export async function ContributionCounter() {
   const totalContributions = await fetchContributionCount();
 
   return (
     <div className="space-y-2">
-      <NumberTicker value={totalContributions} className="text-5xl font-bold" />
+      <ContributionCounterValue
+        value={totalContributions}
+        className="text-5xl font-bold"
+      />
       <p className="text-muted-foreground py-0 text-sm leading-0">
         Contributions by members
       </p>

--- a/src/components/home/gear-counter-value.tsx
+++ b/src/components/home/gear-counter-value.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { AnimatedStatCounterValue } from "./animated-stat-counter-value";
+
+type GearCounterValueProps = {
+  value: number;
+  className?: string;
+};
+
+export function GearCounterValue({ value, className }: GearCounterValueProps) {
+  return (
+    <AnimatedStatCounterValue
+      value={value}
+      className={className}
+      delayMs={0}
+      seed={83}
+      startRatio={0.34}
+      randomnessRatio={0.12}
+      transformDurationMs={1_250}
+      spinDurationMs={2_250}
+    />
+  );
+}

--- a/src/components/home/gear-counter.tsx
+++ b/src/components/home/gear-counter.tsx
@@ -1,12 +1,12 @@
-import { NumberTicker } from "~/components/magicui/number-ticker";
 import { fetchGearCount } from "~/server/metrics/service";
+import { GearCounterValue } from "./gear-counter-value";
 
 export async function GearCounter() {
   const totalGearItems = await fetchGearCount();
 
   return (
     <div className="space-y-2">
-      <NumberTicker value={totalGearItems} className="text-5xl font-bold" />
+      <GearCounterValue value={totalGearItems} className="text-5xl font-bold" />
       <p className="text-muted-foreground py-0 text-sm leading-0">
         Items in our database
       </p>

--- a/src/lib/nav-items.ts
+++ b/src/lib/nav-items.ts
@@ -115,6 +115,12 @@ export const navItems: NavItem[] = [
         iconKey: "scale",
       },
       {
+        title: "Shutter Count & EXIF Viewer",
+        url: "/exif-viewer",
+        description: "Inspect EXIF metadata and track shutter count history",
+        iconKey: "file",
+      },
+      {
         title: "Instagram Post Builder",
         url: "/instagram-post-builder",
         description: "Create Instagram posts with multiple images",


### PR DESCRIPTION
This pull request introduces animated stat counters for displaying contribution and gear item counts on the homepage, replacing the previous static number ticker. It adds reusable, configurable animated counter components for both contributions and gear, and updates the navigation to include a new EXIF Viewer tool.

**Animated Stat Counter Implementation:**

- Added a new reusable `AnimatedStatCounterValue` component in `animated-stat-counter-value.tsx` that animates number transitions with configurable parameters such as delay, randomness, and animation duration. This component uses the `@number-flow/react` library and supports reduced motion accessibility preferences.

**Integration of Animated Counters:**

- Created `ContributionCounterValue` and `GearCounterValue` components that wrap `AnimatedStatCounterValue` with domain-specific configuration for contributions and gear items, respectively. [[1]](diffhunk://#diff-dfe449458a5955644504c58468200327783d9fc96f377ed925422e53489663aeR1-R26) [[2]](diffhunk://#diff-638f7a780b881d24aa1079194ebd6ded4e93fa7401eae2b0cb3826b93ed6e7bdR1-R23)
- Updated `ContributionCounter` and `GearCounter` components to use the new animated counter components instead of the previous `NumberTicker`. [[1]](diffhunk://#diff-85cc19e91c2a2fb3374a2753b2bd587fdef590afb49c6f43556d002e3193bf5eL1-R12) [[2]](diffhunk://#diff-f85f43a09fbeb5e6425b41554647cfabef935c24f1674b2d408afa98355dec68L1-R9)

**Navigation Update:**

- Added a new navigation item for the "Shutter Count & EXIF Viewer" tool, allowing users to access EXIF metadata and shutter count history.