### PR TITLE
Refine image request localization and limit rear-view images to cameras

### DIFF
--- a/docs/adding-spec-columns.md
+++ b/docs/adding-spec-columns.md
@@ -545,6 +545,7 @@ Admin/review surfaces:
 
 - New proposal keys must also be checked in the contributor confirmation preview and the admin approval queue.
 - For boolean specs, ensure these surfaces render `Yes` / `No` / `Empty` rather than raw `true` / `false` values.
+- Reuse `gearDetail.specRegistry.shared.*` for shared simple preview/admin values like `Yes` and `No`; do not introduce ad hoc translation namespaces for those labels.
 - For yes-only public specs like `hasIlluminatedButtons`, keep the form and approval UI tri-state even though the public spec table hides `false` and unknown values.
 
 ### Example: Add internal storage (GB with TB display)

--- a/docs/features/image-request-architecture.md
+++ b/docs/features/image-request-architecture.md
@@ -7,7 +7,7 @@
 │                    Gear Detail Page                         │
 │              (src/app/.../gear/[slug]/page.tsx)             │
 │                                                             │
-│  - Fetches hasImageRequest status from service layer        │
+│  - Passes null for viewer-specific request state            │
 │  - Passes to GearImageCarousel component                    │
 └──────────────────────┬──────────────────────────────────────┘
                        │
@@ -27,6 +27,9 @@
 │      (src/app/.../gear/_components/                         │
 │              request-image-button.tsx)                      │
 │                                                             │
+│  - Hydrates request/auth state via /api/gear/[slug]/        │
+│    user-state                                               │
+│  - Stays blank until hydration resolves                     │
 │  - Manages button state                                     │
 │  - Calls actionToggleImageRequest                           │
 │  - Shows toast notifications                                │
@@ -127,6 +130,7 @@
 ### User Experience
 
 - ✅ Toast notifications for all actions
+- ✅ Blank initial state while viewer/request state resolves
 - ✅ Loading states during API calls
 - ✅ Different button states (Request vs Requested)
 - ✅ Button hidden for non-authenticated users

