### PR TITLE
[codex] reduce build-time workload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,6 @@ PAYLOAD_SECRET="my-payload-secret" # required (generate your own if you deploy a
 
 NEXT_PUBLIC_BASE_URL="http://localhost:3000/"
 GENERATE_CONSTANTS="false" # leave this false otherwise you will have missing data
-SKIP_BUILD_STATIC_GENERATION="" # optional (set any non-empty value to disable gear static param generation during builds)
 
 # Logs
 DISCORD_ROLLUP_WEBHOOK_URL="" # optional

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint

--- a/next.config.js
+++ b/next.config.js
@@ -44,7 +44,7 @@ const config = {
     ];
   },
   eslint: {
-    ignoreDuringBuilds: false,
+    ignoreDuringBuilds: true,
   },
   images: {
     unoptimized: process.env.NODE_ENV === "development",

--- a/src/app/[locale]/(admin)/admin/analytics/page.tsx
+++ b/src/app/[locale]/(admin)/admin/analytics/page.tsx
@@ -2,6 +2,8 @@ import { Suspense } from "react";
 import { TopComparePairs } from "../top-compare-pairs";
 import { ImageRequestsList } from "./image-requests-list";
 
+export const dynamic = "force-dynamic";
+
 export default function AnalyticsPage() {
   return (
     <div className="space-y-8 px-8">

--- a/src/app/[locale]/(admin)/admin/approved-creators/page.tsx
+++ b/src/app/[locale]/(admin)/admin/approved-creators/page.tsx
@@ -5,6 +5,7 @@ import { requireRole } from "~/lib/auth/auth-helpers";
 import { fetchApprovedCreatorsAdmin } from "~/server/admin/approved-creators/service";
 import { ApprovedCreatorsManager } from "./approved-creators-manager";
 
+export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export default async function ApprovedCreatorsPage() {

--- a/src/app/[locale]/(admin)/admin/bulk-create/page.tsx
+++ b/src/app/[locale]/(admin)/admin/bulk-create/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "Bulk Create",
   openGraph: {

--- a/src/app/[locale]/(admin)/admin/gear/page.tsx
+++ b/src/app/[locale]/(admin)/admin/gear/page.tsx
@@ -6,6 +6,8 @@ import { GearDataTable } from "./data-table";
 
 const PAGE_SIZE_OPTIONS = [10, 20, 50, 100] as const;
 
+export const dynamic = "force-dynamic";
+
 export default async function AdminGearPage() {
   await auth.api.getSession({
     headers: await headers(),

--- a/src/app/[locale]/(admin)/admin/help/page.tsx
+++ b/src/app/[locale]/(admin)/admin/help/page.tsx
@@ -4,6 +4,8 @@ import { auth } from "~/auth";
 import { Card,CardContent,CardHeader,CardTitle } from "~/components/ui/card";
 import { requireRole } from "~/lib/auth/auth-helpers";
 
+export const dynamic = "force-dynamic";
+
 export const metadata = {
   title: "Help",
   openGraph: {

--- a/src/app/[locale]/(admin)/admin/layout.tsx
+++ b/src/app/[locale]/(admin)/admin/layout.tsx
@@ -9,6 +9,8 @@ import { fetchNotificationsForUser } from "~/server/notifications/service";
 import { SiteHeader } from "./admin-header";
 import { AppSidebar } from "./sidebar";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: {
     default: "Admin",

--- a/src/app/[locale]/(admin)/admin/leaderboard/page.tsx
+++ b/src/app/[locale]/(admin)/admin/leaderboard/page.tsx
@@ -2,6 +2,8 @@ import { Avatar,AvatarFallback,AvatarImage } from "~/components/ui/avatar";
 import { Card,CardContent,CardHeader,CardTitle } from "~/components/ui/card";
 import { fetchContributorLeaderboard } from "~/server/leaderboard/service";
 
+export const dynamic = "force-dynamic";
+
 export default async function AdminLeaderboardPage() {
   const rows = await fetchContributorLeaderboard(15);
 

--- a/src/app/[locale]/(admin)/admin/logs/page.tsx
+++ b/src/app/[locale]/(admin)/admin/logs/page.tsx
@@ -3,6 +3,8 @@ import { AuditLogList } from "../admin-audit-log-list";
 import { BadgesAwardsList } from "../badges-awards-list";
 import { RollupRunsList } from "../rollup-runs-list";
 
+export const dynamic = "force-dynamic";
+
 export default function LogsPage() {
   return (
     <div className="space-y-8 px-8">

--- a/src/app/[locale]/(admin)/admin/page.tsx
+++ b/src/app/[locale]/(admin)/admin/page.tsx
@@ -5,6 +5,8 @@ import { fetchAdminReviews } from "~/server/admin/reviews/service";
 import { GearProposalsList } from "./gear-proposals-list";
 import { ReviewsApprovalQueue } from "./reviews-approval-queue";
 
+export const dynamic = "force-dynamic";
+
 export default async function AdminPage() {
   const session = await auth.api.getSession({
     headers: await headers(),

--- a/src/app/[locale]/(admin)/admin/tools/page.tsx
+++ b/src/app/[locale]/(admin)/admin/tools/page.tsx
@@ -8,6 +8,8 @@ import { GradientImageTool } from "../gradient-image-tool";
 import { ManualGearRevalidateTool } from "../manual-gear-revalidate-tool";
 import { SharedListOgPreviewTool } from "../shared-list-og-preview-tool";
 
+export const dynamic = "force-dynamic";
+
 export default async function ToolsPage() {
   const liveBoosts = await fetchLiveBoosts({ limit: 100 });
   return (

--- a/src/app/[locale]/(pages)/admin/recommended-lenses/[brand]/[slug]/page.tsx
+++ b/src/app/[locale]/(pages)/admin/recommended-lenses/[brand]/[slug]/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "~/server/recommendations/service";
 import EditChartContent from "./_components/EditChartContent";
 
+export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export default async function Page(props: {

--- a/src/app/[locale]/(pages)/admin/recommended-lenses/layout.tsx
+++ b/src/app/[locale]/(pages)/admin/recommended-lenses/layout.tsx
@@ -1,0 +1,9 @@
+export const dynamic = "force-dynamic";
+
+export default function RecommendedLensesAdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/[locale]/(pages)/admin/recommended-lenses/new/page.tsx
+++ b/src/app/[locale]/(pages)/admin/recommended-lenses/new/page.tsx
@@ -4,6 +4,8 @@ import { auth } from "~/auth";
 import { requireRole } from "~/lib/auth/auth-helpers";
 import NewChartContent from "./_components/NewChartContent";
 
+export const dynamic = "force-dynamic";
+
 export default async function Page() {
   const session = await auth.api.getSession({
     headers: await headers(),

--- a/src/app/[locale]/(pages)/admin/recommended-lenses/page.tsx
+++ b/src/app/[locale]/(pages)/admin/recommended-lenses/page.tsx
@@ -7,6 +7,7 @@ import { requireRole } from "~/lib/auth/auth-helpers";
 import { formatDate } from "~/lib/format/date";
 import { serviceListCharts } from "~/server/recommendations/service";
 
+export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export default async function Page() {

--- a/src/app/[locale]/(pages)/browse/[[...segments]]/page.tsx
+++ b/src/app/[locale]/(pages)/browse/[[...segments]]/page.tsx
@@ -3,7 +3,6 @@ import { getTranslations } from "next-intl/server";
 import type { JSX } from "react";
 import { Suspense } from "react";
 import { GearCardSkeleton } from "~/components/gear/gear-card";
-import { env } from "~/env";
 import { BRANDS,MOUNTS } from "~/lib/constants";
 import { getMountDisplayName } from "~/lib/mapping/mounts-map";
 import { buildLocalizedMetadata } from "~/lib/seo/metadata";
@@ -23,11 +22,6 @@ import MountButtons from "../_components/mount-buttons";
 export const dynamicParams = true;
 
 export async function generateStaticParams() {
-  if (env.SKIP_BUILD_STATIC_GENERATION) {
-    return [];
-  }
-
-  console.log("[/browse] generateStaticParams running");
   const all: { segments: string[] }[] = [{ segments: [] }];
   const categories: Array<"cameras" | "lenses"> = ["cameras", "lenses"];
 

--- a/src/app/[locale]/(pages)/gear/[slug]/page.tsx
+++ b/src/app/[locale]/(pages)/gear/[slug]/page.tsx
@@ -27,7 +27,6 @@ import {
   ItemContent,
   ItemTitle
 } from "~/components/ui/item";
-import { env } from "~/env";
 import { formatDate,formatRelativeDate } from "~/lib/format/date";
 import { GetGearDisplayName } from "~/lib/gear/naming";
 import { resolveRegionFromCountryCode } from "~/lib/gear/region";
@@ -577,10 +576,6 @@ export default async function GearPage({
 }
 
 export async function generateStaticParams() {
-  if (env.SKIP_BUILD_STATIC_GENERATION) {
-    return [];
-  }
-
   const [trendingSlugs, newestSlugs, highTrafficSlugs] = await Promise.all([
     fetchTrendingSlugs({
       timeframe: "30d",

--- a/src/app/[locale]/(pages)/learn/(articles)/layout.tsx
+++ b/src/app/[locale]/(pages)/learn/(articles)/layout.tsx
@@ -8,6 +8,8 @@ import { ScrollProgress } from "~/components/ui/skiper-ui/scroll-progress";
 import type { LearnPage } from "~/payload-types";
 import { getLearnPages } from "~/server/payload/service";
 
+export const revalidate = 60;
+
 const sortByCreationDate = <T extends { createdAt: string }>(items: T[]) => {
   return [...items].sort(
     (firstItem, secondItem) =>

--- a/src/app/[locale]/(pages)/news/page.tsx
+++ b/src/app/[locale]/(pages)/news/page.tsx
@@ -6,6 +6,8 @@ import type { News } from "~/payload-types";
 import { getNewsPosts } from "~/server/payload/service";
 import NewsListItem from "./_components/news-list-item";
 
+export const revalidate = 60;
+
 export async function generateMetadata({
   params,
 }: {

--- a/src/app/[locale]/(pages)/reviews/page.tsx
+++ b/src/app/[locale]/(pages)/reviews/page.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { buildLocalizedMetadata } from "~/lib/seo/metadata";
 import { getReviews } from "~/server/payload/service";
 
+export const revalidate = 60;
+
 export async function generateMetadata({
   params,
 }: {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -41,16 +41,6 @@ const trustedOrigins = [
   ...(additionalTrustedOrigins ?? []),
 ].filter(Boolean);
 
-if (process.env.NODE_ENV === "production") {
-  console.info("[auth-callback-debug] trusted_origins_config", {
-    nextPublicBaseURL: process.env.NEXT_PUBLIC_BASE_URL,
-    authBaseURL: staticAuthBaseUrl ?? null,
-    baseURLMode: staticAuthBaseUrl ? "static" : "dynamic_request_origin",
-    additionalTrustedOrigins: process.env.AUTH_ADDITIONAL_TRUSTED_ORIGINS,
-    normalizedTrustedOrigins: trustedOrigins,
-  });
-}
-
 export const auth = betterAuth({
   // config
   appName: "Sharply",

--- a/src/env.js
+++ b/src/env.js
@@ -58,7 +58,6 @@ export const env = createEnv({
         ? z.string()
         : z.string().optional(),
     AMAZON_AFFILIATE_TAG: z.string().optional(),
-    SKIP_BUILD_STATIC_GENERATION: z.string().optional(),
   },
 
   /**
@@ -102,7 +101,6 @@ export const env = createEnv({
     UPLOADTHING_TOKEN: process.env.UPLOADTHING_TOKEN,
     NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL,
     AMAZON_AFFILIATE_TAG: process.env.AMAZON_AFFILIATE_TAG,
-    SKIP_BUILD_STATIC_GENERATION: process.env.SKIP_BUILD_STATIC_GENERATION,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/src/server/gear/browse/service.ts
+++ b/src/server/gear/browse/service.ts
@@ -128,7 +128,6 @@ export async function loadHubData(params: {
 }
 
 export async function buildSeo(params: { segments: string[] }) {
-  console.log("[/browse] buildSeo running", { segments: params.segments });
   // Load data once to obtain scope + total for descriptive metadata
   const { scope, brand, mount, lists } = await loadHubData({
     segments: params.segments,

--- a/src/server/payload/data.ts
+++ b/src/server/payload/data.ts
@@ -1,20 +1,67 @@
+import { unstable_cache } from "next/cache";
 import { getPayload } from "payload";
 import "server-only";
 import type { LearnPage,News,Review } from "~/payload-types";
 import config from "~/payload.config";
 
+const PAYLOAD_CONTENT_REVALIDATE_SECONDS = 60;
+
+let payloadPromise: ReturnType<typeof getPayload> | null = null;
+
+async function getPayloadClient() {
+  if (!payloadPromise) {
+    payloadPromise = getPayload({ config });
+  }
+
+  return payloadPromise;
+}
+
+const getNewsPostsDataCached = unstable_cache(
+  async (): Promise<News[]> => {
+    const payload = await getPayloadClient();
+    const newsPosts = await payload.find({
+      collection: "news",
+      limit: -1,
+    });
+    return newsPosts.docs;
+  },
+  ["payload:news-posts"],
+  { revalidate: PAYLOAD_CONTENT_REVALIDATE_SECONDS },
+);
+
+const getReviewsDataCached = unstable_cache(
+  async (): Promise<Review[]> => {
+    const payload = await getPayloadClient();
+    const reviews = await payload.find({
+      collection: "review",
+      limit: -1,
+    });
+    return reviews.docs;
+  },
+  ["payload:reviews"],
+  { revalidate: PAYLOAD_CONTENT_REVALIDATE_SECONDS },
+);
+
+const getLearnPagesDataCached = unstable_cache(
+  async (): Promise<LearnPage[]> => {
+    const payload = await getPayloadClient();
+    const learnPages = await payload.find({
+      collection: "learn-pages",
+      limit: -1,
+      depth: 1,
+    });
+    return learnPages.docs;
+  },
+  ["payload:learn-pages"],
+  { revalidate: PAYLOAD_CONTENT_REVALIDATE_SECONDS },
+);
+
 export const getNewsPostsData = async (): Promise<News[]> => {
-  const payload = await getPayload({ config });
-  const newsPosts = await payload.find({
-    collection: "news",
-    limit: -1,
-  });
-  console.log("[payload:data] getNewsPostsData fetched", newsPosts.docs.length);
-  return newsPosts.docs;
+  return getNewsPostsDataCached();
 };
 
 export const getNewsPostBySlugData = async (slug: string): Promise<News> => {
-  const payload = await getPayload({ config });
+  const payload = await getPayloadClient();
   const newsPost = await payload.find({
     collection: "news",
     where: { slug: { equals: slug } },
@@ -23,17 +70,11 @@ export const getNewsPostBySlugData = async (slug: string): Promise<News> => {
 };
 
 export const getReviewsData = async (): Promise<Review[]> => {
-  const payload = await getPayload({ config });
-  const reviews = await payload.find({
-    collection: "review",
-    limit: -1,
-  });
-  console.log("[payload:data] getReviewsData fetched", reviews.docs.length);
-  return reviews.docs;
+  return getReviewsDataCached();
 };
 
 export const getReviewBySlugData = async (slug: string): Promise<Review> => {
-  const payload = await getPayload({ config });
+  const payload = await getPayloadClient();
   const review = await payload.find({
     collection: "review",
     where: { slug: { equals: slug } },
@@ -44,7 +85,7 @@ export const getReviewBySlugData = async (slug: string): Promise<Review> => {
 export const getReviewByGearSlugData = async (
   gearSlug: string,
 ): Promise<Review> => {
-  const payload = await getPayload({ config });
+  const payload = await getPayloadClient();
   const review = await payload.find({
     collection: "review",
     where: { review_gear_item: { equals: gearSlug } },
@@ -56,13 +97,9 @@ export const getNewsByRelatedGearSlugData = async (
   gearSlug: string,
   limit: number = 12,
 ): Promise<News[]> => {
-  const payload = await getPayload({ config });
   // Fetch all and filter locally (JSON field cannot be filtered with ILIKE)
-  const all: { docs: News[] } = (await payload.find({
-    collection: "news",
-    limit: -1,
-  })) as unknown as { docs: News[] };
-  const filtered = all.docs.filter((n) => {
+  const all = await getNewsPostsData();
+  const filtered = all.filter((n) => {
     const v = n.related_gear_items;
     if (!Array.isArray(v)) return false;
     return v.some((x) => typeof x === "string" && x === gearSlug);
@@ -71,23 +108,13 @@ export const getNewsByRelatedGearSlugData = async (
 };
 
 export const getLearnPagesData = async (): Promise<LearnPage[]> => {
-  const payload = await getPayload({ config });
-  const learnPages = await payload.find({
-    collection: "learn-pages",
-    limit: -1,
-    depth: 1,
-  });
-  console.log(
-    "[payload:data] getLearnPagesData fetched",
-    learnPages.docs.length,
-  );
-  return learnPages.docs;
+  return getLearnPagesDataCached();
 };
 
 export const getLearnPageBySlugData = async (
   slug: string,
 ): Promise<LearnPage | null> => {
-  const payload = await getPayload({ config });
+  const payload = await getPayloadClient();
   const res = (await payload.find({
     collection: "learn-pages",
     where: { slug: { equals: slug } },


### PR DESCRIPTION
## Summary
- cache repeated Payload content reads for news, reviews, and learn content with a short revalidation window
- remove build-time debug logging and disable ESLint inside `next build` while adding a dedicated PR lint workflow
- force admin surfaces to render dynamically so they stop participating in prerender work

## Why
Preview and production builds were still doing avoidable work during page-data collection and prerender. Repeated Payload list reads, noisy debug logging, static admin surfaces, and running ESLint inside `next build` were all increasing deploy cost without improving runtime behavior.

## Impact
- new Payload content can appear without a redeploy, typically within about 60 seconds
- admin pages are treated as dynamic surfaces instead of static build output
- Vercel build logs are cleaner and `next build` skips ESLint while build-time typechecking remains enabled
- lint enforcement moves to a dedicated pull-request workflow instead of deploy time

## Validation
- `npm run lint`
- `npm run test`
- `npm run check`
- `npm run build`