### PR TITLE
Make the shared header static-safe

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -40,8 +40,8 @@ Returned shape to UI (`NotificationView`):
 ## UI
 
 - Header dropdown (popover) trigger near the theme switcher, only when signed in.
-- `src/components/layout/header.tsx` reads the normalized pathname/search from middleware-populated request headers so the correct compact vs expanded shell is present in the initial HTML.
-- Notifications are fetched client-side after session hydration in `src/components/layout/header-client.tsx`, while the shell layout and sign-in callback URL are still server-seeded from the middleware headers.
+- `src/components/layout/header.tsx` builds only the locale-scoped header shell on the server so shared ISR routes stay static-safe.
+- `src/components/layout/header-client.tsx` derives compact vs expanded route state from `usePathname()`, keeps query-string callback enrichment isolated behind a `Suspense` boundary for `useSearchParams()`, and fetches notifications client-side after session hydration.
 - Client UI: `src/components/layout/notifications/notifications-dropdown.tsx`
   - Shows unread count badge on the bell button.
   - Active list (not archived) with actions: mark read, archive.

--- a/docs/search-system.md
+++ b/docs/search-system.md
@@ -165,8 +165,9 @@ Optional ANDed filters for brand/mount/gearType/price range/sensor format. These
 
 ## SSR & Suspense
 
-- `src/components/layout/header.tsx` now builds the header model on the server using request headers populated by `src/middleware.ts`.
-- The compact/expanded header state is chosen server-side from the normalized pathname, then the client header only hydrates the interactive pieces and home-page scroll transition.
+- `src/components/layout/header.tsx` now builds only the locale-scoped header shell on the server so shared ISR routes stay static-safe.
+- `src/components/layout/header-client.tsx` derives compact vs expanded route state from `usePathname()`, while query-string callback enrichment stays isolated behind a `Suspense` boundary around `useSearchParams()`.
+- Auth/session state, notifications, and final sign-in callback refinement all stay client-side.
 
 ## Performance
 

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import Image from "next/image";
-import React from "react";
+import React, { Suspense } from "react";
 import { FaDiscord,FaGithub,FaInstagram,FaTwitter } from "react-icons/fa";
 import { LanguageSwitcher } from "~/components/language-switcher";
 import { LocaleLink } from "~/components/locale-link";
