### PR TITLE
fix(home): Get Started button navigates to Learn basics

### DIFF
--- a/src/app/(app)/(pages)/page.tsx
+++ b/src/app/(app)/(pages)/page.tsx
@@ -221,13 +221,11 @@ export default async function Home() {
                   </p>
                 </div>
                 <Button
-                  // asChild
+                  asChild
                   className="w-full cursor-pointer"
-                  // disabled={true}
                   icon={<BookOpenIcon className="h-4 w-4" />}
                 >
                   <Link href="/learn/basics">Get Started</Link>
-                  {/* Coming Soon */}
                 </Button>
               </div>
               <DiscordBanner vertical />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The "New to Photography?" **Get Started** control on the home page rendered a `<button>` wrapping a Next.js `<Link>`, which is invalid HTML and prevented reliable navigation to `/learn/basics`.

## Changes

- Re-enabled `asChild` on the `Button` so Radix `Slot` merges button styles onto the `<a>` from `Link`, matching the pattern used for "View all gear" and "Learn more" on the same page.

## Testing

- `SKIP_ENV_VALIDATION=1 npm run lint` (passes; existing warnings only).
- `npm run typecheck` fails in this workspace due to a stale `.next/types/validator.ts` reference to a missing route module; unrelated to this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3470a10-6422-4c38-aa27-98bc6e358163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3470a10-6422-4c38-aa27-98bc6e358163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