--- a/docs/features/image-request-examples.md
+++ b/docs/features/image-request-examples.md
@@ -172,6 +172,7 @@ export default async function GearPage({ params }: GearPageProps) {
   return (
     <GearImageCarousel
       name={item.name}
+      gearType={item.gearType}
       thumbnailUrl={item.thumbnailUrl}
       topViewUrl={item.topViewUrl}
       rearViewUrl={item.rearViewUrl}
@@ -181,6 +182,8 @@ export default async function GearPage({ params }: GearPageProps) {
   );
 }
 ```
+
+`rearViewUrl` is camera-only. Lenses continue to use front and top views.
 
 ### 7. Admin Analytics List (image-requests-list.tsx)
 ```typescript

--- a/docs/features/image-request-examples.md
+++ b/docs/features/image-request-examples.md
@@ -3,6 +3,7 @@
 ## Key Code Snippets
 
 ### 1. Database Schema (schema.ts)
+
 ```typescript
 export const imageRequests = appSchema.table(
   "image_requests",
@@ -25,13 +26,19 @@ export const imageRequests = appSchema.table(
 ```
 
 ### 2. Data Layer (data.ts)
+
 ```typescript
 // Check if user has requested
-export async function hasImageRequest(gearId: string, userId: string): Promise<boolean> {
+export async function hasImageRequest(
+  gearId: string,
+  userId: string,
+): Promise<boolean> {
   const row = await db
     .select({ userId: imageRequests.userId })
     .from(imageRequests)
-    .where(and(eq(imageRequests.userId, userId), eq(imageRequests.gearId, gearId)))
+    .where(
+      and(eq(imageRequests.userId, userId), eq(imageRequests.gearId, gearId)),
+    )
     .limit(1);
   return row.length > 0;
 }
@@ -41,7 +48,9 @@ export async function addImageRequest(gearId: string, userId: string) {
   const exists = await db
     .select({ userId: imageRequests.userId })
     .from(imageRequests)
-    .where(and(eq(imageRequests.userId, userId), eq(imageRequests.gearId, gearId)))
+    .where(
+      and(eq(imageRequests.userId, userId), eq(imageRequests.gearId, gearId)),
+    )
     .limit(1);
   if (exists.length > 0) return { alreadyExists: true } as const;
 
@@ -67,21 +76,25 @@ export async function fetchAllImageRequests() {
 ```
 
 ### 3. Service Layer (service.ts)
+
 ```typescript
-export async function toggleImageRequest(slug: string, action: "add" | "remove") {
+export async function toggleImageRequest(
+  slug: string,
+  action: "add" | "remove",
+) {
   const { user } = await getSessionOrThrow(); // Auth check
   const userId = user.id;
   const gearId = await resolveGearIdOrThrow(slug);
-  
+
   if (action === "add") {
     const res = await addImageRequest(gearId, userId);
     if (res.alreadyExists)
       return { ok: false, reason: "already_requested" } as const;
-    
+
     await track("image_request_toggle", { slug, action: "add" }); // Analytics
     return { ok: true, action: "added" as const };
   }
-  
+
   await removeImageRequest(gearId, userId);
   await track("image_request_toggle", { slug, action: "remove" });
   return { ok: true, action: "removed" as const };
@@ -97,6 +110,7 @@ export async function fetchImageRequestStatus(slug: string) {
 ```
 
 ### 4. Server Action (actions.ts)
+
 ```typescript
 export async function actionToggleImageRequest(
   slug: string,
@@ -109,6 +123,7 @@ export async function actionToggleImageRequest(
 ```
 
 ### 5. Request Button Component (request-image-button.tsx)
+
 ```typescript
 "use client";
 
@@ -119,22 +134,25 @@ export function RequestImageButton({ slug, initialHasRequested }: Props) {
   const handleToggle = async () => {
     setIsLoading(true);
     try {
-      const action = hasRequested ? "remove" : "add";
-      const result = await actionToggleImageRequest(slug, action);
+      const result = await actionToggleImageRequest(slug, "add");
 
-      if (result.ok) {
-        if (result.action === "added") {
-          setHasRequested(true);
-          toast.success("Image request submitted", {
-            description: "Thanks for your interest!",
-          });
-        } else {
-          setHasRequested(false);
-          toast.success("Image request removed");
-        }
+      if (result.ok && result.action === "added") {
+        setHasRequested(true);
+        toast.success(t("toastSubmittedTitle"), {
+          description: t("toastSubmittedDescription"),
+        });
+      } else if (!result.ok && result.reason === "already_requested") {
+        setHasRequested(true);
+        toast.error(t("toastAlreadyRequestedTitle"));
+      } else {
+        toast.error(t("toastFailedTitle"), {
+          description: t("toastFailedDescription"),
+        });
       }
     } catch (error) {
-      toast.error("Failed to submit request");
+      toast.error(t("toastFailedTitle"), {
+        description: t("toastFailedDescription"),
+      });
     } finally {
       setIsLoading(false);
     }
@@ -147,27 +165,22 @@ export function RequestImageButton({ slug, initialHasRequested }: Props) {
       variant={hasRequested ? "outline" : "default"}
       icon={hasRequested ? <Check /> : <ImagePlus />}
     >
-      {hasRequested ? "Image Requested" : "Request Image"}
+      {hasRequested ? t("requested") : t("button")}
     </Button>
   );
 }
 ```
 
 ### 6. Gear Page Integration (page.tsx)
+
 ```typescript
 export default async function GearPage({ params }: GearPageProps) {
   const { slug } = await params;
   const item = await fetchGearBySlug(slug);
 
-  // Fetch image request status for current user
-  let hasImageRequest: boolean | null = null;
-  try {
-    const { fetchImageRequestStatus } = await import("~/server/gear/service");
-    const status = await fetchImageRequestStatus(slug).catch(() => null);
-    hasImageRequest = status ? status.hasRequested : null;
-  } catch {
-    hasImageRequest = null; // User not logged in
-  }
+  // Leave viewer-specific image request state unresolved on the server.
+  // The client RequestImageButton hydrates it via /api/gear/[slug]/user-state.
+  const hasImageRequest: boolean | null = null;
 
   return (
     <GearImageCarousel
@@ -186,6 +199,7 @@ export default async function GearPage({ params }: GearPageProps) {
 `rearViewUrl` is camera-only. Lenses continue to use front and top views.
 
 ### 7. Admin Analytics List (image-requests-list.tsx)
+
 ```typescript
 export async function ImageRequestsList() {
   const requests = await fetchAllImageRequests();
@@ -222,8 +236,6 @@ export async function ImageRequestsList() {
 - [ ] Click "Request Image" button
 - [ ] Verify success toast appears
 - [ ] Verify button changes to "Image Requested"
-- [ ] Click again to remove request
-- [ ] Verify removal toast appears
 - [ ] Visit `/admin/analytics` as admin
 - [ ] Verify the request appears in the list
 - [ ] Verify request count is accurate

--- a/docs/features/image-request.md
+++ b/docs/features/image-request.md
@@ -1,17 +1,20 @@
 # Image Request Feature
 
 ## Overview
+
 This feature allows users to request images for gear items that don't have photos. It helps prioritize which items need images the most based on user interest.
 
 ## User Flow
 
 ### For Regular Users
+
 1. When viewing a gear item without an image, users see a "Request Image" button
-2. Clicking the button submits a request and shows a success toast
-3. The button changes to "Image Requested" with a checkmark icon
-4. Users can click again to remove their request
+2. If the viewer's request/auth state is still hydrating, the request control area stays blank until that state resolves
+3. Clicking the button submits a request and shows a success toast
+4. The button changes to "Image Requested" with a checkmark icon
 
 ### For Admins
+
 1. Navigate to `/admin/analytics`
 2. View the "Image Requests" section at the top
 3. See all gear items with pending image requests
@@ -23,6 +26,7 @@ This feature allows users to request images for gear items that don't have photo
 ## Technical Implementation
 
 ### Database Schema
+
 - **Table**: `app.image_requests`
 - **Columns**:
   - `user_id` (varchar, FK to users)
@@ -35,29 +39,36 @@ This feature allows users to request images for gear items that don't have photo
 ### API Structure
 
 #### Data Layer (`src/server/gear/data.ts`)
+
 - `hasImageRequest(gearId, userId)` - Check if request exists
 - `addImageRequest(gearId, userId)` - Create a request
 - `removeImageRequest(gearId, userId)` - Remove a request
 - `fetchAllImageRequests()` - Get aggregated requests for admin
 
 #### Service Layer (`src/server/gear/service.ts`)
+
 - `fetchImageRequestStatus(slug)` - Get user's request status
 - `toggleImageRequest(slug, action)` - Add/remove request with validation
 
 #### Server Actions (`src/server/gear/actions.ts`)
+
 - `actionToggleImageRequest(slug, action)` - Client-callable action with revalidation
 
 ### UI Components
 
 #### Request Image Button
+
 - **Location**: `src/app/[locale]/(pages)/gear/_components/request-image-button.tsx`
 - **Features**:
+  - Client-side hydration via `/api/gear/[slug]/user-state`
+  - Blank initial state while viewer/request state is unresolved
   - Loading state during API call
   - Toast notifications for success/error
   - Different states: "Request Image" vs "Image Requested"
   - Only shown to logged-in users
 
 #### Admin Analytics
+
 - **Location**: `src/app/[locale]/(admin)/admin/analytics/image-requests-list.tsx`
 - **Features**:
   - Displays gear name, request count, and last request date
@@ -67,7 +78,9 @@ This feature allows users to request images for gear items that don't have photo
 ## Usage
 
 ### Running Migrations
+
 After pulling this feature, run:
+
 ```bash
 npm run db:push
 ```
@@ -75,6 +88,7 @@ npm run db:push
 This will create the `image_requests` table in your database.
 
 ### Testing the Feature
+
 1. Navigate to a gear item without an image (e.g., `/gear/[slug]`)
 2. Log in as a user
 3. Click "Request Image" button
@@ -83,7 +97,9 @@ This will create the `image_requests` table in your database.
 6. As admin, check `/admin/analytics` to see the request
 
 ## Notes
+
 - Users must be authenticated to request images
+- The control stays blank while auth/request state is still resolving
 - The button is hidden for non-authenticated users
 - Database constraint prevents duplicate requests
-- Analytics tracking is integrated for request/unrequest actions
+- Analytics tracking is integrated for request actions

--- a/docs/gear-specification-system.md
+++ b/docs/gear-specification-system.md
@@ -18,6 +18,9 @@ The central table that stores common gear information:
   - `mountId`: Single mount reference (kept for backward compatibility, stores "primary" mount)
   - Mount relationships managed via `gear_mounts` junction table for multi-mount support
 - **Metadata**: Release date, price, thumbnail URL, optional top-view URL, optional rear-view URL
+  - `thumbnailUrl` applies to all gear
+  - `topViewUrl` applies to cameras and lenses
+  - `rearViewUrl` applies only to `CAMERA` and `ANALOG_CAMERA`
 - **User Notes**: `notes` — `text[]` for unstructured notes
 - **Commerce**: `mpbMaxPriceUsdCents` — optional MPB max price (USD cents)
 - **Core Specs**: Physical dimensions (width, height, depth in mm), weight

--- a/docs/gear-specification-system.md
+++ b/docs/gear-specification-system.md
@@ -254,6 +254,7 @@ The registry exports `buildGearSpecsSections(item: GearItem, options?)` which re
 - Examples: field labels under `gearDetail.specRegistry.sections.<sectionId>.fields.<fieldKey>.label` and shared values under `gearDetail.specRegistry.shared.*`.
 - The registry will fall back to inline English when a locale key is missing; `registry.tsx` provides these inline English labels as the fallback source.
 - Shared simple values emitted directly by the registry, such as `Yes` and `No`, live under `gearDetail.specRegistry.shared.*`.
+- Contributor submission previews and admin approval views should also reuse `gearDetail.specRegistry.shared.*` for shared simple values like `Yes` and `No` instead of introducing separate namespaces.
 - Edit-form chrome and workflow copy that is not owned by the registry lives under `gearDetail.editGear.*`.
 - Keep canonical English labels inline in registry/edit code where they are the source of truth, then resolve localized UI labels via translation keys. This keeps the English terminology searchable in code while preventing those labels from leaking into non-English UI.
 - Review/use-case genre labels on gear surfaces are resolved by slug under `gearDetail.reviewGenres.*`; do not render the generated English `GENRES[].name` directly in non-English UI.

--- a/docs/top-view-images.md
+++ b/docs/top-view-images.md
@@ -2,6 +2,13 @@
 
 Top-view and rear-view images provide standardized secondary reference angles alongside the primary front view.
 
+## Gear-Type Rules
+
+- Front view (`thumbnailUrl`) applies to all gear.
+- Top view (`topViewUrl`) applies to cameras and lenses.
+- Rear view (`rearViewUrl`) applies only to `CAMERA` and `ANALOG_CAMERA`.
+- Existing lens rear-view values are ignored in the UI, and rear-view mutations for lenses are rejected in the admin service layer.
+
 ## Schema
 
 Stored directly on `gear` table:
@@ -45,4 +52,4 @@ Revalidates `/admin/gear` after mutation.
 
 ## Display
 
-Top-view and rear-view images appear in the gear image carousel (`gear-image-carousel.tsx`) alongside the main product image. The admin gear image modal now manages three slots in this order: front view, top view, rear view.
+Top-view and rear-view images appear in the gear image carousel (`gear-image-carousel.tsx`) alongside the main product image. Camera and analog-camera items expose three slots in this order: front view, top view, rear view. Lens items expose only front view and top view.

--- a/messages/de.json
+++ b/messages/de.json
@@ -197,6 +197,7 @@
     "gearImages": {
       "manageTitle": "Gear-Bilder verwalten",
       "manageDescription": "Lade Bilder der Vorderansicht, Draufsicht und Rückansicht für diesen Ausrüstungsgegenstand hoch.",
+      "manageDescriptionNoRearView": "Lade Bilder der Vorderansicht und Draufsicht für diesen Ausrüstungsgegenstand hoch.",
       "manageButton": "Bilder verwalten",
       "frontView": "Vorderansicht",
       "topView": "Draufsicht",

--- a/messages/de.json
+++ b/messages/de.json
@@ -210,8 +210,19 @@
       "deleted": "Gelöscht",
       "limits": "Lade Bilder mit transparentem Hintergrund, eng zugeschnitten, 1000 px an der langen Kante, als .webp mit 75 % Qualität hoch.",
       "removeNote": "Hinweis: Nur Admins können Bilder entfernen.",
+      "noImageAvailable": "Kein Bild verfügbar",
       "topViewAlt": "{name} - Draufsicht",
       "rearViewAlt": "{name} - Rückansicht"
+    },
+    "imageRequest": {
+      "helper": "Klicke unten, um uns zu helfen, dieses Bild zu priorisieren!",
+      "button": "Bild anfordern",
+      "requested": "Bild angefordert",
+      "toastSubmittedTitle": "Bildanfrage gesendet",
+      "toastSubmittedDescription": "Danke für dein Interesse! Wir priorisieren das Hinzufügen eines Bildes für diesen Eintrag.",
+      "toastAlreadyRequestedTitle": "Anfrage existiert bereits",
+      "toastFailedTitle": "Anfrage konnte nicht gesendet werden",
+      "toastFailedDescription": "Bitte versuche es später erneut."
     },
     "watch": "Ansehen",
     "fromRespectedCreators": "Von angesehenen Creators",

--- a/messages/en.json
+++ b/messages/en.json
@@ -197,6 +197,7 @@
     "gearImages": {
       "manageTitle": "Manage Gear Images",
       "manageDescription": "Upload front view, top view, and rear view images for this gear item.",
+      "manageDescriptionNoRearView": "Upload front view and top view images for this gear item.",
       "manageButton": "Manage Images",
       "frontView": "Front View",
       "topView": "Top View",

--- a/messages/en.json
+++ b/messages/en.json
@@ -210,8 +210,19 @@
       "deleted": "Deleted",
       "limits": "Upload images with transparent background, tightly cropped, 1000px on the long edge, .webp @ 75% quality.",
       "removeNote": "Note: Only admins can remove images.",
+      "noImageAvailable": "No image available",
       "topViewAlt": "{name} - Top View",
       "rearViewAlt": "{name} - Rear View"
+    },
+    "imageRequest": {
+      "helper": "Click below to help us prioritize this image!",
+      "button": "Request Image",
+      "requested": "Image Requested",
+      "toastSubmittedTitle": "Image request submitted",
+      "toastSubmittedDescription": "Thanks for your interest! We'll prioritize adding an image for this item.",
+      "toastAlreadyRequestedTitle": "Request already exists",
+      "toastFailedTitle": "Failed to submit request",
+      "toastFailedDescription": "Please try again later."
     },
     "watch": "Watch",
     "fromRespectedCreators": "From Respected Creators",

--- a/messages/es.json
+++ b/messages/es.json
@@ -197,6 +197,7 @@
     "gearImages": {
       "manageTitle": "Administrar imágenes del equipo",
       "manageDescription": "Sube imágenes de vista frontal, superior y trasera para este artículo de equipo.",
+      "manageDescriptionNoRearView": "Sube imágenes de vista frontal y superior para este artículo de equipo.",
       "manageButton": "Administrar imágenes",
       "frontView": "Vista frontal",
       "topView": "Vista superior",

--- a/messages/es.json
+++ b/messages/es.json
@@ -210,8 +210,19 @@
       "deleted": "Eliminado",
       "limits": "Sube imágenes con fondo transparente, bien recortadas, de 1000 px en el lado más largo, en formato .webp con 75 % de calidad.",
       "removeNote": "Nota: Solo los administradores pueden eliminar imágenes.",
+      "noImageAvailable": "No hay imagen disponible",
       "topViewAlt": "{name} - Vista superior",
       "rearViewAlt": "{name} - Vista trasera"
+    },
+    "imageRequest": {
+      "helper": "Haz clic abajo para ayudarnos a priorizar esta imagen.",
+      "button": "Solicitar imagen",
+      "requested": "Imagen solicitada",
+      "toastSubmittedTitle": "Solicitud de imagen enviada",
+      "toastSubmittedDescription": "Gracias por tu interés. Priorizaremos añadir una imagen para este artículo.",
+      "toastAlreadyRequestedTitle": "La solicitud ya existe",
+      "toastFailedTitle": "No se pudo enviar la solicitud",
+      "toastFailedDescription": "Vuelve a intentarlo más tarde."
     },
     "watch": "Ver",
     "fromRespectedCreators": "De creadores respetados",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -197,6 +197,7 @@
     "gearImages": {
       "manageTitle": "Gérer les images du matériel",
       "manageDescription": "Téléversez des images de face, de dessus et de l’arrière pour cet élément de matériel.",
+      "manageDescriptionNoRearView": "Téléversez des images de face et de dessus pour cet élément de matériel.",
       "manageButton": "Gérer les images",
       "frontView": "Vue de face",
       "topView": "Vue de dessus",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -210,8 +210,19 @@
       "deleted": "Supprimé",
       "limits": "Téléversez des images avec fond transparent, recadrées au plus près, 1000 px sur le bord le plus long, en .webp à 75 % de qualité.",
       "removeNote": "Remarque : seuls les administrateurs peuvent supprimer des images.",
+      "noImageAvailable": "Aucune image disponible",
       "topViewAlt": "{name} - Vue de dessus",
       "rearViewAlt": "{name} - Vue arrière"
+    },
+    "imageRequest": {
+      "helper": "Cliquez ci-dessous pour nous aider à prioriser cette image.",
+      "button": "Demander une image",
+      "requested": "Image demandée",
+      "toastSubmittedTitle": "Demande d’image envoyée",
+      "toastSubmittedDescription": "Merci pour votre intérêt ! Nous prioriserons l’ajout d’une image pour cet article.",
+      "toastAlreadyRequestedTitle": "La demande existe déjà",
+      "toastFailedTitle": "Échec de l’envoi de la demande",
+      "toastFailedDescription": "Veuillez réessayer plus tard."
     },
     "watch": "Regarder",
     "fromRespectedCreators": "Par des créateurs reconnus",

--- a/messages/it.json
+++ b/messages/it.json
@@ -197,6 +197,7 @@
     "gearImages": {
       "manageTitle": "Gestisci immagini dell’attrezzatura",
       "manageDescription": "Carica immagini della vista frontale, superiore e posteriore per questo elemento dell’attrezzatura.",
+      "manageDescriptionNoRearView": "Carica immagini della vista frontale e superiore per questo elemento dell’attrezzatura.",
       "manageButton": "Gestisci immagini",
       "frontView": "Vista frontale",
       "topView": "Vista dall’alto",

--- a/messages/it.json
+++ b/messages/it.json
@@ -210,8 +210,19 @@
       "deleted": "Eliminata",
       "limits": "Carica immagini con sfondo trasparente, ritaglio stretto, 1000 px sul lato lungo, in .webp al 75% di qualità.",
       "removeNote": "Nota: solo gli amministratori possono rimuovere le immagini.",
+      "noImageAvailable": "Nessuna immagine disponibile",
       "topViewAlt": "{name} - Vista dall’alto",
       "rearViewAlt": "{name} - Vista posteriore"
+    },
+    "imageRequest": {
+      "helper": "Fai clic qui sotto per aiutarci a dare priorità a questa immagine.",
+      "button": "Richiedi immagine",
+      "requested": "Immagine richiesta",
+      "toastSubmittedTitle": "Richiesta immagine inviata",
+      "toastSubmittedDescription": "Grazie per il tuo interesse! Daremo priorità all’aggiunta di un’immagine per questo articolo.",
+      "toastAlreadyRequestedTitle": "La richiesta esiste già",
+      "toastFailedTitle": "Invio della richiesta non riuscito",
+      "toastFailedDescription": "Riprova più tardi."
     },
     "watch": "Guarda",
     "fromRespectedCreators": "Da creator autorevoli",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -210,8 +210,19 @@
       "deleted": "削除済み",
       "limits": "背景が透過で、被写体に合わせてタイトにトリミングされ、長辺1000px、品質75%の .webp 画像をアップロードしてください。",
       "removeNote": "注: 画像を削除できるのは管理者のみです。",
+      "noImageAvailable": "画像はありません",
       "topViewAlt": "{name} - 上面",
       "rearViewAlt": "{name} - 背面"
+    },
+    "imageRequest": {
+      "helper": "この画像を優先して追加できるよう、下のボタンでご協力ください。",
+      "button": "画像をリクエスト",
+      "requested": "画像をリクエスト済み",
+      "toastSubmittedTitle": "画像リクエストを送信しました",
+      "toastSubmittedDescription": "ご関心ありがとうございます。この項目の画像追加を優先します。",
+      "toastAlreadyRequestedTitle": "リクエストは既に存在します",
+      "toastFailedTitle": "リクエストを送信できませんでした",
+      "toastFailedDescription": "しばらくしてからもう一度お試しください。"
     },
     "watch": "見る",
     "fromRespectedCreators": "信頼できるクリエイターより",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -197,6 +197,7 @@
     "gearImages": {
       "manageTitle": "機材画像を管理",
       "manageDescription": "この機材の正面、上面、背面の画像をアップロードします。",
+      "manageDescriptionNoRearView": "この機材の正面と上面の画像をアップロードします。",
       "manageButton": "画像を管理",
       "frontView": "正面",
       "topView": "上面",

--- a/messages/ms.json
+++ b/messages/ms.json
@@ -210,8 +210,19 @@
       "deleted": "Dipadam",
       "limits": "Muat naik imej dengan latar belakang lutsinar, dipotong rapat, 1000px pada sisi terpanjang, dalam format .webp pada kualiti 75%.",
       "removeNote": "Nota: Hanya pentadbir boleh memadam imej.",
+      "noImageAvailable": "Tiada imej tersedia",
       "topViewAlt": "{name} - Pandangan Atas",
       "rearViewAlt": "{name} - Pandangan Belakang"
+    },
+    "imageRequest": {
+      "helper": "Klik di bawah untuk membantu kami mengutamakan imej ini.",
+      "button": "Minta Imej",
+      "requested": "Imej Diminta",
+      "toastSubmittedTitle": "Permintaan imej dihantar",
+      "toastSubmittedDescription": "Terima kasih atas minat anda! Kami akan mengutamakan penambahan imej untuk item ini.",
+      "toastAlreadyRequestedTitle": "Permintaan sudah wujud",
+      "toastFailedTitle": "Gagal menghantar permintaan",
+      "toastFailedDescription": "Sila cuba lagi kemudian."
     },
     "watch": "Tonton",
     "fromRespectedCreators": "Daripada Pencipta Yang Dihormati",

--- a/messages/ms.json
+++ b/messages/ms.json
@@ -197,6 +197,7 @@
     "gearImages": {
       "manageTitle": "Urus Imej Peralatan",
       "manageDescription": "Muat naik imej pandangan hadapan, atas dan belakang untuk item peralatan ini.",
+      "manageDescriptionNoRearView": "Muat naik imej pandangan hadapan dan atas untuk item peralatan ini.",
       "manageButton": "Urus Imej",
       "frontView": "Pandangan Hadapan",
       "topView": "Pandangan Atas",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -210,8 +210,19 @@
       "deleted": "已删除",
       "limits": "请上传透明背景、紧密裁切、长边 1000px、质量 75% 的 .webp 图片。",
       "removeNote": "注意：只有管理员可以删除图片。",
+      "noImageAvailable": "无可用图像",
       "topViewAlt": "{name} - 顶部图",
       "rearViewAlt": "{name} - 背面图"
+    },
+    "imageRequest": {
+      "helper": "点击下方帮助我们优先处理这张图片。",
+      "button": "请求图片",
+      "requested": "已请求图片",
+      "toastSubmittedTitle": "图片请求已提交",
+      "toastSubmittedDescription": "感谢你的关注！我们会优先为该条目添加图片。",
+      "toastAlreadyRequestedTitle": "请求已存在",
+      "toastFailedTitle": "提交请求失败",
+      "toastFailedDescription": "请稍后再试。"
     },
     "watch": "手表",
     "fromRespectedCreators": "来自尊敬的创作者",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -197,6 +197,7 @@
     "gearImages": {
       "manageTitle": "管理器材图片",
       "manageDescription": "为这件器材上传正面图、顶部图和背面图。",
+      "manageDescriptionNoRearView": "为这件器材上传正面图和顶部图。",
       "manageButton": "管理图片",
       "frontView": "正面图",
       "topView": "顶部图",

--- a/src/app/[locale]/(admin)/admin/gear-proposals-list.helpers.ts
+++ b/src/app/[locale]/(admin)/admin/gear-proposals-list.helpers.ts
@@ -135,10 +135,10 @@ export function flattenProposalGroups(groups: ProposalGroupDto[]): GearProposal[
 
 export function formatBooleanProposalValue(
   value: unknown,
-  t: (key: string) => string,
+  labels: { yes: string; no: string },
 ): string | null {
   if (typeof value !== "boolean") return null;
-  return value ? t("yes") : t("no");
+  return value ? labels.yes : labels.no;
 }
 
 export function groupGearProposals(proposals: GearProposal[]): ProposalGroup[] {

--- a/src/app/[locale]/(admin)/admin/gear-proposals-list.tsx
+++ b/src/app/[locale]/(admin)/admin/gear-proposals-list.tsx
@@ -26,6 +26,7 @@ import {
   formatAutoApprovalDecisionForAdmin,
   getAutoApprovalDecisionFromMetadata,
 } from "~/lib/gear/auto-approval-reasons";
+import { translateGearDetailWithFallback } from "~/lib/i18n/gear-detail";
 import {
   formatCardSlotDetails,
   formatPrecaptureSupport,
@@ -62,7 +63,19 @@ type ResolvedResponse = {
 
 export function GearProposalsList() {
   const locale = useLocale();
-  const tCommon = useTranslations("common");
+  const tGearDetail = useTranslations("gearDetail");
+  const booleanLabels = {
+    yes: translateGearDetailWithFallback(
+      tGearDetail,
+      "specRegistry.shared.yes",
+      "Yes",
+    ),
+    no: translateGearDetailWithFallback(
+      tGearDetail,
+      "specRegistry.shared.no",
+      "No",
+    ),
+  };
   const [proposals, setProposals] = useState<GearProposal[]>([]);
   const formatDisplayDate = (value: unknown) =>
     formatDate(value as string | Date | number | null | undefined, {
@@ -187,7 +200,7 @@ export function GearProposalsList() {
   const formatValueForKey = (k: string, v: any): string => {
     const isEmpty = v === null || v === undefined || v === "";
     if (isEmpty) return "Empty";
-    const booleanDisplay = formatBooleanProposalValue(v, tCommon);
+    const booleanDisplay = formatBooleanProposalValue(v, booleanLabels);
     if (booleanDisplay) return booleanDisplay;
     if (
       k === "msrpUsdCents" ||
@@ -210,7 +223,7 @@ export function GearProposalsList() {
     return String(v);
   };
   const formatBeforeValueForKey = (k: string, v: any): string => {
-    const booleanDisplay = formatBooleanProposalValue(v, tCommon);
+    const booleanDisplay = formatBooleanProposalValue(v, booleanLabels);
     if (booleanDisplay) return booleanDisplay;
     if (
       k === "msrpUsdCents" ||

--- a/src/app/[locale]/(admin)/admin/gear/columns.tsx
+++ b/src/app/[locale]/(admin)/admin/gear/columns.tsx
@@ -131,6 +131,7 @@ function GearActionsCell({ row }: { row: { original: AdminGearTableRow } }) {
 
       <GearImageModal
         gearId={row.original.id}
+        gearType={row.original.gearType}
         currentThumbnailUrl={row.original.thumbnailUrl ?? undefined}
         currentTopViewUrl={row.original.topViewUrl ?? undefined}
         currentRearViewUrl={row.original.rearViewUrl ?? undefined}

--- a/src/app/[locale]/(pages)/gear/[slug]/page.tsx
+++ b/src/app/[locale]/(pages)/gear/[slug]/page.tsx
@@ -358,6 +358,7 @@ export default async function GearPage({ params }: GearPageProps) {
         <div>
           <GearImageCarousel
             name={item.name}
+            gearType={item.gearType}
             regionalAliases={item.regionalAliases}
             thumbnailUrl={item.thumbnailUrl}
             topViewUrl={item.topViewUrl}

--- a/src/app/[locale]/(pages)/gear/_components/edit-gear/edit-gear-form.tsx
+++ b/src/app/[locale]/(pages)/gear/_components/edit-gear/edit-gear-form.tsx
@@ -203,9 +203,12 @@ function EditGearForm({
 }: EditGearFormProps) {
   const locale = useLocale();
   const t = useTranslations("gearDetail");
-  const tCommon = useTranslations("common");
   const tf = (key: string, fallback: string, values?: TranslationValues) =>
     translateGearDetailWithFallback(t, key, fallback, values);
+  const booleanLabels = {
+    yes: tf("specRegistry.shared.yes", "Yes"),
+    no: tf("specRegistry.shared.no", "No"),
+  };
   const router = useRouter();
   const [internalAutoSubmit, setInternalAutoSubmit] = useState(
     Boolean(canToggleAutoSubmit),
@@ -1287,7 +1290,10 @@ function EditGearForm({
                       <ul className="list-disc pl-5">
                         {Object.entries(diffPreview.core).map(([k, v]) => {
                           let display = safeString(v);
-                          const booleanDisplay = formatBooleanText(v, tCommon);
+                          const booleanDisplay = formatBooleanText(
+                            v,
+                            booleanLabels,
+                          );
                           if (booleanDisplay) display = booleanDisplay;
                           if (
                             k === "msrpNowUsdCents" ||
@@ -1337,7 +1343,10 @@ function EditGearForm({
                         {Object.entries(diffPreview.analogCamera).map(
                           ([k, v]) => {
                           let display = safeString(v);
-                          const booleanDisplay = formatBooleanText(v, tCommon);
+                          const booleanDisplay = formatBooleanText(
+                            v,
+                            booleanLabels,
+                          );
                           if (booleanDisplay) display = booleanDisplay;
                           return (
                           <li key={k}>
@@ -1375,7 +1384,10 @@ function EditGearForm({
                         {Object.entries(diffPreview.camera).map(([k, v]) => {
                           if (k === "availableShutterTypes") return null;
                           let display = safeString(v);
-                          const booleanDisplay = formatBooleanText(v, tCommon);
+                          const booleanDisplay = formatBooleanText(
+                            v,
+                            booleanLabels,
+                          );
                           if (booleanDisplay) display = booleanDisplay;
                           if (k === "sensorFormatId")
                             display = sensorNameFromSlug(v as string);
@@ -1408,7 +1420,10 @@ function EditGearForm({
                       <ul className="list-disc pl-5">
                         {Object.entries(diffPreview.lens).map(([k, v]) => {
                           let display = safeString(v);
-                          const booleanDisplay = formatBooleanText(v, tCommon);
+                          const booleanDisplay = formatBooleanText(
+                            v,
+                            booleanLabels,
+                          );
                           if (booleanDisplay) display = booleanDisplay;
                           return (
                           <li key={k}>
@@ -1430,7 +1445,10 @@ function EditGearForm({
                       <ul className="list-disc pl-5">
                         {Object.entries(diffPreview.fixedLens).map(([k, v]) => {
                           let display = safeString(v);
-                          const booleanDisplay = formatBooleanText(v, tCommon);
+                          const booleanDisplay = formatBooleanText(
+                            v,
+                            booleanLabels,
+                          );
                           if (booleanDisplay) display = booleanDisplay;
                           return (
                           <li key={k}>

--- a/src/app/[locale]/(pages)/gear/_components/edit-gear/edit-gear-formatters.ts
+++ b/src/app/[locale]/(pages)/gear/_components/edit-gear/edit-gear-formatters.ts
@@ -1,7 +1,7 @@
 export function formatBooleanText(
   value: unknown,
-  t: (key: string) => string,
+  labels: { yes: string; no: string },
 ): string | null {
   if (typeof value !== "boolean") return null;
-  return value ? t("yes") : t("no");
+  return value ? labels.yes : labels.no;
 }

--- a/src/app/[locale]/(pages)/gear/_components/gear-image-carousel.tsx
+++ b/src/app/[locale]/(pages)/gear/_components/gear-image-carousel.tsx
@@ -10,11 +10,12 @@ import {
   CarouselPrevious,
 } from "~/components/ui/carousel";
 import { GetGearDisplayName } from "~/lib/gear/naming";
-import type { GearAlias } from "~/types/gear";
+import type { GearAlias,GearType } from "~/types/gear";
 import { RequestImageButton } from "./request-image-button";
 
 interface GearImageCarouselProps {
   name: string;
+  gearType: GearType;
   regionalAliases?: GearAlias[] | null;
   thumbnailUrl: string | null;
   topViewUrl: string | null;
@@ -25,6 +26,7 @@ interface GearImageCarouselProps {
 
 export function GearImageCarousel({
   name,
+  gearType,
   regionalAliases,
   thumbnailUrl,
   topViewUrl,
@@ -35,7 +37,10 @@ export function GearImageCarousel({
   const t = useTranslations("gearDetail");
   const gearImagesT = useTranslations("gearDetail.gearImages");
   const displayName = GetGearDisplayName({ name, regionalAliases });
-  const imageCount = [thumbnailUrl, topViewUrl, rearViewUrl].filter(
+  const supportsRearView =
+    gearType === "CAMERA" || gearType === "ANALOG_CAMERA";
+  const effectiveRearViewUrl = supportsRearView ? rearViewUrl : null;
+  const imageCount = [thumbnailUrl, topViewUrl, effectiveRearViewUrl].filter(
     Boolean,
   ).length;
 
@@ -81,11 +86,11 @@ export function GearImageCarousel({
               </div>
             </CarouselItem>
           )}
-          {rearViewUrl && (
+          {effectiveRearViewUrl && (
             <CarouselItem>
               <div className="bg-muted dark:bg-card flex h-[300px] items-center justify-center overflow-hidden rounded-md p-8 sm:h-[600px] sm:p-12">
                 <Image
-                  src={rearViewUrl}
+                  src={effectiveRearViewUrl}
                   alt={gearImagesT("rearViewAlt", { name: displayName })}
                   className="h-full w-full max-w-[600px] object-contain"
                   width={720}

--- a/src/app/[locale]/(pages)/gear/_components/gear-image-carousel.tsx
+++ b/src/app/[locale]/(pages)/gear/_components/gear-image-carousel.tsx
@@ -10,7 +10,7 @@ import {
   CarouselPrevious,
 } from "~/components/ui/carousel";
 import { GetGearDisplayName } from "~/lib/gear/naming";
-import type { GearAlias,GearType } from "~/types/gear";
+import type { GearAlias, GearType } from "~/types/gear";
 import { RequestImageButton } from "./request-image-button";
 
 interface GearImageCarouselProps {
@@ -34,7 +34,6 @@ export function GearImageCarousel({
   slug,
   hasImageRequest,
 }: GearImageCarouselProps) {
-  const t = useTranslations("gearDetail");
   const gearImagesT = useTranslations("gearDetail.gearImages");
   const displayName = GetGearDisplayName({ name, regionalAliases });
   const supportsRearView =
@@ -48,7 +47,7 @@ export function GearImageCarousel({
     return (
       <div className="bg-muted dark:bg-card flex aspect-video flex-col items-center justify-center gap-1 rounded-md">
         <span className="text-muted-foreground text-lg">
-          {t("noImageAvailable")}
+          {gearImagesT("noImageAvailable")}
         </span>
         <RequestImageButton slug={slug} initialHasRequested={hasImageRequest} />
       </div>

--- a/src/app/[locale]/(pages)/gear/_components/request-image-button-state.ts
+++ b/src/app/[locale]/(pages)/gear/_components/request-image-button-state.ts
@@ -1,0 +1,58 @@
+export interface ResolveRequestImageButtonStateInput {
+  initialHasRequested: boolean | null;
+  hydratedHasRequested?: boolean | null;
+  hasHydrationError: boolean;
+  optimisticHasRequested: boolean | null;
+}
+
+export interface RequestImageButtonRenderState {
+  hasRequested: boolean;
+  shouldRender: boolean;
+  shouldShowHelper: boolean;
+}
+
+export function resolveRequestImageButtonState({
+  initialHasRequested,
+  hydratedHasRequested,
+  hasHydrationError,
+  optimisticHasRequested,
+}: ResolveRequestImageButtonStateInput): RequestImageButtonRenderState {
+  const resolvedHasRequested =
+    optimisticHasRequested ??
+    initialHasRequested ??
+    (typeof hydratedHasRequested === "boolean" ? hydratedHasRequested : null);
+
+  if (typeof resolvedHasRequested !== "boolean") {
+    return {
+      hasRequested: false,
+      shouldRender: false,
+      shouldShowHelper: false,
+    };
+  }
+
+  if (
+    initialHasRequested === null &&
+    optimisticHasRequested === null &&
+    typeof hydratedHasRequested !== "boolean"
+  ) {
+    return {
+      hasRequested: false,
+      shouldRender: false,
+      shouldShowHelper: false,
+    };
+  }
+
+  if (initialHasRequested === null && hasHydrationError) {
+    return {
+      hasRequested: false,
+      shouldRender: false,
+      shouldShowHelper: false,
+    };
+  }
+
+  return {
+    hasRequested: resolvedHasRequested,
+    shouldRender: true,
+    shouldShowHelper: !resolvedHasRequested,
+  };
+}

--- a/src/app/[locale]/(pages)/gear/_components/request-image-button.tsx
+++ b/src/app/[locale]/(pages)/gear/_components/request-image-button.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { Check,ImagePlus } from "lucide-react";
-import { useEffect,useState } from "react";
+import { Check, ImagePlus } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
 import { toast } from "sonner";
 import useSWR from "swr";
 import { Button } from "~/components/ui/button";
 import { fetchJson } from "~/lib/fetch-json";
 import { actionToggleImageRequest } from "~/server/gear/actions";
+import { resolveRequestImageButtonState } from "./request-image-button-state";
 
 interface RequestImageButtonProps {
   slug: string;
@@ -17,9 +19,10 @@ export function RequestImageButton({
   slug,
   initialHasRequested,
 }: RequestImageButtonProps) {
-  const [hasRequested, setHasRequested] = useState(
-    initialHasRequested ?? false,
-  );
+  const t = useTranslations("gearDetail.imageRequest");
+  const [optimisticHasRequested, setOptimisticHasRequested] = useState<
+    boolean | null
+  >(null);
   const [isLoading, setIsLoading] = useState(false);
   const shouldHydrateRequestState = initialHasRequested === null;
   const { data: requestStateData, error: requestStateError } = useSWR<{
@@ -41,23 +44,15 @@ export function RequestImageButton({
       shouldRetryOnError: false,
     },
   );
-
-  useEffect(() => {
-    if (typeof requestStateData?.hasImageRequest === "boolean") {
-      setHasRequested(requestStateData.hasImageRequest);
-    }
-  }, [requestStateData?.hasImageRequest]);
-
-  const isHydrationCheckDone =
-    !shouldHydrateRequestState ||
-    requestStateData !== undefined ||
-    Boolean(requestStateError);
-  const canRequestImage =
-    !shouldHydrateRequestState ||
-    typeof requestStateData?.hasImageRequest === "boolean";
+  const renderState = resolveRequestImageButtonState({
+    initialHasRequested,
+    hydratedHasRequested: requestStateData?.hasImageRequest,
+    hasHydrationError: Boolean(requestStateError),
+    optimisticHasRequested,
+  });
 
   const handleToggle = async () => {
-    if (hasRequested) {
+    if (renderState.hasRequested) {
       return;
     }
     setIsLoading(true);
@@ -65,60 +60,53 @@ export function RequestImageButton({
       const result = await actionToggleImageRequest(slug, "add");
 
       if (result.ok && result.action === "added") {
-        setHasRequested(true);
-        toast.success("Image request submitted", {
-          description:
-            "Thanks for your interest! We'll prioritize adding an image for this item.",
+        setOptimisticHasRequested(true);
+        toast.success(t("toastSubmittedTitle"), {
+          description: t("toastSubmittedDescription"),
         });
       } else if (!result.ok && result.reason === "already_requested") {
-        setHasRequested(true);
-        toast.error("Request already exists");
+        setOptimisticHasRequested(true);
+        toast.error(t("toastAlreadyRequestedTitle"));
       } else {
-        toast.error("Failed to submit request", {
-          description: "Please try again later.",
+        toast.error(t("toastFailedTitle"), {
+          description: t("toastFailedDescription"),
         });
       }
     } catch (error) {
       console.error("Failed to toggle image request:", error);
-      toast.error("Failed to submit request", {
-        description: "Please try again later.",
+      toast.error(t("toastFailedTitle"), {
+        description: t("toastFailedDescription"),
       });
     } finally {
       setIsLoading(false);
     }
   };
 
-  // Keep the control hidden until we know whether the viewer is authenticated.
-  if (!isHydrationCheckDone) {
-    return null;
-  }
-  if (!canRequestImage) {
+  if (!renderState.shouldRender) {
     return null;
   }
 
   return (
     <div className="flex flex-col gap-6">
-      {!hasRequested && (
-        <span className="text-muted-foreground text-sm">
-          Click below to help us prioritize this image!
-        </span>
+      {renderState.shouldShowHelper && (
+        <span className="text-muted-foreground text-sm">{t("helper")}</span>
       )}
 
       <Button
         onClick={handleToggle}
         loading={isLoading}
-        variant={hasRequested ? "outline" : "default"}
-        disabled={hasRequested}
+        variant={renderState.hasRequested ? "outline" : "default"}
+        disabled={renderState.hasRequested}
         size="sm"
         icon={
-          hasRequested ? (
+          renderState.hasRequested ? (
             <Check className="h-4 w-4" />
           ) : (
             <ImagePlus className="h-4 w-4" />
           )
         }
       >
-        {hasRequested ? "Image Requested" : "Request Image"}
+        {renderState.hasRequested ? t("requested") : t("button")}
       </Button>
     </div>
   );

--- a/src/components/gear/gear-tools-dock/dock-buttons.tsx
+++ b/src/components/gear/gear-tools-dock/dock-buttons.tsx
@@ -33,7 +33,7 @@ import { requireRole } from "~/lib/auth/auth-helpers";
 import { formatDate } from "~/lib/format/date";
 import { UploadDropzone } from "~/lib/utils/uploadthing";
 import type { GearAlternativeRow } from "~/server/gear/service";
-import type { RawSample } from "~/types/gear";
+import type { GearType,RawSample } from "~/types/gear";
 
 type DockSample = Omit<RawSample, "createdAt" | "updatedAt"> & {
   createdAt?: string | null;
@@ -49,7 +49,7 @@ export type DockButtonConfig = {
 export interface BuildDockButtonsParams {
   slug: string;
   gearId?: string;
-  gearType: string;
+  gearType: GearType;
   currentThumbnailUrl?: string | null;
   currentTopViewUrl?: string | null;
   currentRearViewUrl?: string | null;
@@ -112,6 +112,7 @@ export function buildDockButtons({
         <Tooltip key="images">
           <GearImageModal
             slug={slug}
+            gearType={gearType}
             currentThumbnailUrl={currentThumbnailUrl ?? undefined}
             currentTopViewUrl={currentTopViewUrl ?? undefined}
             currentRearViewUrl={currentRearViewUrl ?? undefined}

--- a/src/components/gear/gear-tools-dock/gear-item-dock.client.tsx
+++ b/src/components/gear/gear-tools-dock/gear-item-dock.client.tsx
@@ -15,13 +15,13 @@ import {
   actionRemoveGearRawSample,
 } from "~/server/gear/actions";
 import type { GearAlternativeRow } from "~/server/gear/service";
-import type { RawSample } from "~/types/gear";
+import type { GearType,RawSample } from "~/types/gear";
 import { buildDockButtons } from "./dock-buttons";
 
 interface GearItemDockClientProps {
   slug: string;
   gearId?: string;
-  gearType: string;
+  gearType: GearType;
   currentThumbnailUrl?: string | null;
   currentTopViewUrl?: string | null;
   currentRearViewUrl?: string | null;

--- a/src/components/gear/gear-tools-dock/gear-item-dock.tsx
+++ b/src/components/gear/gear-tools-dock/gear-item-dock.tsx
@@ -4,7 +4,7 @@
 import dynamic from "next/dynamic";
 
 import type { GearAlternativeRow } from "~/server/gear/service";
-import type { RawSample } from "~/types/gear";
+import type { GearType,RawSample } from "~/types/gear";
 
 const GearItemDockClient = dynamic(
   () => import("./gear-item-dock.client").then((mod) => mod.GearItemDockClient),
@@ -14,7 +14,7 @@ const GearItemDockClient = dynamic(
 export interface GearItemDockProps {
   slug: string;
   gearId?: string;
-  gearType: string;
+  gearType: GearType;
   currentThumbnailUrl?: string | null;
   currentTopViewUrl?: string | null;
   currentRearViewUrl?: string | null;

--- a/src/components/modals/gear-image-modal.tsx
+++ b/src/components/modals/gear-image-modal.tsx
@@ -19,6 +19,7 @@ import {
 import { Progress } from "~/components/ui/progress";
 import { useSession } from "~/lib/auth/auth-client";
 import { requireRole } from "~/lib/auth/auth-helpers";
+import type { GearType } from "~/types/gear";
 import {
   actionClearGearRearView,
   actionClearGearThumbnail,
@@ -31,6 +32,7 @@ import {
 export interface GearImageModalProps {
   gearId?: string;
   slug?: string;
+  gearType: GearType;
   trigger?: React.ReactNode;
   onSuccess?: (params: { url: string }) => void;
   currentThumbnailUrl?: string;
@@ -77,6 +79,8 @@ export function GearImageModal(props: GearImageModalProps) {
   const [localRearViewUrl, setLocalRearViewUrl] = useState<string | undefined>(
     props.currentRearViewUrl ?? undefined,
   );
+  const supportsRearView =
+    props.gearType === "CAMERA" || props.gearType === "ANALOG_CAMERA";
 
   // Sync when parent changes item or current image
   useEffect(() => {
@@ -384,10 +388,18 @@ export function GearImageModal(props: GearImageModalProps) {
       <DialogContent className="sm:max-w-5xl">
         <DialogHeader>
           <DialogTitle>{t("manageTitle")}</DialogTitle>
-          <DialogDescription>{t("manageDescription")}</DialogDescription>
+          <DialogDescription>
+            {supportsRearView
+              ? t("manageDescription")
+              : t("manageDescriptionNoRearView")}
+          </DialogDescription>
         </DialogHeader>
 
-        <div className="grid gap-10 md:grid-cols-3">
+        <div
+          className={`grid gap-10 ${
+            supportsRearView ? "md:grid-cols-3" : "md:grid-cols-2"
+          }`}
+        >
           <ImageSection
             title={t("frontView")}
             imageUrl={localThumbnailUrl}
@@ -400,12 +412,14 @@ export function GearImageModal(props: GearImageModalProps) {
             imageType="topView"
             fileInputRef={topViewFileInputRef}
           />
-          <ImageSection
-            title={t("rearView")}
-            imageUrl={localRearViewUrl}
-            imageType="rearView"
-            fileInputRef={rearViewFileInputRef}
-          />
+          {supportsRearView ? (
+            <ImageSection
+              title={t("rearView")}
+              imageUrl={localRearViewUrl}
+              imageType="rearView"
+              fileInputRef={rearViewFileInputRef}
+            />
+          ) : null}
         </div>
 
         {showProgress && (

--- a/src/server/admin/gear/service.ts
+++ b/src/server/admin/gear/service.ts
@@ -31,6 +31,18 @@ import {
 
 export type { AdminGearTableRow,GearCreationParams } from "./data";
 
+function assertRearViewSupported(gearType: string) {
+  if (gearType === "LENS") {
+    throw Object.assign(
+      new Error("Rear-view images are only supported for cameras"),
+      {
+        status: 400,
+        code: "REAR_VIEW_UNSUPPORTED_GEAR_TYPE",
+      },
+    );
+  }
+}
+
 export async function performFuzzySearchAdmin(params: {
   inputName: string;
   brandName: string;
@@ -411,6 +423,7 @@ export async function setGearRearViewService(params: {
   // Fetch current gear state to determine if this is an upload, replace, or remove
   const { fetchGearMetadataById } = await import("~/server/gear/data");
   const currentGear = await fetchGearMetadataById(gearId);
+  assertRearViewSupported(currentGear.gearType);
   const hadRearView = !!currentGear.rearViewUrl;
 
   const updated = await updateGearRearViewData({ gearId, rearViewUrl });

--- a/tests/unit/admin-gear-rear-view-service.test.ts
+++ b/tests/unit/admin-gear-rear-view-service.test.ts
@@ -70,6 +70,7 @@ describe("rear view gear admin service", () => {
 
   it("uploads a rear view, clears image requests, and records contribution metadata", async () => {
     gearDataMocks.fetchGearMetadataById.mockResolvedValue({
+      gearType: "CAMERA",
       rearViewUrl: null,
     });
     adminGearDataMocks.updateGearRearViewData.mockResolvedValue({
@@ -117,6 +118,7 @@ describe("rear view gear admin service", () => {
 
   it("records rear view replacements distinctly from first uploads", async () => {
     gearDataMocks.fetchGearMetadataById.mockResolvedValue({
+      gearType: "CAMERA",
       rearViewUrl: "https://cdn.example.com/old-rear.webp",
     });
     adminGearDataMocks.updateGearRearViewData.mockResolvedValue({
@@ -148,6 +150,7 @@ describe("rear view gear admin service", () => {
       user: { id: "admin-1", role: "ADMIN" },
     });
     gearDataMocks.fetchGearMetadataById.mockResolvedValue({
+      gearType: "CAMERA",
       rearViewUrl: "https://cdn.example.com/old-rear.webp",
     });
     adminGearDataMocks.updateGearRearViewData.mockResolvedValue({
@@ -185,5 +188,50 @@ describe("rear view gear admin service", () => {
     ).rejects.toMatchObject({ message: "Unauthorized", status: 401 });
     expect(adminGearDataMocks.updateGearRearViewData).not.toHaveBeenCalled();
     expect(dbState.insertedValues).toHaveLength(0);
+  });
+
+  it("rejects rear views for lenses", async () => {
+    gearDataMocks.fetchGearMetadataById.mockResolvedValue({
+      gearType: "LENS",
+      rearViewUrl: null,
+    });
+
+    await expect(
+      setGearRearViewService({
+        gearId: "gear-1",
+        rearViewUrl: "https://cdn.example.com/rear.webp",
+      }),
+    ).rejects.toMatchObject({
+      message: "Rear-view images are only supported for cameras",
+      status: 400,
+      code: "REAR_VIEW_UNSUPPORTED_GEAR_TYPE",
+    });
+
+    expect(adminGearDataMocks.updateGearRearViewData).not.toHaveBeenCalled();
+    expect(gearDataMocks.clearImageRequestsForGear).not.toHaveBeenCalled();
+    expect(dbState.insertedValues).toHaveLength(0);
+  });
+
+  it("allows rear views for analog cameras", async () => {
+    gearDataMocks.fetchGearMetadataById.mockResolvedValue({
+      gearType: "ANALOG_CAMERA",
+      rearViewUrl: null,
+    });
+    adminGearDataMocks.updateGearRearViewData.mockResolvedValue({
+      id: "gear-1",
+      slug: "nikon-f3",
+      rearViewUrl: "https://cdn.example.com/rear.webp",
+    });
+
+    const result = await setGearRearViewService({
+      gearId: "gear-1",
+      rearViewUrl: "https://cdn.example.com/rear.webp",
+    });
+
+    expect(result).toMatchObject({
+      slug: "nikon-f3",
+      rearViewUrl: "https://cdn.example.com/rear.webp",
+    });
+    expect(adminGearDataMocks.updateGearRearViewData).toHaveBeenCalled();
   });
 });

--- a/tests/unit/edit-gear-form-formatters.test.ts
+++ b/tests/unit/edit-gear-form-formatters.test.ts
@@ -4,16 +4,16 @@ import { formatBooleanText } from "~/app/[locale]/(pages)/gear/_components/edit-
 
 describe("formatBooleanText", () => {
   it("returns translated labels for boolean values", () => {
-    const t = (key: string) => `common.${key}`;
+    const labels = { yes: "Oui", no: "Non" };
 
-    expect(formatBooleanText(true, t)).toBe("common.yes");
-    expect(formatBooleanText(false, t)).toBe("common.no");
+    expect(formatBooleanText(true, labels)).toBe("Oui");
+    expect(formatBooleanText(false, labels)).toBe("Non");
   });
 
   it("returns null for non-boolean values", () => {
-    const t = (key: string) => `common.${key}`;
+    const labels = { yes: "Ja", no: "Nein" };
 
-    expect(formatBooleanText(null, t)).toBeNull();
-    expect(formatBooleanText("true", t)).toBeNull();
+    expect(formatBooleanText(null, labels)).toBeNull();
+    expect(formatBooleanText("true", labels)).toBeNull();
   });
 });

--- a/tests/unit/gear-detail-translations.test.ts
+++ b/tests/unit/gear-detail-translations.test.ts
@@ -58,6 +58,8 @@ describe("gear detail heading translations", () => {
       "editGear.fields.analogBatteryPlaceholder",
       "editGear.fields.bestUseCases",
       "editGear.notes.add",
+      "specRegistry.shared.yes",
+      "specRegistry.shared.no",
       "reviewGenres.weddings",
       "reviewGenres.video",
       "reviewGenres.architecture",
@@ -70,6 +72,8 @@ describe("gear detail heading translations", () => {
       alternatives: "Alternatives",
     });
     expect(getPathValue(enMessages, "editGear.title")).toBe("Edit Gear Item");
+    expect(getPathValue(enMessages, "specRegistry.shared.yes")).toBe("Yes");
+    expect(getPathValue(enMessages, "specRegistry.shared.no")).toBe("No");
     expect(getPathValue(enMessages, "reviewGenres.weddings")).toBe("Weddings");
 
     const locales = [

--- a/tests/unit/gear-image-carousel.test.ts
+++ b/tests/unit/gear-image-carousel.test.ts
@@ -45,6 +45,7 @@ function renderCarousel(
         timeZone: "America/New_York",
         children: React.createElement(GearImageCarousel, {
           name: "Nikon Zf",
+          gearType: "CAMERA",
           thumbnailUrl: null,
           topViewUrl: null,
           rearViewUrl: null,
@@ -65,6 +66,20 @@ describe("GearImageCarousel", () => {
 
     expect(markup).toContain("https://cdn.example.com/rear.webp");
     expect(markup).toContain("Nikon Zf - Rear View");
+    expect(markup).not.toContain("data-testid=\"carousel-previous\"");
+    expect(markup).not.toContain("data-testid=\"carousel-next\"");
+  });
+
+  it("ignores rear view for lenses", () => {
+    const markup = renderCarousel({
+      gearType: "LENS",
+      thumbnailUrl: "https://cdn.example.com/front.webp",
+      rearViewUrl: "https://cdn.example.com/rear.webp",
+    });
+
+    expect(markup).toContain("https://cdn.example.com/front.webp");
+    expect(markup).not.toContain("https://cdn.example.com/rear.webp");
+    expect(markup).not.toContain("Rear View");
     expect(markup).not.toContain("data-testid=\"carousel-previous\"");
     expect(markup).not.toContain("data-testid=\"carousel-next\"");
   });

--- a/tests/unit/gear-image-carousel.test.ts
+++ b/tests/unit/gear-image-carousel.test.ts
@@ -1,7 +1,7 @@
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { NextIntlClientProvider } from "next-intl";
-import { describe,expect,it,vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import messages from "../../messages/en.json";
 import { GearImageCarousel } from "../../src/app/[locale]/(pages)/gear/_components/gear-image-carousel";
@@ -37,28 +37,42 @@ function renderCarousel(
   props: Partial<React.ComponentProps<typeof GearImageCarousel>> = {},
 ) {
   return renderToStaticMarkup(
-    React.createElement(
-      NextIntlClientProvider,
-      {
-        locale: "en",
-        messages,
-        timeZone: "America/New_York",
-        children: React.createElement(GearImageCarousel, {
-          name: "Nikon Zf",
-          gearType: "CAMERA",
-          thumbnailUrl: null,
-          topViewUrl: null,
-          rearViewUrl: null,
-          slug: "nikon-zf",
-          hasImageRequest: false,
-          ...props,
-        }),
-      },
-    ),
+    React.createElement(NextIntlClientProvider, {
+      locale: "en",
+      messages,
+      timeZone: "America/New_York",
+      children: React.createElement(GearImageCarousel, {
+        name: "Nikon Zf",
+        gearType: "CAMERA",
+        thumbnailUrl: null,
+        topViewUrl: null,
+        rearViewUrl: null,
+        slug: "nikon-zf",
+        hasImageRequest: false,
+        ...props,
+      }),
+    }),
   );
 }
 
 describe("GearImageCarousel", () => {
+  it("renders the no-image label from the gear images namespace", () => {
+    const markup = renderCarousel();
+
+    expect(markup).toContain("No image available");
+  });
+
+  it("keeps the request image control hidden during initial hydration", () => {
+    const markup = renderCarousel({
+      hasImageRequest: null,
+    });
+
+    expect(markup).not.toContain("Request Image");
+    expect(markup).not.toContain(
+      "Click below to help us prioritize this image!",
+    );
+  });
+
   it("renders the rear view when it is the only available image", () => {
     const markup = renderCarousel({
       rearViewUrl: "https://cdn.example.com/rear.webp",
@@ -66,8 +80,8 @@ describe("GearImageCarousel", () => {
 
     expect(markup).toContain("https://cdn.example.com/rear.webp");
     expect(markup).toContain("Nikon Zf - Rear View");
-    expect(markup).not.toContain("data-testid=\"carousel-previous\"");
-    expect(markup).not.toContain("data-testid=\"carousel-next\"");
+    expect(markup).not.toContain('data-testid="carousel-previous"');
+    expect(markup).not.toContain('data-testid="carousel-next"');
   });
 
   it("ignores rear view for lenses", () => {
@@ -80,8 +94,8 @@ describe("GearImageCarousel", () => {
     expect(markup).toContain("https://cdn.example.com/front.webp");
     expect(markup).not.toContain("https://cdn.example.com/rear.webp");
     expect(markup).not.toContain("Rear View");
-    expect(markup).not.toContain("data-testid=\"carousel-previous\"");
-    expect(markup).not.toContain("data-testid=\"carousel-next\"");
+    expect(markup).not.toContain('data-testid="carousel-previous"');
+    expect(markup).not.toContain('data-testid="carousel-next"');
   });
 
   it("renders front, top, and rear images in order", () => {
@@ -106,7 +120,7 @@ describe("GearImageCarousel", () => {
       rearViewUrl: "https://cdn.example.com/rear.webp",
     });
 
-    expect(markup).toContain("data-testid=\"carousel-previous\"");
-    expect(markup).toContain("data-testid=\"carousel-next\"");
+    expect(markup).toContain('data-testid="carousel-previous"');
+    expect(markup).toContain('data-testid="carousel-next"');
   });
 });

--- a/tests/unit/gear-image-modal-wiring.test.ts
+++ b/tests/unit/gear-image-modal-wiring.test.ts
@@ -9,14 +9,19 @@ function read(relativePath: string): string {
 }
 
 describe("GearImageModal rear view wiring", () => {
-  it("threads a third rear-view slot through the modal actions and props", () => {
+  it("keeps rear view camera-only while preserving rear-view wiring", () => {
     const source = read("src/components/modals/gear-image-modal.tsx");
 
+    expect(source).toContain("gearType: GearType;");
     expect(source).toContain("currentRearViewUrl?: string;");
     expect(source).toContain('type ImageType = "thumbnail" | "topView" | "rearView"');
+    expect(source).toContain(
+      'props.gearType === "CAMERA" || props.gearType === "ANALOG_CAMERA"',
+    );
     expect(source).toContain("actionSetGearRearView");
     expect(source).toContain("actionClearGearRearView");
+    expect(source).toContain('t("manageDescriptionNoRearView")');
+    expect(source).toContain("supportsRearView ? (");
     expect(source).toContain('imageType="rearView"');
-    expect(source).toContain('title={t("rearView")}');
   });
 });

--- a/tests/unit/gear-proposals-list-helpers.test.ts
+++ b/tests/unit/gear-proposals-list-helpers.test.ts
@@ -289,10 +289,10 @@ describe("gear proposal helpers", () => {
   });
 
   it("formats boolean proposal values for admin approval surfaces", () => {
-    const t = (key: string) => `common.${key}`;
+    const labels = { yes: "Ja", no: "Nein" };
 
-    expect(formatBooleanProposalValue(true, t)).toBe("common.yes");
-    expect(formatBooleanProposalValue(false, t)).toBe("common.no");
-    expect(formatBooleanProposalValue(null, t)).toBeNull();
+    expect(formatBooleanProposalValue(true, labels)).toBe("Ja");
+    expect(formatBooleanProposalValue(false, labels)).toBe("Nein");
+    expect(formatBooleanProposalValue(null, labels)).toBeNull();
   });
 });

--- a/tests/unit/request-image-button-state.test.ts
+++ b/tests/unit/request-image-button-state.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveRequestImageButtonState } from "~/app/[locale]/(pages)/gear/_components/request-image-button-state";
+
+describe("resolveRequestImageButtonState", () => {
+  it("hides the control while hydration is unresolved", () => {
+    expect(
+      resolveRequestImageButtonState({
+        initialHasRequested: null,
+        hydratedHasRequested: undefined,
+        hasHydrationError: false,
+        optimisticHasRequested: null,
+      }),
+    ).toEqual({
+      hasRequested: false,
+      shouldRender: false,
+      shouldShowHelper: false,
+    });
+  });
+
+  it("shows the request state when hydration resolves false", () => {
+    expect(
+      resolveRequestImageButtonState({
+        initialHasRequested: null,
+        hydratedHasRequested: false,
+        hasHydrationError: false,
+        optimisticHasRequested: null,
+      }),
+    ).toEqual({
+      hasRequested: false,
+      shouldRender: true,
+      shouldShowHelper: true,
+    });
+  });
+
+  it("shows the requested state when hydration resolves true", () => {
+    expect(
+      resolveRequestImageButtonState({
+        initialHasRequested: null,
+        hydratedHasRequested: true,
+        hasHydrationError: false,
+        optimisticHasRequested: null,
+      }),
+    ).toEqual({
+      hasRequested: true,
+      shouldRender: true,
+      shouldShowHelper: false,
+    });
+  });
+
+  it("keeps the control hidden when hydration fails without a known state", () => {
+    expect(
+      resolveRequestImageButtonState({
+        initialHasRequested: null,
+        hydratedHasRequested: null,
+        hasHydrationError: true,
+        optimisticHasRequested: null,
+      }),
+    ).toEqual({
+      hasRequested: false,
+      shouldRender: false,
+      shouldShowHelper: false,
+    });
+  });
+
+  it("prefers the optimistic requested state after submission", () => {
+    expect(
+      resolveRequestImageButtonState({
+        initialHasRequested: null,
+        hydratedHasRequested: false,
+        hasHydrationError: false,
+        optimisticHasRequested: true,
+      }),
+    ).toEqual({
+      hasRequested: true,
+      shouldRender: true,
+      shouldShowHelper: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR tightens the gear image request flow and related admin/edit surfaces.

## Changes

- refines image request button hydration to avoid inconsistent client/server state
- improves image request and gear detail localization across all supported locales
- reuses shared boolean gear detail labels in proposal and edit previews for consistency
- restricts rear-view image support to camera gear only
- updates carousel, modal, and gear tools dock behavior to reflect rear-view image constraints
- adds and updates unit coverage for image request state, rear-view handling, modal wiring, and related translations

## Notes

- documentation was updated for the image request and top-view image flows
- translation parity was maintained across locale message files
