### PR TITLE
Resolve auth client base URL from browser origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Sharply validates configuration through `src/env.js`. For onboarding you only ne
 
 - `AUTH_ADDITIONAL_TRUSTED_ORIGINS` – comma-separated extra origins allowed as Better Auth callback targets, such as a fixed `https://myapp.vercel.app`
 - Leave `AUTH_BASE_URL`, `BETTER_AUTH_BASE_URL`, `BETTER_AUTH_URL`, and `NEXT_PUBLIC_BETTER_AUTH_URL` unset if OAuth should use the current request host for provider callbacks
+- Sharply’s browser auth client now resolves its base URL from the current window origin so preview-host sign-in requests stay on the host where auth started
 - Set one of those auth-base overrides only if you intentionally want all OAuth provider callbacks pinned to a single host
 
 **Sign-in providers (pick which providers you want and populate them)**

--- a/docs/authentication-guide.md
+++ b/docs/authentication-guide.md
@@ -187,6 +187,7 @@ Sharply separates the canonical site URL from the Better Auth callback host:
 - `NEXT_PUBLIC_BASE_URL` is the canonical site URL used for metadata, absolute app links, and SEO-sensitive server output.
 - `AUTH_ADDITIONAL_TRUSTED_ORIGINS` adds extra allowed post-login callback origins, such as a fixed `https://myapp.vercel.app`.
 - `AUTH_BASE_URL`, `BETTER_AUTH_BASE_URL`, `BETTER_AUTH_URL`, and `NEXT_PUBLIC_BETTER_AUTH_URL` are single-host auth overrides. If any of them are set, Better Auth pins OAuth provider callbacks to that host.
+- Sharply’s browser auth client resolves its Better Auth base URL from `window.location.origin`, which keeps sign-in and account-link requests on the host where the user started the flow instead of relying on Better Auth’s client-side env inference.
 
 For multi-origin OAuth on a main domain plus a fixed `vercel.app` host:
 

--- a/src/lib/auth/auth-client-config.ts
+++ b/src/lib/auth/auth-client-config.ts
@@ -1,0 +1,7 @@
+export function resolveAuthClientBaseURL() {
+  if (typeof window !== "undefined" && window.location?.origin) {
+    return window.location.origin;
+  }
+
+  return process.env.NEXT_PUBLIC_BASE_URL;
+}

--- a/src/lib/auth/auth-client.ts
+++ b/src/lib/auth/auth-client.ts
@@ -5,6 +5,7 @@ import {
 } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 import { type auth } from "~/auth";
+import { resolveAuthClientBaseURL } from "~/lib/auth/auth-client-config";
 
 // typically done as export const authClient = createAuthClient();, we just destructure the functions we need
 export const {
@@ -17,6 +18,7 @@ export const {
   unlinkAccount,
   passkey,
 } = createAuthClient({
+  baseURL: resolveAuthClientBaseURL(),
   plugins: [
     inferAdditionalFields<typeof auth>(),
     emailOTPClient(),

--- a/tests/unit/auth-client-config.test.ts
+++ b/tests/unit/auth-client-config.test.ts
@@ -1,0 +1,30 @@
+import { afterEach,describe,expect,it,vi } from "vitest";
+import { resolveAuthClientBaseURL } from "~/lib/auth/auth-client-config";
+
+const originalBaseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  process.env.NEXT_PUBLIC_BASE_URL = originalBaseUrl;
+});
+
+describe("auth client config", () => {
+  it("uses the current browser origin when available", () => {
+    process.env.NEXT_PUBLIC_BASE_URL = "https://www.sharplyphoto.com";
+    vi.stubGlobal("window", {
+      location: {
+        origin: "https://sharplyphoto-ten.vercel.app",
+      },
+    });
+
+    expect(resolveAuthClientBaseURL()).toBe(
+      "https://sharplyphoto-ten.vercel.app",
+    );
+  });
+
+  it("falls back to the canonical base URL during server execution", () => {
+    process.env.NEXT_PUBLIC_BASE_URL = "https://www.sharplyphoto.com";
+
+    expect(resolveAuthClientBaseURL()).toBe("https://www.sharplyphoto.com");
+  });
+});


### PR DESCRIPTION
- Use window.location.origin for browser auth requests
- Keep server fallback on NEXT_PUBLIC_BASE_URL
- Add unit coverage and docs updates