### PR TITLE
Pass locale into browse server components

### DIFF
--- a/docs/gear-browse-routing.md
+++ b/docs/gear-browse-routing.md
@@ -53,6 +53,7 @@ Notes:
   - mount-depth browse routes (`/browse/[brand]/[category]/[mount]`) are left to on-demand ISR
 - `export const revalidate = 3600` (1 hour) for ISR.
 - `dynamicParams = true` so non-prebuilt combinations still render on-demand.
+- Browse server components pass `locale` explicitly into `next-intl` server translation calls so the route remains static-safe under ISR/SSG and avoids request-bound locale lookups during production renders.
 - `getPopularScopes` is deprecated and no longer used.
 
 ## Gear Detail SSG/ISR

--- a/src/app/[locale]/(pages)/browse/[[...segments]]/page.tsx
+++ b/src/app/[locale]/(pages)/browse/[[...segments]]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
+import { getTranslations,setRequestLocale } from "next-intl/server";
 import type { JSX } from "react";
 import { Suspense } from "react";
 import { GearCardSkeleton } from "~/components/gear/gear-card";
@@ -67,16 +67,17 @@ const BROWSE_PAGE_SKELETON_KEYS = Array.from(
 export default async function BrowseCatchAll({
   params,
 }: {
-  params: Promise<{ segments?: string[] }>;
+  params: Promise<{ locale: string; segments?: string[] }>;
 }) {
-  const t = await getTranslations("browsePage");
-  const { segments = [] } = await params;
+  const { locale, segments = [] } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations({ locale, namespace: "browsePage" });
   const { depth, scope, brand, mount } = await resolveScopeOrThrow(segments);
 
   if (depth === 0) {
     return (
       <main className="space-y-6 pb-24">
-        <AllGearContent />
+        <AllGearContent locale={locale} />
       </main>
     );
   }
@@ -84,9 +85,12 @@ export default async function BrowseCatchAll({
   if (depth === 1) {
     return (
       <main className="space-y-6 pb-24">
-        <Breadcrumbs brand={{ name: brand!.name, slug: brand!.slug }} />
+        <Breadcrumbs
+          locale={locale}
+          brand={{ name: brand!.name, slug: brand!.slug }}
+        />
         <h1 className="text-3xl font-semibold">{brand!.name}</h1>
-        <BrandContent brandSlug={brand!.slug} />
+        <BrandContent brandSlug={brand!.slug} locale={locale} />
       </main>
     );
   }
@@ -105,6 +109,7 @@ export default async function BrowseCatchAll({
     return (
       <main className="space-y-6 pb-24">
         <Breadcrumbs
+          locale={locale}
           brand={{ name: brand!.name, slug: brand!.slug }}
           category={scope.categorySlug}
         />
@@ -115,6 +120,7 @@ export default async function BrowseCatchAll({
           brandId={brand!.id}
           brandSlug={brand!.slug}
           category={scope.categorySlug!}
+          locale={locale}
         />
         <Suspense fallback={<SortSelectFallback label={t("sortBy")} />}>
           <BrowseQueryControls category={scope.categorySlug} hasMount={false} />
@@ -140,6 +146,7 @@ export default async function BrowseCatchAll({
   return (
     <main className="space-y-6 pb-24">
       <Breadcrumbs
+        locale={locale}
         brand={{ name: brand!.name, slug: brand!.slug }}
         category={scope.categorySlug}
         mountValue={mount?.value ?? null}

--- a/src/app/[locale]/(pages)/browse/_components/all-gear-content.tsx
+++ b/src/app/[locale]/(pages)/browse/_components/all-gear-content.tsx
@@ -24,12 +24,14 @@ const TRENDING_SKELETON_KEYS = [
 
 export default async function AllGearContent({
   brandSlug,
+  locale,
   showBrandPicker = true,
 }: {
   brandSlug?: string;
+  locale: string;
   showBrandPicker?: boolean;
-} = {}) {
-  const t = await getTranslations("browsePage");
+}) {
+  const t = await getTranslations({ locale, namespace: "browsePage" });
   // return <Loading />;
   const brand = brandSlug ? await fetchBrandBySlug(brandSlug) : null;
   if (brandSlug && !brand) {

--- a/src/app/[locale]/(pages)/browse/_components/brand-content.tsx
+++ b/src/app/[locale]/(pages)/browse/_components/brand-content.tsx
@@ -4,10 +4,12 @@ import AllGearContent from "./all-gear-content";
 
 export default async function BrandContent({
   brandSlug,
+  locale,
 }: {
   brandSlug: string;
+  locale: string;
 }) {
-  const t = await getTranslations("browsePage");
+  const t = await getTranslations({ locale, namespace: "browsePage" });
   const items = [
     { label: t("cameras"), href: `/browse/${brandSlug}/cameras` },
     { label: t("lenses"), href: `/browse/${brandSlug}/lenses` },
@@ -31,7 +33,11 @@ export default async function BrandContent({
         ))}
       </div>
       {/* Brand-specific latest and trending */}
-      <AllGearContent brandSlug={brandSlug} showBrandPicker={false} />
+      <AllGearContent
+        brandSlug={brandSlug}
+        locale={locale}
+        showBrandPicker={false}
+      />
     </div>
   );
 }

--- a/src/app/[locale]/(pages)/browse/_components/breadcrumbs.tsx
+++ b/src/app/[locale]/(pages)/browse/_components/breadcrumbs.tsx
@@ -4,13 +4,19 @@ import type { GearCategorySlug } from "~/lib/browse/routing";
 import { getMountDisplayName } from "~/lib/mapping/mounts-map";
 
 type Props = {
+  locale: string;
   brand?: { name: string; slug: string } | null;
   category?: GearCategorySlug | null;
   mountValue?: string | null;
 };
 
-export default async function Breadcrumbs({ brand, category, mountValue }: Props) {
-  const t = await getTranslations("browsePage");
+export default async function Breadcrumbs({
+  locale,
+  brand,
+  category,
+  mountValue,
+}: Props) {
+  const t = await getTranslations({ locale, namespace: "browsePage" });
   const items: Array<{ label: string; href?: string }> = [];
   items.push({ label: t("browse"), href: "/browse" });
 

--- a/src/app/[locale]/(pages)/browse/_components/mount-buttons.tsx
+++ b/src/app/[locale]/(pages)/browse/_components/mount-buttons.tsx
@@ -14,12 +14,14 @@ export default async function MountButtons({
   brandId,
   brandSlug,
   category,
+  locale,
 }: {
   brandId: string;
   brandSlug: string;
   category: "cameras" | "lenses";
+  locale: string;
 }) {
-  const t = await getTranslations("browsePage");
+  const t = await getTranslations({ locale, namespace: "browsePage" });
   let mounts = await fetchMountsForBrand(brandId);
   let hiddenMounts: typeof mounts = [];
   const rules = mountUIConfig[brandSlug]?.[category];

--- a/tests/unit/browse-server-locale.test.ts
+++ b/tests/unit/browse-server-locale.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach,describe,expect,it,vi } from "vitest";
+
+vi.hoisted(() => {
+  process.env.DATABASE_URL ??= "postgres://user:pass@localhost:5432/sharply";
+  process.env.PAYLOAD_SECRET ??= "test-secret";
+  process.env.NEXT_PUBLIC_BASE_URL ??= "https://www.sharplyphoto.com";
+});
+
+const intlServerMocks = vi.hoisted(() => ({
+  getTranslations: vi.fn(),
+  setRequestLocale: vi.fn(),
+}));
+
+const browseServiceMocks = vi.hoisted(() => ({
+  resolveScopeOrThrow: vi.fn(),
+  fetchBrowseListPage: vi.fn(),
+  fetchBrandBySlug: vi.fn(),
+  fetchReleaseFeedPage: vi.fn(),
+  fetchMountsForBrand: vi.fn(),
+  buildSeo: vi.fn(),
+}));
+
+const popularityServiceMocks = vi.hoisted(() => ({
+  fetchTrendingSlugs: vi.fn(),
+  fetchTrending: vi.fn(),
+}));
+
+vi.mock("next-intl/server", () => intlServerMocks);
+vi.mock("server-only", () => ({}));
+vi.mock("~/server/gear/browse/service", () => browseServiceMocks);
+vi.mock("~/server/popularity/service", () => popularityServiceMocks);
+vi.mock("~/components/gear/gear-card", () => ({
+  GearCard: () => null,
+  GearCardSkeleton: () => null,
+}));
+vi.mock("~/app/[locale]/(pages)/browse/_components/other-brands-select", () => ({
+  OtherBrandsSelect: () => null,
+}));
+vi.mock("~/app/[locale]/(pages)/browse/_components/release-feed-grid", () => ({
+  ReleaseFeedGrid: () => null,
+}));
+vi.mock(
+  "~/app/[locale]/(pages)/browse/_components/browse-query-controls",
+  () => ({
+    BrowseQueryControls: () => null,
+  }),
+);
+vi.mock("~/app/[locale]/(pages)/browse/_components/browse-results-grid", () => ({
+  BrowseResultsGrid: () => null,
+}));
+
+import BrowsePage from "~/app/[locale]/(pages)/browse/[[...segments]]/page";
+import AllGearContent from "~/app/[locale]/(pages)/browse/_components/all-gear-content";
+import Breadcrumbs from "~/app/[locale]/(pages)/browse/_components/breadcrumbs";
+import MountButtons from "~/app/[locale]/(pages)/browse/_components/mount-buttons";
+
+describe("browse server locale handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    intlServerMocks.getTranslations.mockResolvedValue((key: string) => key);
+    browseServiceMocks.resolveScopeOrThrow.mockResolvedValue({
+      depth: 0,
+      scope: {},
+      brand: null,
+      mount: null,
+    });
+    browseServiceMocks.fetchBrowseListPage.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      perPage: 24,
+      hasMore: false,
+    });
+    browseServiceMocks.fetchBrandBySlug.mockResolvedValue(null);
+    browseServiceMocks.fetchReleaseFeedPage.mockResolvedValue({
+      items: [],
+      nextCursor: null,
+      hasMore: false,
+    });
+    browseServiceMocks.fetchMountsForBrand.mockResolvedValue([]);
+    popularityServiceMocks.fetchTrendingSlugs.mockResolvedValue([]);
+    popularityServiceMocks.fetchTrending.mockResolvedValue([]);
+  });
+
+  it("sets the request locale and uses explicit translations on the browse page", async () => {
+    await BrowsePage({
+      params: Promise.resolve({ locale: "ja", segments: [] }),
+    });
+
+    expect(intlServerMocks.setRequestLocale).toHaveBeenCalledWith("ja");
+    expect(intlServerMocks.getTranslations).toHaveBeenCalledWith({
+      locale: "ja",
+      namespace: "browsePage",
+    });
+  });
+
+  it("uses explicit locale-scoped translations in browse server components", async () => {
+    await AllGearContent({ locale: "de" });
+    await Breadcrumbs({
+      locale: "fr",
+      brand: { name: "Canon", slug: "canon" },
+      category: "lenses",
+      mountValue: "RF",
+    });
+    await MountButtons({
+      locale: "it",
+      brandId: "brand-1",
+      brandSlug: "canon",
+      category: "lenses",
+    });
+
+    expect(intlServerMocks.getTranslations).toHaveBeenCalledWith({
+      locale: "de",
+      namespace: "browsePage",
+    });
+    expect(intlServerMocks.getTranslations).toHaveBeenCalledWith({
+      locale: "fr",
+      namespace: "browsePage",
+    });
+    expect(intlServerMocks.getTranslations).toHaveBeenCalledWith({
+      locale: "it",
+      namespace: "browsePage",
+    });
+  });
+});


### PR DESCRIPTION
Explicitly thread locale through the browse server components and use next-intl server APIs with an explicit locale. The catch-all browse page now calls setRequestLocale and calls getTranslations({ locale, namespace: 'browsePage' }), and it passes locale props into AllGearContent, BrandContent, Breadcrumbs and MountButtons. Each component now requests translations with the explicit locale to remain static-safe under ISR/SSG and avoid request-bound locale lookups. Documentation updated to note this, and a unit test (browse-server-locale.test.ts) was added to assert setRequestLocale and locale-scoped getTranslations calls.