@@ -85,7 +85,9 @@ export default function Footer({
               />
             </LocaleLink>
             <h2 className="text-xl font-semibold">{logo.title}</h2>
-            <LanguageSwitcher />
+            <Suspense fallback={<div aria-hidden="true" className="h-9 min-w-[210px]" />}>
+              <LanguageSwitcher />
+            </Suspense>
           </div>
           <p className="text-muted-foreground max-w-[70%] text-sm">
             {resolvedDescription}

--- a/src/components/layout/header-client.tsx
+++ b/src/components/layout/header-client.tsx
@@ -59,14 +59,9 @@ export default function HeaderClient({
   const rawPathname = usePathname();
   const normalizedPathname = rawPathname
     ? stripLocalePrefix(rawPathname).pathname
-    : model.normalizedPathname;
-  const routeState = rawPathname
-    ? buildHeaderRouteState(normalizedPathname)
-    : {
-        initialMode: model.initialMode,
-        scrollResponsive: model.scrollResponsive,
-      };
-  const [normalizedSearch, setNormalizedSearch] = useState(model.normalizedSearch);
+    : "/";
+  const routeState = buildHeaderRouteState(normalizedPathname);
+  const [normalizedSearch, setNormalizedSearch] = useState("");
   const callbackUrl = buildHeaderCallbackUrl(
     locale,
     normalizedPathname,
@@ -104,9 +99,7 @@ export default function HeaderClient({
   })();
 
   // Client-side notifications — fetched once user is known.
-  const [notifications, setNotifications] = useState<HeaderNotificationsData>(
-    model.notifications,
-  );
+  const [notifications, setNotifications] = useState<HeaderNotificationsData>(null);
   useEffect(() => {
     if (isSessionPending) {
       return;

--- a/src/components/layout/header-model.ts
+++ b/src/components/layout/header-model.ts
@@ -1,10 +1,6 @@
 import type { UserRole } from "~/auth";
 import type { Locale } from "~/i18n/config";
-import {
-  localizePathname,
-  normalizedPathHeaderName,
-  normalizedSearchHeaderName,
-} from "~/i18n/routing";
+import { localizePathname } from "~/i18n/routing";
 import type { NotificationView } from "~/server/notifications/service";
 
 export type HeaderIconKey =
@@ -91,23 +87,13 @@ export type HeaderLabels = {
 };
 
 export type HeaderViewModel = {
-  normalizedPathname: string;
-  normalizedSearch: string;
-  initialMode: HeaderMode;
-  scrollResponsive: boolean;
-  callbackUrl: string;
   homeHref: string;
   adminHref: string;
   accountHref: string;
-  signInHref: string;
-  profileHref: string | null;
-  isAdminOrEditor: boolean;
   labels: HeaderLabels;
   navItems: HeaderNavItem[];
   footerItems: HeaderFooterItems;
   moreLabel: string;
-  user: HeaderUser;
-  notifications: HeaderNotificationsData;
 };
 
 export function buildHeaderRouteState(normalizedPathname: string): {
@@ -143,30 +129,6 @@ export function buildHeaderCallbackUrl(
   normalizedSearch: string,
 ) {
   return `${localizePathname(normalizedPathname, locale)}${normalizedSearch}`;
-}
-
-export function buildHeaderInitialState(requestHeaders: Headers) {
-  const headerPathname = requestHeaders.get(normalizedPathHeaderName)?.trim();
-  const normalizedPathname = !headerPathname
-    ? "/"
-    : headerPathname.startsWith("/")
-      ? headerPathname
-      : `/${headerPathname}`;
-
-  return {
-    normalizedPathname,
-    routeState: buildHeaderRouteState(normalizedPathname),
-  };
-}
-
-export function buildHeaderInitialSearch(requestHeaders: Headers) {
-  const headerSearch = requestHeaders.get(normalizedSearchHeaderName)?.trim();
-
-  if (!headerSearch) {
-    return "";
-  }
-
-  return headerSearch.startsWith("?") ? headerSearch : `?${headerSearch}`;
 }
 
 function localizeHeaderNavItems(
@@ -206,61 +168,24 @@ function localizeHeaderFooterItems(
 
 export function buildHeaderViewModel({
   locale,
-  normalizedPathname,
-  normalizedSearch = "",
   navItems,
   footerItems,
   labels,
   moreLabel,
-  user,
-  notifications,
 }: {
   locale: Locale;
-  normalizedPathname: string;
-  normalizedSearch?: string;
   navItems: HeaderNavItemSource[];
   footerItems: HeaderFooterItemsSource;
   labels: HeaderLabels;
   moreLabel: string;
-  user: HeaderUser;
-  notifications: HeaderNotificationsData;
 }): HeaderViewModel {
-  const { initialMode, scrollResponsive } =
-    buildHeaderRouteState(normalizedPathname);
-  const callbackUrl = buildHeaderCallbackUrl(
-    locale,
-    normalizedPathname,
-    normalizedSearch,
-  );
-  const signInBaseHref = localizePathname("/auth/signin", locale);
-  const signInHref = `${signInBaseHref}?callbackUrl=${encodeURIComponent(callbackUrl)}`;
-
-  let profileHref: string | null = null;
-  if (user && ((user.handle && user.handle.trim() !== "") || user.memberNumber != null)) {
-    const profileSlug = user.handle || `user-${user.memberNumber}`;
-    profileHref = localizePathname(`/u/${profileSlug}`, locale);
-  }
-
   return {
-    normalizedPathname,
-    normalizedSearch,
-    initialMode,
-    scrollResponsive,
-    callbackUrl,
     homeHref: localizePathname("/", locale),
     adminHref: localizePathname("/admin", locale),
     accountHref: localizePathname("/profile/settings", locale),
-    signInHref,
-    profileHref,
-    isAdminOrEditor:
-      user?.role === "ADMIN" ||
-      user?.role === "SUPERADMIN" ||
-      user?.role === "EDITOR",
     labels,
     navItems: localizeHeaderNavItems(navItems, locale),
     footerItems: localizeHeaderFooterItems(footerItems, locale),
     moreLabel,
-    user,
-    notifications,
   };
 }

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,28 +1,19 @@
 import { getTranslations } from "next-intl/server";
-import { headers } from "next/headers";
-import {
-  buildHeaderInitialSearch,
-  buildHeaderInitialState,
-  buildHeaderViewModel,
-} from "~/components/layout/header-model";
+import { buildHeaderViewModel } from "~/components/layout/header-model";
 import type { Locale } from "~/i18n/config";
 import { getFooterItems, getNavItems } from "~/lib/nav-items";
 import HeaderClient from "./header-client";
 
 export default async function Header({ locale }: { locale: Locale }) {
-  const requestHeaders = await headers();
   const [tCommon, tNav] = await Promise.all([
     getTranslations({ locale, namespace: "common" }),
     getTranslations({ locale, namespace: "nav" }),
   ]);
 
-  const { normalizedPathname } = buildHeaderInitialState(requestHeaders);
-  const normalizedSearch = buildHeaderInitialSearch(requestHeaders);
-
+  // Keep this shared header cache-safe: request APIs like headers()/cookies()
+  // would make prerendered browse and gear ISR routes dynamic again.
   const model = buildHeaderViewModel({
     locale,
-    normalizedPathname,
-    normalizedSearch,
     navItems: getNavItems(tNav),
     footerItems: getFooterItems(tNav),
     labels: {
@@ -34,8 +25,6 @@ export default async function Header({ locale }: { locale: Locale }) {
       anonymous: tCommon("anonymous"),
     },
     moreLabel: tNav("more"),
-    user: null,
-    notifications: null,
   });
 
   return <HeaderClient model={model} locale={locale} />;

--- a/tests/playwright/basic/smoke.spec.ts
+++ b/tests/playwright/basic/smoke.spec.ts
@@ -1,8 +1,16 @@
-import { expect,test } from "@playwright/test";
+import { expect,test, type Page } from "@playwright/test";
+
+async function expectHeaderMode(page: Page, mode: "expanded" | "compact") {
+  const header = page.getByRole("banner");
+  await expect(header).toBeVisible();
+  await expect(header).toHaveClass(mode === "compact" ? /h-16/ : /h-20/);
+}
 
 test.describe("smoke", () => {
   test("landing renders hero and search", async ({ page }) => {
     await page.goto("/");
+
+    await expectHeaderMode(page, "expanded");
 
     // Ensure headline and search trigger render, then opening search shows the dialog.
     await expect(
@@ -22,6 +30,8 @@ test.describe("smoke", () => {
   test("landing CTA routes to browse hub", async ({ page }) => {
     await page.goto("/");
 
+    await expectHeaderMode(page, "expanded");
+
     // Validate the CTA destination from the homepage, then load the browse
     // hub directly. Direct navigation is more stable than relying on the
     // client-side transition here and still covers the user-facing contract.
@@ -30,12 +40,14 @@ test.describe("smoke", () => {
     await expect(browseCta).toHaveAttribute("href", "/browse");
     await page.goto("/browse");
     await expect(page).toHaveURL(/\/browse/);
+    await expectHeaderMode(page, "compact");
     await expect(page.getByRole("heading", { name: "All Gear" })).toBeVisible();
   });
 
   test("browse hub surfaces key sections", async ({ page }) => {
     await page.goto("/browse");
 
+    await expectHeaderMode(page, "compact");
     // Root browse page should surface catalog and discovery sections.
     await expect(page.getByRole("heading", { name: "All Gear" })).toBeVisible();
     await expect(
@@ -44,6 +56,24 @@ test.describe("smoke", () => {
     await expect(
       page.getByRole("heading", { name: "Latest releases" }),
     ).toBeVisible();
+  });
+
+  test("search keeps the expanded non-hero header shell", async ({ page }) => {
+    await page.goto("/search");
+
+    await expectHeaderMode(page, "expanded");
+  });
+
+  test("gear detail keeps the compact header shell", async ({ page }) => {
+    await page.goto("/browse");
+
+    await expectHeaderMode(page, "compact");
+    const firstGearLink = page.locator('a[href^="/gear/"]').first();
+    await expect(firstGearLink).toBeVisible();
+    await firstGearLink.click();
+
+    await expect(page).toHaveURL(/\/gear\//);
+    await expectHeaderMode(page, "compact");
   });
 
   test("about page loads mission content", async ({ page }) => {

--- a/tests/unit/header-model.test.ts
+++ b/tests/unit/header-model.test.ts
@@ -1,12 +1,9 @@
 import { describe,expect,it } from "vitest";
 import {
-  buildHeaderInitialSearch,
-  buildHeaderInitialState,
+  buildHeaderCallbackUrl,
   buildHeaderRouteState,
   buildHeaderViewModel,
   type HeaderLabels,
-  type HeaderNotificationsData,
-  type HeaderUser,
 } from "~/components/layout/header-model";
 import { getFooterItems,getNavItems } from "~/lib/nav-items";
 
@@ -22,67 +19,6 @@ const labels: HeaderLabels = {
 };
 
 describe("header model", () => {
-  it("reads initial route state from middleware headers", () => {
-    const requestHeaders = new Headers({
-      "x-sharply-normalized-pathname": "/search",
-      "x-sharply-normalized-search": "?q=sony",
-    });
-
-    expect(buildHeaderInitialState(requestHeaders)).toEqual({
-      normalizedPathname: "/search",
-      routeState: {
-        initialMode: "expanded",
-        scrollResponsive: false,
-      },
-    });
-    expect(buildHeaderInitialSearch(requestHeaders)).toBe("?q=sony");
-  });
-
-  it("falls back to defaults when routing headers are absent", () => {
-    const requestHeaders = new Headers();
-
-    expect(buildHeaderInitialState(requestHeaders)).toEqual({
-      normalizedPathname: "/",
-      routeState: {
-        initialMode: "expanded",
-        scrollResponsive: true,
-      },
-    });
-    expect(buildHeaderInitialSearch(requestHeaders)).toBe("");
-  });
-
-  it("sanitizes malformed routing headers before deriving route state", () => {
-    const requestHeaders = new Headers({
-      "x-sharply-normalized-pathname": "  search/results  ",
-      "x-sharply-normalized-search": "  q=sony  ",
-    });
-
-    expect(buildHeaderInitialState(requestHeaders)).toEqual({
-      normalizedPathname: "/search/results",
-      routeState: {
-        initialMode: "expanded",
-        scrollResponsive: false,
-      },
-    });
-    expect(buildHeaderInitialSearch(requestHeaders)).toBe("?q=sony");
-  });
-
-  it("treats blank routing headers as defaults", () => {
-    const requestHeaders = new Headers({
-      "x-sharply-normalized-pathname": "   ",
-      "x-sharply-normalized-search": "   ",
-    });
-
-    expect(buildHeaderInitialState(requestHeaders)).toEqual({
-      normalizedPathname: "/",
-      routeState: {
-        initialMode: "expanded",
-        scrollResponsive: true,
-      },
-    });
-    expect(buildHeaderInitialSearch(requestHeaders)).toBe("");
-  });
-
   it("chooses the expected initial mode for home, search, and normal pages", () => {
     expect(buildHeaderRouteState("/")).toEqual({
       initialMode: "expanded",
@@ -98,74 +34,41 @@ describe("header model", () => {
     });
   });
 
-  it("localizes links and preserves callback URLs for non-default locales", () => {
+  it("builds localized callback URLs for non-default locales", () => {
+    expect(buildHeaderCallbackUrl("ja", "/about", "?q=sony")).toBe(
+      "/ja/about?q=sony",
+    );
+  });
+
+  it("localizes server-safe header links for non-default locales", () => {
     const model = buildHeaderViewModel({
       locale: "ja",
-      normalizedPathname: "/about",
-      normalizedSearch: "?q=sony",
       navItems: getNavItems(t),
       footerItems: getFooterItems(t),
       labels,
       moreLabel: "More",
-      user: null,
-      notifications: null,
     });
 
-    expect(model.callbackUrl).toBe("/ja/about?q=sony");
-    expect(model.signInHref).toBe(
-      "/ja/auth/signin?callbackUrl=%2Fja%2Fabout%3Fq%3Dsony",
-    );
+    expect(model.homeHref).toBe("/ja");
+    expect(model.adminHref).toBe("/ja/admin");
+    expect(model.accountHref).toBe("/ja/profile/settings");
     expect(model.navItems[0]?.href).toBe("/ja/about");
     expect(model.footerItems.bottomLinks).toEqual(
       expect.arrayContaining([expect.objectContaining({ href: "/ja/contact" })]),
     );
   });
 
-  it("keeps default-locale links unprefixed and carries signed-in data through", () => {
-    const user: HeaderUser = {
-      id: "user-1",
-      role: "EDITOR",
-      handle: "camfan",
-      memberNumber: 7,
-      name: "Cam Fan",
-      email: "cam@example.com",
-      image: null,
-    };
-    const notifications: HeaderNotificationsData = {
-      notifications: [
-        {
-          id: "n1",
-          type: "badge_awarded",
-          title: "Badge",
-          body: "Won a badge",
-          linkUrl: "/u/camfan",
-          sourceType: null,
-          sourceId: null,
-          metadata: null,
-          readAt: null,
-          archivedAt: null,
-          createdAt: "2026-04-22T12:00:00.000Z",
-        },
-      ],
-      archived: [],
-      unreadCount: 1,
-    };
-
+  it("keeps default-locale links unprefixed", () => {
     const model = buildHeaderViewModel({
       locale: "en",
-      normalizedPathname: "/gear",
-      normalizedSearch: "",
       navItems: getNavItems(t),
       footerItems: getFooterItems(t),
       labels,
       moreLabel: "More",
-      user,
-      notifications,
     });
 
     expect(model.homeHref).toBe("/");
-    expect(model.profileHref).toBe("/u/camfan");
-    expect(model.isAdminOrEditor).toBe(true);
-    expect(model.notifications).toEqual(notifications);
+    expect(model.adminHref).toBe("/admin");
+    expect(model.accountHref).toBe("/profile/settings");
   });
 });

--- a/tests/unit/header-server.test.ts
+++ b/tests/unit/header-server.test.ts
@@ -2,34 +2,13 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach,describe,expect,it,vi } from "vitest";
 import type { HeaderViewModel } from "~/components/layout/header-model";
 
-// Keep mocks for modules that are still transitively imported (e.g. header-model
-// imports types from ~/auth and ~/server/notifications/service).
-const authMocks = vi.hoisted(() => ({
-  auth: {
-    api: {
-      getSession: vi.fn(),
-    },
-  },
-}));
-
 const intlServerMocks = vi.hoisted(() => ({
   getTranslations: vi.fn(),
 }));
 
-const nextHeadersMocks = vi.hoisted(() => ({
-  headers: vi.fn(),
-}));
-
-const notificationMocks = vi.hoisted(() => ({
-  fetchNotificationsForUser: vi.fn(),
-}));
-
 const headerClientMock = vi.hoisted(() => vi.fn((_props: unknown) => null));
 
-vi.mock("~/auth", () => authMocks);
 vi.mock("next-intl/server", () => intlServerMocks);
-vi.mock("next/headers", () => nextHeadersMocks);
-vi.mock("~/server/notifications/service", () => notificationMocks);
 vi.mock("~/components/layout/header-client", () => ({
   default: headerClientMock,
 }));
@@ -45,15 +24,18 @@ function getHeaderModel() {
   return (firstCall[0] as { model: HeaderViewModel }).model;
 }
 
+function getHeaderClientProps() {
+  const firstCall = headerClientMock.mock.calls.at(0);
+  if (!firstCall) {
+    throw new Error("Expected HeaderClient to render");
+  }
+
+  return firstCall[0] as { locale: string; model: HeaderViewModel };
+}
+
 describe("header server component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    nextHeadersMocks.headers.mockResolvedValue(
-      new Headers({
-        "x-sharply-normalized-pathname": "/",
-        "x-sharply-normalized-search": "",
-      }),
-    );
     intlServerMocks.getTranslations.mockImplementation(
       async ({
         namespace,
@@ -68,36 +50,35 @@ describe("header server component", () => {
   it("builds a signed-out model with localized hrefs for the given locale", async () => {
     renderToStaticMarkup(await Header({ locale: "ja" }));
     const model = getHeaderModel();
+    const props = getHeaderClientProps();
 
-    expect(model.user).toBeNull();
-    expect(model.notifications).toBeNull();
+    expect(props.locale).toBe("ja");
     expect(model.homeHref).toBe("/ja");
     expect(model.adminHref).toBe("/ja/admin");
-    expect(model.initialMode).toBe("expanded");
+    expect(model.accountHref).toBe("/ja/profile/settings");
     expect(model.labels.signIn).toBe("common.signIn");
-    expect(model.callbackUrl).toBe("/ja");
-    expect(model.signInHref).toBe("/ja/auth/signin?callbackUrl=%2Fja");
-    expect(notificationMocks.fetchNotificationsForUser).not.toHaveBeenCalled();
+    expect(model.moreLabel).toBe("nav.more");
   });
 
-  it("uses normalized routing headers to seed inner pages without auth fetches", async () => {
-    nextHeadersMocks.headers.mockResolvedValue(
-      new Headers({
-        "x-sharply-normalized-pathname": "/gear/sony-a6700",
-        "x-sharply-normalized-search": "?tab=reviews",
-      }),
-    );
-
-    renderToStaticMarkup(await Header({ locale: "ja" }));
+  it("keeps the server model static and locale-scoped", async () => {
+    renderToStaticMarkup(await Header({ locale: "en" }));
     const model = getHeaderModel();
 
-    expect(model.user).toBeNull();
-    expect(model.notifications).toBeNull();
-    expect(model.initialMode).toBe("compact");
-    expect(model.callbackUrl).toBe("/ja/gear/sony-a6700?tab=reviews");
-    expect(model.signInHref).toBe(
-      "/ja/auth/signin?callbackUrl=%2Fja%2Fgear%2Fsony-a6700%3Ftab%3Dreviews",
-    );
-    expect(notificationMocks.fetchNotificationsForUser).not.toHaveBeenCalled();
+    expect(model).toEqual({
+      homeHref: "/",
+      adminHref: "/admin",
+      accountHref: "/profile/settings",
+      labels: {
+        adminPanel: "common.adminPanel",
+        signIn: "common.signIn",
+        profile: "common.profile",
+        account: "common.account",
+        logOut: "common.logOut",
+        anonymous: "common.anonymous",
+      },
+      navItems: expect.any(Array),
+      footerItems: expect.any(Object),
+      moreLabel: "nav.more",
+    });
   });
 });

--- a/tests/unit/static-route-safety.test.ts
+++ b/tests/unit/static-route-safety.test.ts
@@ -23,6 +23,14 @@ describe("static route safety", () => {
     );
   });
 
+  it("keeps the footer language switcher isolated behind Suspense", () => {
+    const footer = readSource("src/components/layout/footer.tsx");
+
+    expect(footer).toMatch(
+      /<Suspense fallback=\{<div aria-hidden="true" className="h-9 min-w-\[210px\]" \/>\}>\s*<LanguageSwitcher/,
+    );
+  });
+
   it("keeps browse ISR routes anchored to params locale and off request APIs", () => {
     const browsePage = readSource(
       "src/app/[locale]/(pages)/browse/[[...segments]]/page.tsx",

--- a/tests/unit/static-route-safety.test.ts
+++ b/tests/unit/static-route-safety.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe,expect,it } from "vitest";
+
+function readSource(relativePath: string) {
+  return readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+describe("static route safety", () => {
+  it("keeps the shared header free of dynamic request APIs", () => {
+    const header = readSource("src/components/layout/header.tsx");
+
+    expect(header).not.toMatch(/from "next\/headers"/);
+    expect(header).not.toMatch(/\bawait headers\(/);
+    expect(header).not.toMatch(/\bawait cookies\(/);
+  });
+
+  it("keeps search param syncing isolated behind Suspense in the header client", () => {
+    const headerClient = readSource("src/components/layout/header-client.tsx");
+
+    expect(headerClient).toMatch(
+      /<Suspense fallback=\{null\}>\s*<HeaderSearchParamsSync/,
+    );
+  });
+
+  it("keeps browse ISR routes anchored to params locale and off request APIs", () => {
+    const browsePage = readSource(
+      "src/app/[locale]/(pages)/browse/[[...segments]]/page.tsx",
+    );
+
+    expect(browsePage).toMatch(/setRequestLocale\(locale\);/);
+    expect(browsePage).not.toMatch(/\bheaders\(/);
+    expect(browsePage).not.toMatch(/\bcookies\(/);
+  });
+
+  it("keeps gear ISR routes anchored to params locale and off request APIs", () => {
+    const gearPage = readSource("src/app/[locale]/(pages)/gear/[slug]/page.tsx");
+
+    expect(gearPage).toMatch(/setRequestLocale\(locale\);/);
+    expect(gearPage).not.toMatch(/searchParams:/);
+    expect(gearPage).not.toMatch(/await searchParams/);
+    expect(gearPage).not.toMatch(/\bheaders\(/);
+    expect(gearPage).not.toMatch(/\bcookies\(/);
+    expect(gearPage).toMatch(/<EditAppliedToast \/>/);
+  });
+});


### PR DESCRIPTION
- Move route and callback state into the client header
- Keep ISR browse and gear pages off request APIs
- Update docs and tests for the new header flow