### PR TITLE
Add optional US regional gear names

### DIFF
--- a/docs/camera-specs/regional-naming-system.md
+++ b/docs/camera-specs/regional-naming-system.md
@@ -1,29 +1,29 @@
 ## Regional Naming System
 
-Sharply now maintains a single canonical gear record while also surfacing regional aliases for EU and Japan (plus automatic locale-aware fallbacks) in every layer that touches gear naming.
+Sharply maintains a single canonical gear record while also surfacing optional regional aliases for the United States, Europe, and Japan in every layer that touches gear naming.
 
 ### Schema and search plumbing
 
-- `gear_aliases` (composite PK `gear_id + region`) stores `name` per `GearRegion` (`GLOBAL`, `EU`, `JP`). The alias rows are joined in the core fetchers (`fetchGearBySlug`, browse endpoints, alternatives, popularity/trending queries, comparison data, search results) via the helpers `fetchGearAliasesByGearIds`/`fetchGearAliasesByGearId`.
+- `gear_aliases` (composite PK `gear_id + region`) stores `name` per `GearRegion` (`GLOBAL`, `US`, `EU`, `JP`). The alias rows are joined in the core fetchers (`fetchGearBySlug`, browse endpoints, alternatives, popularity/trending queries, comparison data, search results) via the helpers `fetchGearAliasesByGearIds`/`fetchGearAliasesByGearId`.
 - Display helpers (`GetGearDisplayName`, `buildGearSearchName`, `normalizeGearSearchText`) consume `regionalAliases` so alias names can influence both the rendered label and the normalized search index. Search suggestions and commands now accept `countryCode`/locale to resolve the right alias.
 - Search metadata (`metadata.tsx`, JSON-LD) now uses `GetGearDisplayName`, and rename workflows rebuild `search_name` after alias updates so results stay consistent.
 
 ### Locale tooling & regional routing
 
-- `src/lib/locale/locales.ts` defines the supported locale options (US, UK, EU, DE, FR, ES, IT, CN, MY, JP, Global) with explicit MPB routing config and canonical `gearRegion`. `CountryProvider` stores the locale id, resolves geo headers (including `EU`/`UK` pseudo codes), and exposes `locale`, `localeId`, `countryCode`, and `gearRegion`. The legacy `countryCode` setters now resolve to the locale map.
+- `src/lib/locale/locales.ts` defines the supported locale options (US, UK, EU, DE, FR, ES, IT, CN, MY, JP, Global) with explicit MPB routing config and canonical `gearRegion`. The US locale maps to `US`; the Global locale remains `GLOBAL`. `CountryProvider` stores the locale id, resolves geo headers, and exposes `locale`, `localeId`, `countryCode`, and `gearRegion`.
 - `CountrySelect` consumes this list (minus the Global option) so editors can choose US, UK, EU, or JP — each with consistent labels/flags — while `resolveRegionFromCountryCode` remains tolerant of `EU`/`UK` to keep alias resolution stable.
 - Gear commerce links (`gear/_components/gear-links.tsx`) now pass the locale’s MPB market rather than the raw country code so JP or EU selections go through the right storefront.
 
 ### Editor experience and alias persistence
 
-- The rename modal (`RenameGearDialog`) now includes EU and JP alias inputs alongside the new name field. Input text is automatically prefixed with the brand name (matching the canonical rename behavior). Submissions are allowed even when only aliases change, and the CTA enables whenever there’s any difference vs. the stored alias values.
+- The rename modal (`RenameGearDialog`) includes US, EU, and JP alias inputs alongside the canonical name field. Regional values are complete display names and are trimmed but otherwise stored exactly as entered, so an alias may use a different regional brand such as Rokinon. Canonical renames retain automatic brand prefixing. Submissions are allowed even when only aliases change.
 - Alias edits are saved via `actionUpdateGearAliases` → `updateGearAliasesService`, which filters to allowed regions, performs upserts/deletes, and rebuilds `gear.searchName` using `buildGearSearchName` (re-using brand tokens + alias names). This service also revalidates `/admin/gear`, `/gear`, and `/browse`.
-- The admin table and gear page pass the current `regionalAliases` + `brandName` into the dialog so existing alias values prefill.
+- The admin table and gear page pass current `regionalAliases` into the dialog so existing values prefill.
 
 ### Viewer-facing surfaces
 
-- Gear cards, hero sections, horizontal lists, browse/trending tables, alternatives, compare pages, wishlist/collection lists, price/metadata sections, reviews/news cards, and image carousel alt text now rely on `GetGearDisplayName` + `regionalAliases`, so EU/Japan viewers automatically see the correct name.
-- Specs table now includes a dedicated “Regional Names” row that mirrors the spacing/typography of other rows. It lists the EU alias, Japan alias, and (for non-global viewers) the base name so editors can verify all names at a glance.
+- Gear cards, hero sections, horizontal lists, browse/trending tables, alternatives, compare pages, wishlist/collection lists, price/metadata sections, reviews/news cards, and image carousel alt text rely on `GetGearDisplayName` + `regionalAliases`, so US/EU/JP viewers automatically receive an exact regional alias when one exists and otherwise receive the canonical name.
+- Specs table includes a dedicated “Regional Names” row so editors can verify stored aliases and the canonical fallback.
 - Metadata/JSON-LD, compare metadata, and command palette/search suggestions use the region-aware display name to keep sharing/search consistent.
 
 ### Outcome

--- a/docs/developer-api.md
+++ b/docs/developer-api.md
@@ -33,6 +33,10 @@ Returns a ranked page of published results:
 }
 ```
 
+### `GET /api/v1/search/suggestions`
+
+Required query parameter: `q` (2–200 characters). Optional `limit` defaults to 8 (maximum 10). Optional `region` defaults to `GLOBAL` and accepts `GLOBAL`, `US`, `EU`, or `JP`. A regional alias is returned when the requested region has one; otherwise the canonical name is used.
+
 ### `GET /api/v1/catalog`
 
 Downloads one shared, lightweight snapshot of every published gear record. It is

--- a/docs/gear-specification-system.md
+++ b/docs/gear-specification-system.md
@@ -57,11 +57,12 @@ Stores alternate consumer-facing names used in specific regions (aliases, not lo
 
 - **Primary Key**: Composite (`gearId`, `region`) to enforce one alias per region
 - **Gear Reference**: Foreign key to `gear.id` (cascade on delete)
-- **Region**: `gear_region` enum (`GLOBAL`, `EU`, `JP`)
-- **Name**: Alternate display name for that region
+- **Region**: `gear_region` enum (`GLOBAL`, `US`, `EU`, `JP`)
+- **Name**: Complete alternate display name for that region, stored without canonical-brand prefix enforcement
 - **Use Cases**:
   - Canon "Kiss" line in Japan
   - Canon EU variants (secondary)
+  - Rokinon branding for Samyang products in the United States
 - **Search**: Aliases are denormalized into `gear.search_name` for query performance
 
 #### `gear_exif_aliases` - EXIF Metadata Model Aliases

--- a/docs/mapping-system.md
+++ b/docs/mapping-system.md
@@ -154,7 +154,7 @@ Regional aliases are resolved through a single helper to keep UI consistent:
 
 - **Helper**: `GetGearDisplayName(item)` in `src/lib/gear/naming.ts`
 - **Inputs**: canonical `name` plus optional `regionalAliases`
-- **Resolution**: country → region (GLOBAL/EU/JP), then alias match, else canonical
+- **Resolution**: country → region (GLOBAL/US/EU/JP), then exact alias match, else canonical; US does not inherit a `GLOBAL` alias
 - **Usage**: all gear name surfaces should use the helper or `useGearDisplayName`
 
 ## Routing note: Mount shortName

--- a/docs/search-system.md
+++ b/docs/search-system.md
@@ -56,7 +56,7 @@ The key-authenticated developer API has separate public endpoints at `/api/v1/se
 - Migration: `drizzle/0006_search_trgm.sql`
   - Creates extension if missing
   - Adds a GIN trigram index on `sharply_gear.search_name`
-- `gear.search_name` is denormalized to include canonical names plus any regional aliases.
+- `gear.search_name` is denormalized to include canonical names plus any US, EU, JP, or Global aliases. Aliases may contain a different regional brand, while search normalization retains canonical-brand tokens so either name can match.
 
 ## Core algorithm
 

--- a/drizzle/0025_ordinary_valeria_richards.sql
+++ b/drizzle/0025_ordinary_valeria_richards.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."gear_region" ADD VALUE 'US' BEFORE 'EU';

--- a/drizzle/meta/0025_snapshot.json
+++ b/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,9341 @@
+{
+  "id": "1a23cbf6-b7c5-4c06-b1c7-6f85b8bb88d9",
+  "prevId": "dc52b1a9-03b4-4fcc-aa9e-ba73046b5396",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app.af_area_modes": {
+      "name": "af_area_modes",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_name": {
+          "name": "search_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "af_area_modes_brand_idx": {
+          "name": "af_area_modes_brand_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "af_area_modes_name_idx": {
+          "name": "af_area_modes_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "af_area_modes_search_name_idx": {
+          "name": "af_area_modes_search_name_idx",
+          "columns": [
+            {
+              "expression": "search_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "af_area_modes_brand_id_brands_id_fk": {
+          "name": "af_area_modes_brand_id_brands_id_fk",
+          "tableFrom": "af_area_modes",
+          "tableTo": "brands",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.analog_camera_specs": {
+      "name": "analog_camera_specs",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "camera_type": {
+          "name": "camera_type",
+          "type": "analog_types_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_medium": {
+          "name": "capture_medium",
+          "type": "analog_medium_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "film_transport_type": {
+          "name": "film_transport_type",
+          "type": "film_transport_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_auto_film_advance": {
+          "name": "has_auto_film_advance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_optional_motorized_drive": {
+          "name": "has_optional_motorized_drive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewfinder_type": {
+          "name": "viewfinder_type",
+          "type": "analog_viewfinder_types_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_type": {
+          "name": "shutter_type",
+          "type": "shutter_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_max": {
+          "name": "shutter_speed_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_min": {
+          "name": "shutter_speed_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flash_sync_speed": {
+          "name": "flash_sync_speed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_bulb_mode": {
+          "name": "has_bulb_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_metering": {
+          "name": "has_metering",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metering_modes": {
+          "name": "metering_modes",
+          "type": "metering_mode_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exposure_modes": {
+          "name": "exposure_modes",
+          "type": "exposure_modes_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metering_display_types": {
+          "name": "metering_display_types",
+          "type": "metering_display_type_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_exposure_compensation": {
+          "name": "has_exposure_compensation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso_setting_method": {
+          "name": "iso_setting_method",
+          "type": "iso_setting_method_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso_min": {
+          "name": "iso_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso_max": {
+          "name": "iso_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_auto_focus": {
+          "name": "has_auto_focus",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focus_aid_types": {
+          "name": "focus_aid_types",
+          "type": "focus_aid_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_battery_for_shutter": {
+          "name": "requires_battery_for_shutter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_battery_for_metering": {
+          "name": "requires_battery_for_metering",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_batteries": {
+          "name": "supported_batteries",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_continuous_drive": {
+          "name": "has_continuous_drive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_continuous_fps": {
+          "name": "max_continuous_fps",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_hot_shoe": {
+          "name": "has_hot_shoe",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_self_timer": {
+          "name": "has_self_timer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_intervalometer": {
+          "name": "has_intervalometer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analog_camera_specs_gear_idx": {
+          "name": "analog_camera_specs_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analog_camera_specs_gear_id_gear_id_fk": {
+          "name": "analog_camera_specs_gear_id_gear_id_fk",
+          "tableFrom": "analog_camera_specs",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.approved_creators": {
+      "name": "approved_creators",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "creator_video_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_url": {
+          "name": "channel_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "internal_notes": {
+          "name": "internal_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approved_creators_name_idx": {
+          "name": "approved_creators_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approved_creators_platform_active_idx": {
+          "name": "approved_creators_platform_active_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.audit_logs": {
+      "name": "audit_logs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "action": {
+          "name": "action",
+          "type": "audit_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gear_edit_id": {
+          "name": "gear_edit_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_created_idx": {
+          "name": "audit_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_action_idx": {
+          "name": "audit_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_actor_idx": {
+          "name": "audit_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_gear_idx": {
+          "name": "audit_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_edit_idx": {
+          "name": "audit_edit_idx",
+          "columns": [
+            {
+              "expression": "gear_edit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_actor_user_id_user_id_fk": {
+          "name": "audit_logs_actor_user_id_user_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "audit_logs_gear_id_gear_id_fk": {
+          "name": "audit_logs_gear_id_gear_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_logs_gear_edit_id_gear_edits_id_fk": {
+          "name": "audit_logs_gear_edit_id_gear_edits_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "gear_edits",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_edit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.auth_accounts": {
+      "name": "auth_accounts",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_accounts_userId_idx": {
+          "name": "auth_accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_accounts_user_id_user_id_fk": {
+          "name": "auth_accounts_user_id_user_id_fk",
+          "tableFrom": "auth_accounts",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_sessions_userId_idx": {
+          "name": "auth_sessions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_sessions_user_id_user_id_fk": {
+          "name": "auth_sessions_user_id_user_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_sessions_token_unique": {
+          "name": "auth_sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.auth_verifications": {
+      "name": "auth_verifications",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_verifications_identifier_idx": {
+          "name": "auth_verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.badge_awards_log": {
+      "name": "badge_awards_log",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "badgeKey": {
+          "name": "badgeKey",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "badge_award_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awardedAt": {
+          "name": "awardedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "badge_awards_log_user_idx": {
+          "name": "badge_awards_log_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "badge_awards_log_awarded_idx": {
+          "name": "badge_awards_log_awarded_idx",
+          "columns": [
+            {
+              "expression": "awardedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "badge_awards_log_badge_idx": {
+          "name": "badge_awards_log_badge_idx",
+          "columns": [
+            {
+              "expression": "badgeKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "badge_awards_log_userId_user_id_fk": {
+          "name": "badge_awards_log_userId_user_id_fk",
+          "tableFrom": "badge_awards_log",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.bingo_board_tiles": {
+      "name": "bingo_board_tiles",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_free_tile": {
+          "name": "is_free_tile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_by_user_id": {
+          "name": "completed_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_submission_id": {
+          "name": "completed_submission_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bingo_board_tiles_board_position_uq": {
+          "name": "bingo_board_tiles_board_position_uq",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bingo_board_tiles_board_completed_idx": {
+          "name": "bingo_board_tiles_board_completed_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bingo_board_tiles_board_id_bingo_boards_id_fk": {
+          "name": "bingo_board_tiles_board_id_bingo_boards_id_fk",
+          "tableFrom": "bingo_board_tiles",
+          "tableTo": "bingo_boards",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bingo_board_tiles_completed_by_user_id_user_id_fk": {
+          "name": "bingo_board_tiles_completed_by_user_id_user_id_fk",
+          "tableFrom": "bingo_board_tiles",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "completed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bingo_board_tiles_completed_submission_id_bingo_submissions_id_fk": {
+          "name": "bingo_board_tiles_completed_submission_id_bingo_submissions_id_fk",
+          "tableFrom": "bingo_board_tiles",
+          "tableTo": "bingo_submissions",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "completed_submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.bingo_boards": {
+      "name": "bingo_boards",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "status": {
+          "name": "status",
+          "type": "bingo_board_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "inactivity_duration_seconds": {
+          "name": "inactivity_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14400
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_completed_at": {
+          "name": "first_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bingo_boards_status_idx": {
+          "name": "bingo_boards_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bingo_boards_created_idx": {
+          "name": "bingo_boards_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bingo_boards_created_by_user_id_user_id_fk": {
+          "name": "bingo_boards_created_by_user_id_user_id_fk",
+          "tableFrom": "bingo_boards",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.bingo_events": {
+      "name": "bingo_events",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "bingo_events_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "type": {
+          "name": "type",
+          "type": "bingo_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_tile_id": {
+          "name": "board_tile_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bingo_events_board_idx": {
+          "name": "bingo_events_board_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bingo_events_board_id_idx": {
+          "name": "bingo_events_board_id_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bingo_events_created_idx": {
+          "name": "bingo_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bingo_events_board_id_bingo_boards_id_fk": {
+          "name": "bingo_events_board_id_bingo_boards_id_fk",
+          "tableFrom": "bingo_events",
+          "tableTo": "bingo_boards",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bingo_events_board_tile_id_bingo_board_tiles_id_fk": {
+          "name": "bingo_events_board_tile_id_bingo_board_tiles_id_fk",
+          "tableFrom": "bingo_events",
+          "tableTo": "bingo_board_tiles",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "board_tile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bingo_events_submission_id_bingo_submissions_id_fk": {
+          "name": "bingo_events_submission_id_bingo_submissions_id_fk",
+          "tableFrom": "bingo_events",
+          "tableTo": "bingo_submissions",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bingo_events_user_id_user_id_fk": {
+          "name": "bingo_events_user_id_user_id_fk",
+          "tableFrom": "bingo_events",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.bingo_scores": {
+      "name": "bingo_scores",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bingo_scores_board_user_uq": {
+          "name": "bingo_scores_board_user_uq",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bingo_scores_board_points_idx": {
+          "name": "bingo_scores_board_points_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "points",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bingo_scores_board_id_bingo_boards_id_fk": {
+          "name": "bingo_scores_board_id_bingo_boards_id_fk",
+          "tableFrom": "bingo_scores",
+          "tableTo": "bingo_boards",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bingo_scores_user_id_user_id_fk": {
+          "name": "bingo_scores_user_id_user_id_fk",
+          "tableFrom": "bingo_scores",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.bingo_submissions": {
+      "name": "bingo_submissions",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_tile_id": {
+          "name": "board_tile_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_message_url": {
+          "name": "discord_message_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_guild_id": {
+          "name": "discord_guild_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_channel_id": {
+          "name": "discord_channel_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validation_passed": {
+          "name": "validation_passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "validation_metadata": {
+          "name": "validation_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bingo_submissions_board_idx": {
+          "name": "bingo_submissions_board_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bingo_submissions_user_idx": {
+          "name": "bingo_submissions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bingo_submissions_tile_idx": {
+          "name": "bingo_submissions_tile_idx",
+          "columns": [
+            {
+              "expression": "board_tile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bingo_submissions_created_idx": {
+          "name": "bingo_submissions_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bingo_submissions_board_id_bingo_boards_id_fk": {
+          "name": "bingo_submissions_board_id_bingo_boards_id_fk",
+          "tableFrom": "bingo_submissions",
+          "tableTo": "bingo_boards",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bingo_submissions_board_tile_id_bingo_board_tiles_id_fk": {
+          "name": "bingo_submissions_board_tile_id_bingo_board_tiles_id_fk",
+          "tableFrom": "bingo_submissions",
+          "tableTo": "bingo_board_tiles",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "board_tile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bingo_submissions_user_id_user_id_fk": {
+          "name": "bingo_submissions_user_id_user_id_fk",
+          "tableFrom": "bingo_submissions",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.brands": {
+      "name": "brands",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "brands_name_unique": {
+          "name": "brands_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "brands_slug_unique": {
+          "name": "brands_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.camera_af_area_specs": {
+      "name": "camera_af_area_specs",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "af_area_mode_id": {
+          "name": "af_area_mode_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "camera_af_area_specs_af_area_mode_idx": {
+          "name": "camera_af_area_specs_af_area_mode_idx",
+          "columns": [
+            {
+              "expression": "af_area_mode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "camera_af_area_specs_gear_idx": {
+          "name": "camera_af_area_specs_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "camera_af_area_specs_gear_id_gear_id_fk": {
+          "name": "camera_af_area_specs_gear_id_gear_id_fk",
+          "tableFrom": "camera_af_area_specs",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "camera_af_area_specs_af_area_mode_id_af_area_modes_id_fk": {
+          "name": "camera_af_area_specs_af_area_mode_id_af_area_modes_id_fk",
+          "tableFrom": "camera_af_area_specs",
+          "tableTo": "af_area_modes",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "af_area_mode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "camera_af_area_specs_gear_id_af_area_mode_id_pk": {
+          "name": "camera_af_area_specs_gear_id_af_area_mode_id_pk",
+          "columns": [
+            "gear_id",
+            "af_area_mode_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.camera_card_slots": {
+      "name": "camera_card_slots",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_index": {
+          "name": "slot_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_form_factors": {
+          "name": "supported_form_factors",
+          "type": "card_form_factor_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_buses": {
+          "name": "supported_buses",
+          "type": "card_bus_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_speed_classes": {
+          "name": "supported_speed_classes",
+          "type": "card_speed_class_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_camera_card_slot": {
+          "name": "uniq_camera_card_slot",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slot_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.camera_specs": {
+      "name": "camera_specs",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sensor_format_id": {
+          "name": "sensor_format_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_mp": {
+          "name": "resolution_mp",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sensor_stacking_type": {
+          "name": "sensor_stacking_type",
+          "type": "sensor_stacking_types_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sensor_tech_type": {
+          "name": "sensor_tech_type",
+          "type": "sensor_tech_types_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_back_side_illuminated": {
+          "name": "is_back_side_illuminated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso_min": {
+          "name": "iso_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso_max": {
+          "name": "iso_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sensor_readout_speed_ms": {
+          "name": "sensor_readout_speed_ms",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_raw_bit_depth": {
+          "name": "max_raw_bit_depth",
+          "type": "raw_bit_depth_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_ibis": {
+          "name": "has_ibis",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_electronic_vibration_reduction": {
+          "name": "has_electronic_vibration_reduction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cipa_stabilization_rating_stops": {
+          "name": "cipa_stabilization_rating_stops",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_pixel_shift_shooting": {
+          "name": "has_pixel_shift_shooting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_anti_aliasing_filter": {
+          "name": "has_anti_aliasing_filter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "precapture_support_level": {
+          "name": "precapture_support_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_type": {
+          "name": "camera_type",
+          "type": "camera_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processor_name": {
+          "name": "processor_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_weather_sealing": {
+          "name": "has_weather_sealing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focus_points": {
+          "name": "focus_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "af_subject_categories": {
+          "name": "af_subject_categories",
+          "type": "camera_af_subject_categories_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_focus_peaking": {
+          "name": "has_focus_peaking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_focus_bracketing": {
+          "name": "has_focus_bracketing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_max": {
+          "name": "shutter_speed_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_min": {
+          "name": "shutter_speed_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_fps_raw": {
+          "name": "max_fps_raw",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_fps_jpg": {
+          "name": "max_fps_jpg",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_fps_by_shutter": {
+          "name": "max_fps_by_shutter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flash_sync_speed": {
+          "name": "flash_sync_speed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_silent_shooting_available": {
+          "name": "has_silent_shooting_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_shutter_types": {
+          "name": "available_shutter_types",
+          "type": "shutter_types_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_storage_gb": {
+          "name": "internal_storage_gb",
+          "type": "numeric(6, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cipa_battery_shots_per_charge": {
+          "name": "cipa_battery_shots_per_charge",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_batteries": {
+          "name": "supported_batteries",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usb_power_delivery": {
+          "name": "usb_power_delivery",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usb_charging": {
+          "name": "usb_charging",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_log_color_profile": {
+          "name": "has_log_color_profile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_10_bit_video": {
+          "name": "has_10_bit_video",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_12_bit_video": {
+          "name": "has_12_bit_video",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_open_gate_video": {
+          "name": "has_open_gate_video",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supports_external_recording": {
+          "name": "supports_external_recording",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supports_record_to_drive": {
+          "name": "supports_record_to_drive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_intervalometer": {
+          "name": "has_intervalometer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_self_timer": {
+          "name": "has_self_timer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_built_in_flash": {
+          "name": "has_built_in_flash",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_hot_shoe": {
+          "name": "has_hot_shoe",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_illuminated_buttons": {
+          "name": "has_illuminated_buttons",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_usb_file_transfer": {
+          "name": "has_usb_file_transfer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rear_display_type": {
+          "name": "rear_display_type",
+          "type": "rear_display_types_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rear_display_resolution_million_dots": {
+          "name": "rear_display_resolution_million_dots",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rear_display_size_inches": {
+          "name": "rear_display_size_inches",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_rear_touchscreen": {
+          "name": "has_rear_touchscreen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewfinder_type": {
+          "name": "viewfinder_type",
+          "type": "viewfinder_types_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewfinder_magnification": {
+          "name": "viewfinder_magnification",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewfinder_resolution_million_dots": {
+          "name": "viewfinder_resolution_million_dots",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_top_display": {
+          "name": "has_top_display",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "camera_specs_sensor_idx": {
+          "name": "camera_specs_sensor_idx",
+          "columns": [
+            {
+              "expression": "sensor_format_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "camera_specs_gear_id_gear_id_fk": {
+          "name": "camera_specs_gear_id_gear_id_fk",
+          "tableFrom": "camera_specs",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "camera_specs_sensor_format_id_sensor_formats_id_fk": {
+          "name": "camera_specs_sensor_format_id_sensor_formats_id_fk",
+          "tableFrom": "camera_specs",
+          "tableTo": "sensor_formats",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "sensor_format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.camera_video_modes": {
+      "name": "camera_video_modes",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution_key": {
+          "name": "resolution_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution_label": {
+          "name": "resolution_label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution_horizontal": {
+          "name": "resolution_horizontal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_vertical": {
+          "name": "resolution_vertical",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fps": {
+          "name": "fps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codec_label": {
+          "name": "codec_label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bit_depth": {
+          "name": "bit_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_factor": {
+          "name": "crop_factor",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "camera_video_modes_gear_idx": {
+          "name": "camera_video_modes_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "camera_video_modes_gear_id_gear_id_fk": {
+          "name": "camera_video_modes_gear_id_gear_id_fk",
+          "tableFrom": "camera_video_modes",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.compare_pair_counts": {
+      "name": "compare_pair_counts",
+      "schema": "app",
+      "columns": {
+        "pair_key": {
+          "name": "pair_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_a_id": {
+          "name": "gear_a_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_b_id": {
+          "name": "gear_b_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pair_counts_gear_a_idx": {
+          "name": "pair_counts_gear_a_idx",
+          "columns": [
+            {
+              "expression": "gear_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pair_counts_gear_b_idx": {
+          "name": "pair_counts_gear_b_idx",
+          "columns": [
+            {
+              "expression": "gear_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pair_counts_count_idx": {
+          "name": "pair_counts_count_idx",
+          "columns": [
+            {
+              "expression": "count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compare_pair_counts_gear_a_id_gear_id_fk": {
+          "name": "compare_pair_counts_gear_a_id_gear_id_fk",
+          "tableFrom": "compare_pair_counts",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "compare_pair_counts_gear_b_id_gear_id_fk": {
+          "name": "compare_pair_counts_gear_b_id_gear_id_fk",
+          "tableFrom": "compare_pair_counts",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "compare_pair_counts_gear_a_id_gear_b_id_pk": {
+          "name": "compare_pair_counts_gear_a_id_gear_b_id_pk",
+          "columns": [
+            "gear_a_id",
+            "gear_b_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.developer_api_keys": {
+      "name": "developer_api_keys",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(48)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "developer_api_keys_user_active_idx": {
+          "name": "developer_api_keys_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "developer_api_keys_last_used_idx": {
+          "name": "developer_api_keys_last_used_idx",
+          "columns": [
+            {
+              "expression": "last_used_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "developer_api_keys_user_id_user_id_fk": {
+          "name": "developer_api_keys_user_id_user_id_fk",
+          "tableFrom": "developer_api_keys",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "developer_api_keys_revoked_by_user_id_user_id_fk": {
+          "name": "developer_api_keys_revoked_by_user_id_user_id_fk",
+          "tableFrom": "developer_api_keys",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "developer_api_keys_key_hash_unique": {
+          "name": "developer_api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.developer_api_rate_limit_buckets": {
+      "name": "developer_api_rate_limit_buckets",
+      "schema": "app",
+      "columns": {
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "developer_api_rate_limit_buckets_window_idx": {
+          "name": "developer_api_rate_limit_buckets_window_idx",
+          "columns": [
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "developer_api_rate_limit_buckets_api_key_id_developer_api_keys_id_fk": {
+          "name": "developer_api_rate_limit_buckets_api_key_id_developer_api_keys_id_fk",
+          "tableFrom": "developer_api_rate_limit_buckets",
+          "tableTo": "developer_api_keys",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "developer_api_rate_limit_buckets_api_key_id_window_start_pk": {
+          "name": "developer_api_rate_limit_buckets_api_key_id_window_start_pk",
+          "columns": [
+            "api_key_id",
+            "window_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.developer_api_usage_daily": {
+      "name": "developer_api_usage_daily",
+      "schema": "app",
+      "columns": {
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_date": {
+          "name": "usage_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_requests": {
+          "name": "total_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "search_requests": {
+          "name": "search_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "suggestion_requests": {
+          "name": "suggestion_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "gear_requests": {
+          "name": "gear_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "developer_api_usage_daily_date_idx": {
+          "name": "developer_api_usage_daily_date_idx",
+          "columns": [
+            {
+              "expression": "usage_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "developer_api_usage_daily_api_key_id_developer_api_keys_id_fk": {
+          "name": "developer_api_usage_daily_api_key_id_developer_api_keys_id_fk",
+          "tableFrom": "developer_api_usage_daily",
+          "tableTo": "developer_api_keys",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "developer_api_usage_daily_api_key_id_usage_date_pk": {
+          "name": "developer_api_usage_daily_api_key_id_usage_date_pk",
+          "columns": [
+            "api_key_id",
+            "usage_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.exif_shutter_readings": {
+      "name": "exif_shutter_readings",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "tracked_camera_id": {
+          "name": "tracked_camera_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_at": {
+          "name": "capture_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_count_type": {
+          "name": "primary_count_type",
+          "type": "exif_primary_count_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_count_value": {
+          "name": "primary_count_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shutter_count": {
+          "name": "shutter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_shutter_count": {
+          "name": "total_shutter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mechanical_shutter_count": {
+          "name": "mechanical_shutter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_tag": {
+          "name": "source_tag",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mechanical_source_tag": {
+          "name": "mechanical_source_tag",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exif_shutter_readings_dedupe_uq": {
+          "name": "exif_shutter_readings_dedupe_uq",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exif_shutter_readings_tracked_camera_idx": {
+          "name": "exif_shutter_readings_tracked_camera_idx",
+          "columns": [
+            {
+              "expression": "tracked_camera_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exif_shutter_readings_camera_capture_idx": {
+          "name": "exif_shutter_readings_camera_capture_idx",
+          "columns": [
+            {
+              "expression": "tracked_camera_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "capture_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exif_shutter_readings_tracked_camera_id_exif_tracked_cameras_id_fk": {
+          "name": "exif_shutter_readings_tracked_camera_id_exif_tracked_cameras_id_fk",
+          "tableFrom": "exif_shutter_readings",
+          "tableTo": "exif_tracked_cameras",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "tracked_camera_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.exif_tracked_cameras": {
+      "name": "exif_tracked_cameras",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_brand": {
+          "name": "normalized_brand",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make_raw": {
+          "name": "make_raw",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_raw": {
+          "name": "model_raw",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_hash": {
+          "name": "serial_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exif_tracked_cameras_user_serial_uq": {
+          "name": "exif_tracked_cameras_user_serial_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "serial_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exif_tracked_cameras_gear_idx": {
+          "name": "exif_tracked_cameras_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exif_tracked_cameras_user_idx": {
+          "name": "exif_tracked_cameras_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exif_tracked_cameras_user_id_user_id_fk": {
+          "name": "exif_tracked_cameras_user_id_user_id_fk",
+          "tableFrom": "exif_tracked_cameras",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exif_tracked_cameras_gear_id_gear_id_fk": {
+          "name": "exif_tracked_cameras_gear_id_gear_id_fk",
+          "tableFrom": "exif_tracked_cameras",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.fixed_lens_specs": {
+      "name": "fixed_lens_specs",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_prime": {
+          "name": "is_prime",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_min_mm": {
+          "name": "focal_length_min_mm",
+          "type": "numeric(5, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_max_mm": {
+          "name": "focal_length_max_mm",
+          "type": "numeric(5, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_circle_size_id": {
+          "name": "image_circle_size_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_aperture_wide": {
+          "name": "max_aperture_wide",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_aperture_tele": {
+          "name": "max_aperture_tele",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_aperture_wide": {
+          "name": "min_aperture_wide",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_aperture_tele": {
+          "name": "min_aperture_tele",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_autofocus": {
+          "name": "has_autofocus",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minimum_focus_distance_mm": {
+          "name": "minimum_focus_distance_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "front_element_rotates": {
+          "name": "front_element_rotates",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "front_filter_thread_size_mm": {
+          "name": "front_filter_thread_size_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_lens_hood": {
+          "name": "has_lens_hood",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fixed_lens_specs_focal_idx": {
+          "name": "fixed_lens_specs_focal_idx",
+          "columns": [
+            {
+              "expression": "focal_length_min_mm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "focal_length_max_mm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fixed_lens_specs_gear_id_gear_id_fk": {
+          "name": "fixed_lens_specs_gear_id_gear_id_fk",
+          "tableFrom": "fixed_lens_specs",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fixed_lens_specs_image_circle_size_id_sensor_formats_id_fk": {
+          "name": "fixed_lens_specs_image_circle_size_id_sensor_formats_id_fk",
+          "tableFrom": "fixed_lens_specs",
+          "tableTo": "sensor_formats",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "image_circle_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear": {
+      "name": "gear",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(220)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_name": {
+          "name": "search_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_number": {
+          "name": "model_number",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gear_type": {
+          "name": "gear_type",
+          "type": "gear_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_state": {
+          "name": "publication_state",
+          "type": "gear_publication_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PUBLISHED'"
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mount_id": {
+          "name": "mount_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "announced_date": {
+          "name": "announced_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "announce_date_precision": {
+          "name": "announce_date_precision",
+          "type": "date_precision_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'DAY'"
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date_precision": {
+          "name": "release_date_precision",
+          "type": "date_precision_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'DAY'"
+        },
+        "msrp_now_usd_cents": {
+          "name": "msrp_now_usd_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "msrp_at_launch_usd_cents": {
+          "name": "msrp_at_launch_usd_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mpb_max_price_usd_cents": {
+          "name": "mpb_max_price_usd_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_image_url": {
+          "name": "og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_view_url": {
+          "name": "top_view_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rear_view_url": {
+          "name": "rear_view_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_grams": {
+          "name": "weight_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width_mm": {
+          "name": "width_mm",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height_mm": {
+          "name": "height_mm",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth_mm": {
+          "name": "depth_mm",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_manufacturer": {
+          "name": "link_manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_instruction_manual": {
+          "name": "link_instruction_manual",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_mpb": {
+          "name": "link_mpb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_bh": {
+          "name": "link_bh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_amazon": {
+          "name": "link_amazon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_search_idx": {
+          "name": "gear_search_idx",
+          "columns": [
+            {
+              "expression": "search_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_publication_state_idx": {
+          "name": "gear_publication_state_idx",
+          "columns": [
+            {
+              "expression": "publication_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_type_brand_idx": {
+          "name": "gear_type_brand_idx",
+          "columns": [
+            {
+              "expression": "gear_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_brand_mount_idx": {
+          "name": "gear_brand_mount_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mount_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_brand_id_brands_id_fk": {
+          "name": "gear_brand_id_brands_id_fk",
+          "tableFrom": "gear",
+          "tableTo": "brands",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "gear_mount_id_mounts_id_fk": {
+          "name": "gear_mount_id_mounts_id_fk",
+          "tableFrom": "gear",
+          "tableTo": "mounts",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "mount_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gear_slug_unique": {
+          "name": "gear_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "gear_name_unique": {
+          "name": "gear_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "gear_model_number_unique": {
+          "name": "gear_model_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "model_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_aliases": {
+      "name": "gear_aliases",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "gear_region",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_aliases_gear_idx": {
+          "name": "gear_aliases_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_aliases_region_idx": {
+          "name": "gear_aliases_region_idx",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_aliases_gear_id_gear_id_fk": {
+          "name": "gear_aliases_gear_id_gear_id_fk",
+          "tableFrom": "gear_aliases",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_aliases_gear_id_region_pk": {
+          "name": "gear_aliases_gear_id_region_pk",
+          "columns": [
+            "gear_id",
+            "region"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_alternatives": {
+      "name": "gear_alternatives",
+      "schema": "app",
+      "columns": {
+        "gear_a_id": {
+          "name": "gear_a_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_b_id": {
+          "name": "gear_b_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_competitor": {
+          "name": "is_competitor",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_alternatives_gear_a_idx": {
+          "name": "gear_alternatives_gear_a_idx",
+          "columns": [
+            {
+              "expression": "gear_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_alternatives_gear_b_idx": {
+          "name": "gear_alternatives_gear_b_idx",
+          "columns": [
+            {
+              "expression": "gear_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_alternatives_gear_a_id_gear_id_fk": {
+          "name": "gear_alternatives_gear_a_id_gear_id_fk",
+          "tableFrom": "gear_alternatives",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_alternatives_gear_b_id_gear_id_fk": {
+          "name": "gear_alternatives_gear_b_id_gear_id_fk",
+          "tableFrom": "gear_alternatives",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_alternatives_gear_a_id_gear_b_id_pk": {
+          "name": "gear_alternatives_gear_a_id_gear_b_id_pk",
+          "columns": [
+            "gear_a_id",
+            "gear_b_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_colorways": {
+      "name": "gear_colorways",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(140)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "swatch_color_a": {
+          "name": "swatch_color_a",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "swatch_color_b": {
+          "name": "swatch_color_b",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "front_image_url": {
+          "name": "front_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_view_url": {
+          "name": "top_view_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rear_view_url": {
+          "name": "rear_view_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_colorways_gear_slug_uidx": {
+          "name": "gear_colorways_gear_slug_uidx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_colorways_gear_order_idx": {
+          "name": "gear_colorways_gear_order_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_colorways_gear_id_gear_id_fk": {
+          "name": "gear_colorways_gear_id_gear_id_fk",
+          "tableFrom": "gear_colorways",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_creator_videos": {
+      "name": "gear_creator_videos",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_url": {
+          "name": "normalized_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embed_url": {
+          "name": "embed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "creator_video_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_video_id": {
+          "name": "external_video_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_note": {
+          "name": "editor_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_creator_videos_gear_active_idx": {
+          "name": "gear_creator_videos_gear_active_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_creator_videos_creator_idx": {
+          "name": "gear_creator_videos_creator_idx",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_creator_videos_platform_external_idx": {
+          "name": "gear_creator_videos_platform_external_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_video_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_creator_videos_gear_platform_external_uidx": {
+          "name": "gear_creator_videos_gear_platform_external_uidx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_video_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_creator_videos_gear_id_gear_id_fk": {
+          "name": "gear_creator_videos_gear_id_gear_id_fk",
+          "tableFrom": "gear_creator_videos",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_creator_videos_creator_id_approved_creators_id_fk": {
+          "name": "gear_creator_videos_creator_id_approved_creators_id_fk",
+          "tableFrom": "gear_creator_videos",
+          "tableTo": "approved_creators",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "gear_creator_videos_created_by_user_id_user_id_fk": {
+          "name": "gear_creator_videos_created_by_user_id_user_id_fk",
+          "tableFrom": "gear_creator_videos",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gear_creator_videos_updated_by_user_id_user_id_fk": {
+          "name": "gear_creator_videos_updated_by_user_id_user_id_fk",
+          "tableFrom": "gear_creator_videos",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_edits": {
+      "name": "gear_edits",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_edits_status_idx": {
+          "name": "gear_edits_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_edits_gear_idx": {
+          "name": "gear_edits_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_edits_created_by_idx": {
+          "name": "gear_edits_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_edits_gear_id_gear_id_fk": {
+          "name": "gear_edits_gear_id_gear_id_fk",
+          "tableFrom": "gear_edits",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_edits_created_by_id_user_id_fk": {
+          "name": "gear_edits_created_by_id_user_id_fk",
+          "tableFrom": "gear_edits",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_exif_aliases": {
+      "name": "gear_exif_aliases",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_brand": {
+          "name": "normalized_brand",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make_raw": {
+          "name": "make_raw",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_raw": {
+          "name": "model_raw",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "make_normalized": {
+          "name": "make_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_normalized": {
+          "name": "model_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_exif_aliases_gear_idx": {
+          "name": "gear_exif_aliases_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_exif_aliases_make_model_idx": {
+          "name": "gear_exif_aliases_make_model_idx",
+          "columns": [
+            {
+              "expression": "make_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_exif_aliases_gear_make_model_uq": {
+          "name": "gear_exif_aliases_gear_make_model_uq",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "make_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_exif_aliases_gear_id_gear_id_fk": {
+          "name": "gear_exif_aliases_gear_id_gear_id_fk",
+          "tableFrom": "gear_exif_aliases",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_genres": {
+      "name": "gear_genres",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_genres_gear_idx": {
+          "name": "gear_genres_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_genres_genre_idx": {
+          "name": "gear_genres_genre_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_genres_gear_id_gear_id_fk": {
+          "name": "gear_genres_gear_id_gear_id_fk",
+          "tableFrom": "gear_genres",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_genres_genre_id_genres_id_fk": {
+          "name": "gear_genres_genre_id_genres_id_fk",
+          "tableFrom": "gear_genres",
+          "tableTo": "genres",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_genres_gear_id_genre_id_pk": {
+          "name": "gear_genres_gear_id_genre_id_pk",
+          "columns": [
+            "gear_id",
+            "genre_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_mounts": {
+      "name": "gear_mounts",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mount_id": {
+          "name": "mount_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_mounts_gear_idx": {
+          "name": "gear_mounts_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_mounts_mount_idx": {
+          "name": "gear_mounts_mount_idx",
+          "columns": [
+            {
+              "expression": "mount_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_mounts_gear_id_gear_id_fk": {
+          "name": "gear_mounts_gear_id_gear_id_fk",
+          "tableFrom": "gear_mounts",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_mounts_mount_id_mounts_id_fk": {
+          "name": "gear_mounts_mount_id_mounts_id_fk",
+          "tableFrom": "gear_mounts",
+          "tableTo": "mounts",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "mount_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_mounts_gear_id_mount_id_pk": {
+          "name": "gear_mounts_gear_id_mount_id_pk",
+          "columns": [
+            "gear_id",
+            "mount_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_popularity_daily": {
+      "name": "gear_popularity_daily",
+      "schema": "app",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wishlist_adds": {
+          "name": "wishlist_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "owner_adds": {
+          "name": "owner_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compare_adds": {
+          "name": "compare_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "review_submits": {
+          "name": "review_submits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "api_fetches": {
+          "name": "api_fetches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gpd_gear_idx": {
+          "name": "gpd_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gpd_date_idx": {
+          "name": "gpd_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_popularity_daily_gear_id_gear_id_fk": {
+          "name": "gear_popularity_daily_gear_id_gear_id_fk",
+          "tableFrom": "gear_popularity_daily",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_popularity_daily_date_gear_id_pk": {
+          "name": "gear_popularity_daily_date_gear_id_pk",
+          "columns": [
+            "date",
+            "gear_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_popularity_intraday": {
+      "name": "gear_popularity_intraday",
+      "schema": "app",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wishlist_adds": {
+          "name": "wishlist_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "owner_adds": {
+          "name": "owner_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compare_adds": {
+          "name": "compare_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "review_submits": {
+          "name": "review_submits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "api_fetches": {
+          "name": "api_fetches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gpi_gear_idx": {
+          "name": "gpi_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gpi_date_idx": {
+          "name": "gpi_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_popularity_intraday_gear_id_gear_id_fk": {
+          "name": "gear_popularity_intraday_gear_id_gear_id_fk",
+          "tableFrom": "gear_popularity_intraday",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_popularity_intraday_date_gear_id_pk": {
+          "name": "gear_popularity_intraday_date_gear_id_pk",
+          "columns": [
+            "date",
+            "gear_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_popularity_lifetime": {
+      "name": "gear_popularity_lifetime",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "views_lifetime": {
+          "name": "views_lifetime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wishlist_lifetime_adds": {
+          "name": "wishlist_lifetime_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "owner_lifetime_adds": {
+          "name": "owner_lifetime_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compare_lifetime_adds": {
+          "name": "compare_lifetime_adds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "review_lifetime_submits": {
+          "name": "review_lifetime_submits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "api_fetch_lifetime": {
+          "name": "api_fetch_lifetime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gpl_gear_idx": {
+          "name": "gpl_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_popularity_lifetime_gear_id_gear_id_fk": {
+          "name": "gear_popularity_lifetime_gear_id_gear_id_fk",
+          "tableFrom": "gear_popularity_lifetime",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_popularity_windows": {
+      "name": "gear_popularity_windows",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeframe": {
+          "name": "timeframe",
+          "type": "popularity_timeframe",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of_date": {
+          "name": "as_of_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "views_sum": {
+          "name": "views_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wishlist_adds_sum": {
+          "name": "wishlist_adds_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "owner_adds_sum": {
+          "name": "owner_adds_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compare_adds_sum": {
+          "name": "compare_adds_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "review_submits_sum": {
+          "name": "review_submits_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "api_fetches_sum": {
+          "name": "api_fetches_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gpw_timeframe_idx": {
+          "name": "gpw_timeframe_idx",
+          "columns": [
+            {
+              "expression": "timeframe",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_popularity_windows_gear_id_gear_id_fk": {
+          "name": "gear_popularity_windows_gear_id_gear_id_fk",
+          "tableFrom": "gear_popularity_windows",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_popularity_windows_gear_id_timeframe_pk": {
+          "name": "gear_popularity_windows_gear_id_timeframe_pk",
+          "columns": [
+            "gear_id",
+            "timeframe"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.gear_raw_samples": {
+      "name": "gear_raw_samples",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_sample_id": {
+          "name": "raw_sample_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gear_raw_samples_gear_idx": {
+          "name": "gear_raw_samples_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gear_raw_samples_sample_idx": {
+          "name": "gear_raw_samples_sample_idx",
+          "columns": [
+            {
+              "expression": "raw_sample_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gear_raw_samples_gear_id_gear_id_fk": {
+          "name": "gear_raw_samples_gear_id_gear_id_fk",
+          "tableFrom": "gear_raw_samples",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_raw_samples_raw_sample_id_raw_samples_id_fk": {
+          "name": "gear_raw_samples_raw_sample_id_raw_samples_id_fk",
+          "tableFrom": "gear_raw_samples",
+          "tableTo": "raw_samples",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "raw_sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_raw_samples_gear_id_raw_sample_id_pk": {
+          "name": "gear_raw_samples_gear_id_raw_sample_id_pk",
+          "columns": [
+            "gear_id",
+            "raw_sample_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.genres": {
+      "name": "genres",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applies_to": {
+          "name": "applies_to",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genres_name_unique": {
+          "name": "genres_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "genres_slug_unique": {
+          "name": "genres_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.image_requests": {
+      "name": "image_requests",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "image_request_gear_idx": {
+          "name": "image_request_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "image_requests_user_id_user_id_fk": {
+          "name": "image_requests_user_id_user_id_fk",
+          "tableFrom": "image_requests",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "image_requests_gear_id_gear_id_fk": {
+          "name": "image_requests_gear_id_gear_id_fk",
+          "tableFrom": "image_requests",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "image_requests_user_id_gear_id_pk": {
+          "name": "image_requests_user_id_gear_id_pk",
+          "columns": [
+            "user_id",
+            "gear_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.invites": {
+      "name": "invites",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "inviteeName": {
+          "name": "inviteeName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_used": {
+          "name": "is_used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "usedByUserId": {
+          "name": "usedByUserId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invites_created_by_idx": {
+          "name": "invites_created_by_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_is_used_idx": {
+          "name": "invites_is_used_idx",
+          "columns": [
+            {
+              "expression": "is_used",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_used_by_idx": {
+          "name": "invites_used_by_idx",
+          "columns": [
+            {
+              "expression": "usedByUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_createdById_user_id_fk": {
+          "name": "invites_createdById_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "createdById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "invites_usedByUserId_user_id_fk": {
+          "name": "invites_usedByUserId_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "usedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.lens_specs": {
+      "name": "lens_specs",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_prime": {
+          "name": "is_prime",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_min_mm": {
+          "name": "focal_length_min_mm",
+          "type": "numeric(5, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_max_mm": {
+          "name": "focal_length_max_mm",
+          "type": "numeric(5, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_circle_size_id": {
+          "name": "image_circle_size_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_aperture_wide": {
+          "name": "max_aperture_wide",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_aperture_tele": {
+          "name": "max_aperture_tele",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_aperture_wide": {
+          "name": "min_aperture_wide",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_aperture_tele": {
+          "name": "min_aperture_tele",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_stabilization": {
+          "name": "has_stabilization",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cipa_stabilization_rating_stops": {
+          "name": "cipa_stabilization_rating_stops",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_stabilization_switch": {
+          "name": "has_stabilization_switch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_autofocus": {
+          "name": "has_autofocus",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_macro": {
+          "name": "is_macro",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "magnification": {
+          "name": "magnification",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minimum_focus_distance_mm": {
+          "name": "minimum_focus_distance_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_focus_ring": {
+          "name": "has_focus_ring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focus_motor_type": {
+          "name": "focus_motor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focus_throw_degrees": {
+          "name": "focus_throw_degrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_af_mf_switch": {
+          "name": "has_af_mf_switch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_focus_limiter": {
+          "name": "has_focus_limiter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_focus_recall_button": {
+          "name": "has_focus_recall_button",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_elements": {
+          "name": "number_elements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_element_groups": {
+          "name": "number_element_groups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_diffractive_optics": {
+          "name": "has_diffractive_optics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lens_zoom_type": {
+          "name": "lens_zoom_type",
+          "type": "lens_zoom_types_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_diaphragm_blades": {
+          "name": "number_diaphragm_blades",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_rounded_diaphragm_blades": {
+          "name": "has_rounded_diaphragm_blades",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_internal_zoom": {
+          "name": "has_internal_zoom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_internal_focus": {
+          "name": "has_internal_focus",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "front_element_rotates": {
+          "name": "front_element_rotates",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mount_material": {
+          "name": "mount_material",
+          "type": "mount_material_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_weather_sealing": {
+          "name": "has_weather_sealing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_aperture_ring": {
+          "name": "has_aperture_ring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_custom_control_rings": {
+          "name": "number_custom_control_rings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_function_buttons": {
+          "name": "number_function_buttons",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepts_filter_types": {
+          "name": "accepts_filter_types",
+          "type": "lens_filter_types_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "front_filter_thread_size_mm": {
+          "name": "front_filter_thread_size_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rear_filter_thread_size_mm": {
+          "name": "rear_filter_thread_size_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drop_in_filter_size_mm": {
+          "name": "drop_in_filter_size_mm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_built_in_teleconverter": {
+          "name": "has_built_in_teleconverter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_lens_hood": {
+          "name": "has_lens_hood",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_tripod_collar": {
+          "name": "has_tripod_collar",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_tilt_shift": {
+          "name": "is_tilt_shift",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tilt_degrees": {
+          "name": "tilt_degrees",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shift_mm": {
+          "name": "shift_mm",
+          "type": "numeric(5, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lens_specs_focal_idx": {
+          "name": "lens_specs_focal_idx",
+          "columns": [
+            {
+              "expression": "focal_length_min_mm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "focal_length_max_mm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lens_specs_gear_id_gear_id_fk": {
+          "name": "lens_specs_gear_id_gear_id_fk",
+          "tableFrom": "lens_specs",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lens_specs_image_circle_size_id_sensor_formats_id_fk": {
+          "name": "lens_specs_image_circle_size_id_sensor_formats_id_fk",
+          "tableFrom": "lens_specs",
+          "tableTo": "sensor_formats",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "image_circle_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.mounts": {
+      "name": "mounts",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mounts_brand_id_brands_id_fk": {
+          "name": "mounts_brand_id_brands_id_fk",
+          "tableFrom": "mounts",
+          "tableTo": "brands",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mounts_value_unique": {
+          "name": "mounts_value_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.notifications": {
+      "name": "notifications",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_archived_idx": {
+          "name": "notifications_user_archived_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.ownerships": {
+      "name": "ownerships",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "colorway_id": {
+          "name": "colorway_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ownership_gear_idx": {
+          "name": "ownership_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ownership_colorway_idx": {
+          "name": "ownership_colorway_idx",
+          "columns": [
+            {
+              "expression": "colorway_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ownerships_user_id_user_id_fk": {
+          "name": "ownerships_user_id_user_id_fk",
+          "tableFrom": "ownerships",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ownerships_gear_id_gear_id_fk": {
+          "name": "ownerships_gear_id_gear_id_fk",
+          "tableFrom": "ownerships",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ownerships_colorway_id_gear_colorways_id_fk": {
+          "name": "ownerships_colorway_id_gear_colorways_id_fk",
+          "tableFrom": "ownerships",
+          "tableTo": "gear_colorways",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "colorway_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ownerships_user_id_gear_id_pk": {
+          "name": "ownerships_user_id_gear_id_pk",
+          "columns": [
+            "user_id",
+            "gear_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.passkeys": {
+      "name": "passkeys",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "passkeys_user_idx": {
+          "name": "passkeys_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkeys_user_id_user_id_fk": {
+          "name": "passkeys_user_id_user_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.popularity_events": {
+      "name": "popularity_events",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitor_id": {
+          "name": "visitor_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "popularity_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pop_events_gear_idx": {
+          "name": "pop_events_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pop_events_gear_type_idx": {
+          "name": "pop_events_gear_type_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pop_events_created_idx": {
+          "name": "pop_events_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pop_events_visitor_idx": {
+          "name": "pop_events_visitor_idx",
+          "columns": [
+            {
+              "expression": "visitor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pop_events_gear_visitor_created_idx": {
+          "name": "pop_events_gear_visitor_created_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visitor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "popularity_events_gear_id_gear_id_fk": {
+          "name": "popularity_events_gear_id_gear_id_fk",
+          "tableFrom": "popularity_events",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "popularity_events_user_id_user_id_fk": {
+          "name": "popularity_events_user_id_user_id_fk",
+          "tableFrom": "popularity_events",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.raw_samples": {
+      "name": "raw_samples",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by_user_id": {
+          "name": "uploaded_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "raw_samples_file_url_idx": {
+          "name": "raw_samples_file_url_idx",
+          "columns": [
+            {
+              "expression": "file_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raw_samples_user_idx": {
+          "name": "raw_samples_user_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.recommendation_charts": {
+      "name": "recommendation_charts",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(800)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rec_brand_slug": {
+          "name": "rec_brand_slug",
+          "columns": [
+            {
+              "expression": "brand",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.recommendation_items": {
+      "name": "recommendation_items",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "chart_id": {
+          "name": "chart_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "rec_rating",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_override": {
+          "name": "group_override",
+          "type": "rec_group",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_column": {
+          "name": "custom_column",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_min_override": {
+          "name": "price_min_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_max_override": {
+          "name": "price_max_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rec_items_chart_idx": {
+          "name": "rec_items_chart_idx",
+          "columns": [
+            {
+              "expression": "chart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rec_items_gear_idx": {
+          "name": "rec_items_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recommendation_items_chart_id_recommendation_charts_id_fk": {
+          "name": "recommendation_items_chart_id_recommendation_charts_id_fk",
+          "tableFrom": "recommendation_items",
+          "tableTo": "recommendation_charts",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "chart_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recommendation_items_gear_id_gear_id_fk": {
+          "name": "recommendation_items_gear_id_gear_id_fk",
+          "tableFrom": "recommendation_items",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.review_flags": {
+      "name": "review_flags",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_user_id": {
+          "name": "reporter_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "review_flag_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_flags_status_idx": {
+          "name": "review_flags_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_flags_review_status_idx": {
+          "name": "review_flags_review_status_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_flags_reporter_status_idx": {
+          "name": "review_flags_reporter_status_idx",
+          "columns": [
+            {
+              "expression": "reporter_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_flags_review_id_reviews_id_fk": {
+          "name": "review_flags_review_id_reviews_id_fk",
+          "tableFrom": "review_flags",
+          "tableTo": "reviews",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_flags_reporter_user_id_user_id_fk": {
+          "name": "review_flags_reporter_user_id_user_id_fk",
+          "tableFrom": "review_flags",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "reporter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_flags_resolved_by_user_id_user_id_fk": {
+          "name": "review_flags_resolved_by_user_id_user_id_fk",
+          "tableFrom": "review_flags",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.review_summaries": {
+      "name": "review_summaries",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "summary_text": {
+          "name": "summary_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_summaries_updated_idx": {
+          "name": "review_summaries_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_summaries_gear_id_gear_id_fk": {
+          "name": "review_summaries_gear_id_gear_id_fk",
+          "tableFrom": "review_summaries",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.reviews": {
+      "name": "reviews",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "review_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommend": {
+          "name": "recommend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reviews_status_idx": {
+          "name": "reviews_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_gear_idx": {
+          "name": "reviews_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_created_by_idx": {
+          "name": "reviews_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_created_by_created_at_idx": {
+          "name": "reviews_created_by_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_gear_id_gear_id_fk": {
+          "name": "reviews_gear_id_gear_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_created_by_id_user_id_fk": {
+          "name": "reviews_created_by_id_user_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.rollup_runs": {
+      "name": "rollup_runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "as_of_date": {
+          "name": "as_of_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_date": {
+          "name": "corrected_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_rows": {
+          "name": "daily_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "late_arrivals": {
+          "name": "late_arrivals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "windows_rows": {
+          "name": "windows_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifetime_total_rows": {
+          "name": "lifetime_total_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rollup_runs_created_idx": {
+          "name": "rollup_runs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.sensor_formats": {
+      "name": "sensor_formats",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_factor": {
+          "name": "crop_factor",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width_mm": {
+          "name": "width_mm",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height_mm": {
+          "name": "height_mm",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_mm_2": {
+          "name": "area_mm_2",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sensor_formats_name_unique": {
+          "name": "sensor_formats_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "sensor_formats_slug_unique": {
+          "name": "sensor_formats_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.shared_lists": {
+      "name": "shared_lists",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(180)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "unpublished_at": {
+          "name": "unpublished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shared_lists_list_uq": {
+          "name": "shared_lists_list_uq",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shared_lists_public_id_uq": {
+          "name": "shared_lists_public_id_uq",
+          "columns": [
+            {
+              "expression": "public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shared_lists_slug_idx": {
+          "name": "shared_lists_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shared_lists_list_id_user_lists_id_fk": {
+          "name": "shared_lists_list_id_user_lists_id_fk",
+          "tableFrom": "shared_lists",
+          "tableTo": "user_lists",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.staff_verdicts": {
+      "name": "staff_verdicts",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pros": {
+          "name": "pros",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cons": {
+          "name": "cons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "who_for": {
+          "name": "who_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_for": {
+          "name": "not_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alternatives": {
+          "name": "alternatives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "staff_verdicts_author_idx": {
+          "name": "staff_verdicts_author_idx",
+          "columns": [
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_verdicts_gear_id_gear_id_fk": {
+          "name": "staff_verdicts_gear_id_gear_id_fk",
+          "tableFrom": "staff_verdicts",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staff_verdicts_author_user_id_user_id_fk": {
+          "name": "staff_verdicts_author_user_id_user_id_fk",
+          "tableFrom": "staff_verdicts",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.use_case_ratings": {
+      "name": "use_case_ratings",
+      "schema": "app",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ucr_gear_idx": {
+          "name": "ucr_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ucr_genre_idx": {
+          "name": "ucr_genre_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "use_case_ratings_gear_id_gear_id_fk": {
+          "name": "use_case_ratings_gear_id_gear_id_fk",
+          "tableFrom": "use_case_ratings",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "use_case_ratings_genre_id_genres_id_fk": {
+          "name": "use_case_ratings_genre_id_genres_id_fk",
+          "tableFrom": "use_case_ratings",
+          "tableTo": "genres",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "use_case_ratings_gear_id_genre_id_pk": {
+          "name": "use_case_ratings_gear_id_genre_id_pk",
+          "columns": [
+            "gear_id",
+            "genre_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.user_badges": {
+      "name": "user_badges",
+      "schema": "app",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badgeKey": {
+          "name": "badgeKey",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awardedAt": {
+          "name": "awardedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "source": {
+          "name": "source",
+          "type": "badge_award_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_override": {
+          "name": "sort_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_badges_userId_user_id_fk": {
+          "name": "user_badges_userId_user_id_fk",
+          "tableFrom": "user_badges",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_badges_userId_badgeKey_pk": {
+          "name": "user_badges_userId_badgeKey_pk",
+          "columns": [
+            "userId",
+            "badgeKey"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.user_list_items": {
+      "name": "user_list_items",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_list_items_list_gear_uq": {
+          "name": "user_list_items_list_gear_uq",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_list_items_list_position_idx": {
+          "name": "user_list_items_list_position_idx",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_list_items_gear_idx": {
+          "name": "user_list_items_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_list_items_list_id_user_lists_id_fk": {
+          "name": "user_list_items_list_id_user_lists_id_fk",
+          "tableFrom": "user_list_items",
+          "tableTo": "user_lists",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_list_items_gear_id_gear_id_fk": {
+          "name": "user_list_items_gear_id_gear_id_fk",
+          "tableFrom": "user_list_items",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.user_lists": {
+      "name": "user_lists",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(140)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_lists_user_idx": {
+          "name": "user_lists_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_lists_user_created_idx": {
+          "name": "user_lists_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_lists_user_id_user_id_fk": {
+          "name": "user_lists_user_id_user_id_fk",
+          "tableFrom": "user_lists",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.user": {
+      "name": "user",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "member_number": {
+          "name": "member_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "user_member_number_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "invite_id": {
+          "name": "invite_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "developer_access_enabled": {
+          "name": "developer_access_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_handle_unique": {
+          "name": "user_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        },
+        "user_member_number_unique": {
+          "name": "user_member_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.wishlists": {
+      "name": "wishlists",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wishlist_gear_idx": {
+          "name": "wishlist_gear_idx",
+          "columns": [
+            {
+              "expression": "gear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wishlists_user_id_user_id_fk": {
+          "name": "wishlists_user_id_user_id_fk",
+          "tableFrom": "wishlists",
+          "tableTo": "user",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wishlists_gear_id_gear_id_fk": {
+          "name": "wishlists_gear_id_gear_id_fk",
+          "tableFrom": "wishlists",
+          "tableTo": "gear",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "wishlists_user_id_gear_id_pk": {
+          "name": "wishlists_user_id_gear_id_pk",
+          "columns": [
+            "user_id",
+            "gear_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.camera_af_subject_categories_enum": {
+      "name": "camera_af_subject_categories_enum",
+      "schema": "public",
+      "values": [
+        "people",
+        "animals",
+        "vehicles",
+        "birds",
+        "aircraft"
+      ]
+    },
+    "public.analog_medium_enum": {
+      "name": "analog_medium_enum",
+      "schema": "public",
+      "values": [
+        "35mm",
+        "half-frame",
+        "panoramic-35mm",
+        "aps",
+        "110",
+        "126-instamatic",
+        "828",
+        "120",
+        "220",
+        "127",
+        "620",
+        "large-format-4x5",
+        "large-format-5x7",
+        "large-format-8x10",
+        "ultra-large-format",
+        "sheet-film",
+        "metal-plate",
+        "glass-plate",
+        "experimental-other"
+      ]
+    },
+    "public.analog_types_enum": {
+      "name": "analog_types_enum",
+      "schema": "public",
+      "values": [
+        "single-lens-reflex-slr",
+        "rangefinder",
+        "twin-lens-reflex-tlr",
+        "point-and-shoot",
+        "large-format",
+        "instant-film",
+        "disposable",
+        "toy",
+        "stereo",
+        "panoramic",
+        "folding",
+        "box",
+        "pinhole",
+        "press"
+      ]
+    },
+    "public.analog_viewfinder_types_enum": {
+      "name": "analog_viewfinder_types_enum",
+      "schema": "public",
+      "values": [
+        "none",
+        "pentaprism",
+        "pentamirror",
+        "waist-level",
+        "sports-finder",
+        "rangefinder-style",
+        "ground-glass",
+        "other"
+      ]
+    },
+    "public.audit_action": {
+      "name": "audit_action",
+      "schema": "public",
+      "values": [
+        "GEAR_CREATE",
+        "GEAR_RENAME",
+        "GEAR_DELETE",
+        "GEAR_IMAGE_UPLOAD",
+        "GEAR_IMAGE_REPLACE",
+        "GEAR_IMAGE_REMOVE",
+        "GEAR_TOP_VIEW_UPLOAD",
+        "GEAR_TOP_VIEW_REPLACE",
+        "GEAR_TOP_VIEW_REMOVE",
+        "GEAR_REAR_VIEW_UPLOAD",
+        "GEAR_REAR_VIEW_REPLACE",
+        "GEAR_REAR_VIEW_REMOVE",
+        "GEAR_COLORWAY_CREATE",
+        "GEAR_COLORWAY_UPDATE",
+        "GEAR_COLORWAY_REORDER",
+        "GEAR_COLORWAY_DELETE",
+        "GEAR_COLORWAY_RESET",
+        "GEAR_COLORWAY_IMAGE_UPLOAD",
+        "GEAR_COLORWAY_IMAGE_REPLACE",
+        "GEAR_COLORWAY_IMAGE_REMOVE",
+        "GEAR_EDIT_PROPOSE",
+        "GEAR_EDIT_APPROVE",
+        "GEAR_EDIT_REJECT",
+        "GEAR_EDIT_MERGE",
+        "REVIEW_APPROVE",
+        "REVIEW_REJECT"
+      ]
+    },
+    "public.badge_award_source": {
+      "name": "badge_award_source",
+      "schema": "public",
+      "values": [
+        "auto",
+        "manual"
+      ]
+    },
+    "public.bingo_board_status": {
+      "name": "bingo_board_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "COMPLETED",
+        "EXPIRED",
+        "ARCHIVED"
+      ]
+    },
+    "public.bingo_event_type": {
+      "name": "bingo_event_type",
+      "schema": "public",
+      "values": [
+        "tile_completed",
+        "submission_created",
+        "score_updated",
+        "board_completed",
+        "board_expired",
+        "board_created",
+        "inactivity_timer_started",
+        "inactivity_timer_extended"
+      ]
+    },
+    "public.camera_type_enum": {
+      "name": "camera_type_enum",
+      "schema": "public",
+      "values": [
+        "dslr",
+        "mirrorless",
+        "slr",
+        "action",
+        "cinema"
+      ]
+    },
+    "public.card_bus_enum": {
+      "name": "card_bus_enum",
+      "schema": "public",
+      "values": [
+        "sd_default",
+        "uhs_i",
+        "uhs_ii",
+        "uhs_iii",
+        "sd_express",
+        "cfexpress_pcie_gen3x1",
+        "cfexpress_pcie_gen3x2",
+        "cfexpress_pcie_gen4x1",
+        "cfexpress_pcie_gen4x2",
+        "xqd_1_0",
+        "xqd_2_0",
+        "cfast_sata_ii",
+        "cfast_sata_iii",
+        "cf_udma4",
+        "cf_udma5",
+        "cf_udma6",
+        "cf_udma7",
+        "sxs_pcie_gen1",
+        "sxs_pcie_gen2",
+        "p2_pci"
+      ]
+    },
+    "public.card_form_factor_enum": {
+      "name": "card_form_factor_enum",
+      "schema": "public",
+      "values": [
+        "sd",
+        "micro_sd",
+        "cfexpress_type_a",
+        "cfexpress_type_b",
+        "cfexpress_type_c",
+        "xqd",
+        "cfast",
+        "compactflash_type_i",
+        "compactflash_type_ii",
+        "memory_stick_pro_duo",
+        "memory_stick_pro_hg_duo",
+        "xd_picture_card",
+        "smartmedia",
+        "sxs",
+        "p2"
+      ]
+    },
+    "public.card_speed_class_enum": {
+      "name": "card_speed_class_enum",
+      "schema": "public",
+      "values": [
+        "c2",
+        "c4",
+        "c6",
+        "c10",
+        "u1",
+        "u3",
+        "v6",
+        "v10",
+        "v30",
+        "v60",
+        "v90",
+        "vpg_20",
+        "vpg_65",
+        "vpg_130"
+      ]
+    },
+    "public.creator_video_platform": {
+      "name": "creator_video_platform",
+      "schema": "public",
+      "values": [
+        "YOUTUBE"
+      ]
+    },
+    "public.date_precision_enum": {
+      "name": "date_precision_enum",
+      "schema": "public",
+      "values": [
+        "YEAR",
+        "MONTH",
+        "DAY"
+      ]
+    },
+    "public.exif_primary_count_type_enum": {
+      "name": "exif_primary_count_type_enum",
+      "schema": "public",
+      "values": [
+        "total",
+        "mechanical",
+        "generic"
+      ]
+    },
+    "public.metering_mode_enum": {
+      "name": "metering_mode_enum",
+      "schema": "public",
+      "values": [
+        "average",
+        "center-weighted",
+        "spot",
+        "other"
+      ]
+    },
+    "public.exposure_modes_enum": {
+      "name": "exposure_modes_enum",
+      "schema": "public",
+      "values": [
+        "manual",
+        "aperture-priority",
+        "shutter-priority",
+        "program",
+        "auto",
+        "other"
+      ]
+    },
+    "public.film_transport_enum": {
+      "name": "film_transport_enum",
+      "schema": "public",
+      "values": [
+        "not-applicable",
+        "manual-lever",
+        "manual-knob",
+        "manual-other",
+        "motorized",
+        "other"
+      ]
+    },
+    "public.focus_aid_enum": {
+      "name": "focus_aid_enum",
+      "schema": "public",
+      "values": [
+        "none",
+        "split-prism",
+        "microprism",
+        "rangefinder-patch",
+        "electronic-confirm",
+        "electronic-directional",
+        "af-point"
+      ]
+    },
+    "public.gear_publication_state": {
+      "name": "gear_publication_state",
+      "schema": "public",
+      "values": [
+        "PUBLISHED",
+        "RUMORED",
+        "HIDDEN"
+      ]
+    },
+    "public.gear_region": {
+      "name": "gear_region",
+      "schema": "public",
+      "values": [
+        "GLOBAL",
+        "US",
+        "EU",
+        "JP"
+      ]
+    },
+    "public.gear_type": {
+      "name": "gear_type",
+      "schema": "public",
+      "values": [
+        "CAMERA",
+        "ANALOG_CAMERA",
+        "LENS"
+      ]
+    },
+    "public.iso_setting_method_enum": {
+      "name": "iso_setting_method_enum",
+      "schema": "public",
+      "values": [
+        "manual",
+        "dx-only",
+        "dx-with-override",
+        "fixed",
+        "other"
+      ]
+    },
+    "public.lens_filter_types_enum": {
+      "name": "lens_filter_types_enum",
+      "schema": "public",
+      "values": [
+        "none",
+        "front-screw-on",
+        "rear-screw-on",
+        "rear-bayonet",
+        "rear-gel-slot",
+        "rear-drop-in",
+        "internal-rotary"
+      ]
+    },
+    "public.lens_zoom_types_enum": {
+      "name": "lens_zoom_types_enum",
+      "schema": "public",
+      "values": [
+        "two-ring",
+        "push-pull",
+        "power-zoom",
+        "zoom-by-wire",
+        "collar-zoom",
+        "other"
+      ]
+    },
+    "public.metering_display_type_enum": {
+      "name": "metering_display_type_enum",
+      "schema": "public",
+      "values": [
+        "needle-middle",
+        "needle-match",
+        "led-indicators",
+        "led-scale",
+        "lcd-viewfinder",
+        "lcd-top-panel",
+        "none",
+        "other"
+      ]
+    },
+    "public.mount_material_enum": {
+      "name": "mount_material_enum",
+      "schema": "public",
+      "values": [
+        "metal",
+        "plastic"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "gear_spec_approved",
+        "badge_awarded",
+        "prompt_handle_setup"
+      ]
+    },
+    "public.popularity_event_type": {
+      "name": "popularity_event_type",
+      "schema": "public",
+      "values": [
+        "view",
+        "wishlist_add",
+        "owner_add",
+        "compare_add",
+        "review_submit",
+        "api_fetch"
+      ]
+    },
+    "public.popularity_timeframe": {
+      "name": "popularity_timeframe",
+      "schema": "public",
+      "values": [
+        "7d",
+        "30d"
+      ]
+    },
+    "public.proposal_status": {
+      "name": "proposal_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED",
+        "MERGED"
+      ]
+    },
+    "public.raw_bit_depth_enum": {
+      "name": "raw_bit_depth_enum",
+      "schema": "public",
+      "values": [
+        "10",
+        "12",
+        "14",
+        "16"
+      ]
+    },
+    "public.rear_display_types_enum": {
+      "name": "rear_display_types_enum",
+      "schema": "public",
+      "values": [
+        "none",
+        "fixed",
+        "single_axis_tilt",
+        "dual_axis_tilt",
+        "fully_articulated",
+        "four_axis_tilt_flip",
+        "other"
+      ]
+    },
+    "public.rec_group": {
+      "name": "rec_group",
+      "schema": "public",
+      "values": [
+        "prime",
+        "zoom"
+      ]
+    },
+    "public.rec_rating": {
+      "name": "rec_rating",
+      "schema": "public",
+      "values": [
+        "best value",
+        "best performance",
+        "situational",
+        "balanced"
+      ]
+    },
+    "public.review_flag_status": {
+      "name": "review_flag_status",
+      "schema": "public",
+      "values": [
+        "OPEN",
+        "RESOLVED_KEEP",
+        "RESOLVED_REJECTED",
+        "RESOLVED_DELETED"
+      ]
+    },
+    "public.review_status": {
+      "name": "review_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED"
+      ]
+    },
+    "public.sensor_stacking_types_enum": {
+      "name": "sensor_stacking_types_enum",
+      "schema": "public",
+      "values": [
+        "unstacked",
+        "partially-stacked",
+        "fully-stacked"
+      ]
+    },
+    "public.sensor_tech_types_enum": {
+      "name": "sensor_tech_types_enum",
+      "schema": "public",
+      "values": [
+        "cmos",
+        "ccd"
+      ]
+    },
+    "public.shutter_type_enum": {
+      "name": "shutter_type_enum",
+      "schema": "public",
+      "values": [
+        "focal-plane-cloth",
+        "focal-plane-metal",
+        "focal-plane-electronic",
+        "leaf",
+        "rotary",
+        "none",
+        "other"
+      ]
+    },
+    "public.shutter_types_enum": {
+      "name": "shutter_types_enum",
+      "schema": "public",
+      "values": [
+        "mechanical",
+        "efc",
+        "electronic"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "USER",
+        "MODERATOR",
+        "EDITOR",
+        "ADMIN",
+        "SUPERADMIN"
+      ]
+    },
+    "public.viewfinder_types_enum": {
+      "name": "viewfinder_types_enum",
+      "schema": "public",
+      "values": [
+        "none",
+        "optical",
+        "electronic"
+      ]
+    }
+  },
+  "schemas": {
+    "app": "app"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1784051102838,
       "tag": "0024_tiresome_lilandra",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1784291996503,
+      "tag": "0025_ordinary_valeria_richards",
+      "breakpoints": true
     }
   ]
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -158,6 +158,26 @@
     "latestReviewsTitle": "Neueste Reviews"
   },
   "gearDetail": {
+    "renameDialog": {
+      "title": "Ausrüstung umbenennen",
+      "description": "Aktualisiere den Namen dieses Ausrüstungsartikels. Slug und Suchindex werden automatisch aktualisiert.",
+      "currentName": "Aktueller Name",
+      "newName": "Neuer Name",
+      "newNamePlaceholder": "Neuen Namen eingeben...",
+      "canonicalHelp": "Das Markenpräfix wird automatisch hinzugefügt, wenn es fehlt.",
+      "regionalAliases": "Regionale Namen",
+      "regionalHelp": "Optionale vollständige Namen für bestimmte Regionen. Leer lassen, um einen Namen zu entfernen. Namen werden genau wie eingegeben gespeichert.",
+      "aliasPlaceholder": "Name für {region}",
+      "navigateAfterRename": "Nach dem Umbenennen zur Artikelseite wechseln",
+      "cancel": "Abbrechen",
+      "save": "Speichern",
+      "trigger": "Umbenennen",
+      "enterNewName": "Bitte gib einen neuen Namen ein",
+      "noChanges": "Keine Änderungen zum Speichern",
+      "saved": "Gespeichert",
+      "savedRenamed": "Gespeichert — umbenannt in „{name}“",
+      "failure": "Ausrüstung konnte nicht umbenannt werden"
+    },
     "metaTitleSuffix": "Spezifikationen & Reviews",
     "itemNotFoundTitle": "Eintrag nicht gefunden",
     "itemNotFoundDescription": "Die angeforderte Ausrüstung konnte nicht gefunden werden.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -158,6 +158,26 @@
     "latestReviewsTitle": "Latest Reviews"
   },
   "gearDetail": {
+    "renameDialog": {
+      "title": "Rename Gear Item",
+      "description": "Update this gear item's name. The slug and search index will be updated automatically.",
+      "currentName": "Current Name",
+      "newName": "New Name",
+      "newNamePlaceholder": "Enter a new name...",
+      "canonicalHelp": "The brand prefix will be added automatically if it is not present.",
+      "regionalAliases": "Regional Names",
+      "regionalHelp": "Optional complete names for specific regions. Leave a field blank to remove it. Names are saved exactly as entered.",
+      "aliasPlaceholder": "Name for {region}",
+      "navigateAfterRename": "Go to item page after renaming",
+      "cancel": "Cancel",
+      "save": "Save",
+      "trigger": "Rename",
+      "enterNewName": "Please enter a new name",
+      "noChanges": "No changes to save",
+      "saved": "Saved",
+      "savedRenamed": "Saved — renamed to \"{name}\"",
+      "failure": "Failed to rename gear"
+    },
     "metaTitleSuffix": "Specs & Reviews",
     "itemNotFoundTitle": "Item not found",
     "itemNotFoundDescription": "The requested gear could not be found.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -158,6 +158,26 @@
     "latestReviewsTitle": "Últimas reseñas"
   },
   "gearDetail": {
+    "renameDialog": {
+      "title": "Cambiar nombre del equipo",
+      "description": "Actualiza el nombre de este equipo. El slug y el índice de búsqueda se actualizarán automáticamente.",
+      "currentName": "Nombre actual",
+      "newName": "Nombre nuevo",
+      "newNamePlaceholder": "Introduce un nombre nuevo...",
+      "canonicalHelp": "El prefijo de la marca se añadirá automáticamente si falta.",
+      "regionalAliases": "Nombres regionales",
+      "regionalHelp": "Nombres completos opcionales para regiones concretas. Deja un campo vacío para eliminarlo. Los nombres se guardan exactamente como se introducen.",
+      "aliasPlaceholder": "Nombre para {region}",
+      "navigateAfterRename": "Ir a la página del equipo después de cambiar el nombre",
+      "cancel": "Cancelar",
+      "save": "Guardar",
+      "trigger": "Cambiar nombre",
+      "enterNewName": "Introduce un nombre nuevo",
+      "noChanges": "No hay cambios para guardar",
+      "saved": "Guardado",
+      "savedRenamed": "Guardado — nombre cambiado a \"{name}\"",
+      "failure": "No se pudo cambiar el nombre del equipo"
+    },
     "metaTitleSuffix": "Especificaciones y reviews",
     "itemNotFoundTitle": "Elemento no encontrado",
     "itemNotFoundDescription": "No se pudo encontrar el equipo solicitado.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -158,6 +158,26 @@
     "latestReviewsTitle": "Derniers avis"
   },
   "gearDetail": {
+    "renameDialog": {
+      "title": "Renommer le matériel",
+      "description": "Modifiez le nom de ce matériel. Le slug et l’index de recherche seront mis à jour automatiquement.",
+      "currentName": "Nom actuel",
+      "newName": "Nouveau nom",
+      "newNamePlaceholder": "Saisissez un nouveau nom...",
+      "canonicalHelp": "Le préfixe de la marque sera ajouté automatiquement s’il est absent.",
+      "regionalAliases": "Noms régionaux",
+      "regionalHelp": "Noms complets facultatifs pour certaines régions. Laissez un champ vide pour le supprimer. Les noms sont enregistrés exactement comme saisis.",
+      "aliasPlaceholder": "Nom pour {region}",
+      "navigateAfterRename": "Accéder à la page du matériel après le renommage",
+      "cancel": "Annuler",
+      "save": "Enregistrer",
+      "trigger": "Renommer",
+      "enterNewName": "Veuillez saisir un nouveau nom",
+      "noChanges": "Aucune modification à enregistrer",
+      "saved": "Enregistré",
+      "savedRenamed": "Enregistré — renommé en « {name} »",
+      "failure": "Impossible de renommer le matériel"
+    },
     "metaTitleSuffix": "Spécifications et avis",
     "itemNotFoundTitle": "Article introuvable",
     "itemNotFoundDescription": "Le matériel demandé est introuvable.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -158,6 +158,26 @@
     "latestReviewsTitle": "Ultime recensioni"
   },
   "gearDetail": {
+    "renameDialog": {
+      "title": "Rinomina attrezzatura",
+      "description": "Aggiorna il nome di questa attrezzatura. Lo slug e l’indice di ricerca verranno aggiornati automaticamente.",
+      "currentName": "Nome attuale",
+      "newName": "Nuovo nome",
+      "newNamePlaceholder": "Inserisci un nuovo nome...",
+      "canonicalHelp": "Il prefisso del marchio verrà aggiunto automaticamente se non è presente.",
+      "regionalAliases": "Nomi regionali",
+      "regionalHelp": "Nomi completi facoltativi per regioni specifiche. Lascia vuoto un campo per rimuoverlo. I nomi vengono salvati esattamente come inseriti.",
+      "aliasPlaceholder": "Nome per {region}",
+      "navigateAfterRename": "Vai alla pagina dell’articolo dopo averlo rinominato",
+      "cancel": "Annulla",
+      "save": "Salva",
+      "trigger": "Rinomina",
+      "enterNewName": "Inserisci un nuovo nome",
+      "noChanges": "Nessuna modifica da salvare",
+      "saved": "Salvato",
+      "savedRenamed": "Salvato — rinominato in \"{name}\"",
+      "failure": "Impossibile rinominare l’attrezzatura"
+    },
     "metaTitleSuffix": "Specifiche e reviews",
     "itemNotFoundTitle": "Elemento non trovato",
     "itemNotFoundDescription": "L’attrezzatura richiesta non è stata trovata.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -158,6 +158,26 @@
     "latestReviewsTitle": "最新レビュー"
   },
   "gearDetail": {
+    "renameDialog": {
+      "title": "機材名を変更",
+      "description": "この機材の名前を更新します。スラッグと検索インデックスは自動的に更新されます。",
+      "currentName": "現在の名前",
+      "newName": "新しい名前",
+      "newNamePlaceholder": "新しい名前を入力...",
+      "canonicalHelp": "ブランド名が含まれていない場合は自動的に追加されます。",
+      "regionalAliases": "地域別の名前",
+      "regionalHelp": "特定の地域で使用する完全な名前を任意で入力できます。削除するには空欄にしてください。名前は入力どおりに保存されます。",
+      "aliasPlaceholder": "{region}向けの名前",
+      "navigateAfterRename": "名前の変更後に機材ページへ移動",
+      "cancel": "キャンセル",
+      "save": "保存",
+      "trigger": "名前を変更",
+      "enterNewName": "新しい名前を入力してください",
+      "noChanges": "保存する変更はありません",
+      "saved": "保存しました",
+      "savedRenamed": "保存しました — 「{name}」に変更しました",
+      "failure": "機材名を変更できませんでした"
+    },
     "metaTitleSuffix": "スペック＆レビュー",
     "itemNotFoundTitle": "機材が見つかりません",
     "itemNotFoundDescription": "指定された機材は見つかりませんでした。",

--- a/messages/ms.json
+++ b/messages/ms.json
@@ -158,6 +158,26 @@
     "latestReviewsTitle": "Ulasan Terkini"
   },
   "gearDetail": {
+    "renameDialog": {
+      "title": "Namakan semula peralatan",
+      "description": "Kemas kini nama peralatan ini. Slug dan indeks carian akan dikemas kini secara automatik.",
+      "currentName": "Nama semasa",
+      "newName": "Nama baharu",
+      "newNamePlaceholder": "Masukkan nama baharu...",
+      "canonicalHelp": "Awalan jenama akan ditambah secara automatik jika tiada.",
+      "regionalAliases": "Nama serantau",
+      "regionalHelp": "Nama penuh pilihan untuk wilayah tertentu. Biarkan medan kosong untuk membuangnya. Nama disimpan tepat seperti yang dimasukkan.",
+      "aliasPlaceholder": "Nama untuk {region}",
+      "navigateAfterRename": "Pergi ke halaman item selepas menamakan semula",
+      "cancel": "Batal",
+      "save": "Simpan",
+      "trigger": "Namakan semula",
+      "enterNewName": "Sila masukkan nama baharu",
+      "noChanges": "Tiada perubahan untuk disimpan",
+      "saved": "Disimpan",
+      "savedRenamed": "Disimpan — dinamakan semula kepada \"{name}\"",
+      "failure": "Gagal menamakan semula peralatan"
+    },
     "metaTitleSuffix": "Spesifikasi & Ulasan",
     "itemNotFoundTitle": "Item tidak ditemui",
     "itemNotFoundDescription": "Gear yang diminta tidak ditemui.",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -158,6 +158,26 @@
     "latestReviewsTitle": "最新评论"
   },
   "gearDetail": {
+    "renameDialog": {
+      "title": "重命名器材",
+      "description": "更新此器材的名称。URL 标识和搜索索引将自动更新。",
+      "currentName": "当前名称",
+      "newName": "新名称",
+      "newNamePlaceholder": "输入新名称...",
+      "canonicalHelp": "如果未包含品牌前缀，系统会自动添加。",
+      "regionalAliases": "地区名称",
+      "regionalHelp": "可为特定地区填写完整名称。留空即可删除。名称会按输入内容原样保存。",
+      "aliasPlaceholder": "{region} 地区名称",
+      "navigateAfterRename": "重命名后前往器材页面",
+      "cancel": "取消",
+      "save": "保存",
+      "trigger": "重命名",
+      "enterNewName": "请输入新名称",
+      "noChanges": "没有可保存的更改",
+      "saved": "已保存",
+      "savedRenamed": "已保存 — 已重命名为“{name}”",
+      "failure": "器材重命名失败"
+    },
     "metaTitleSuffix": "规格与评论",
     "itemNotFoundTitle": "未找到项目",
     "itemNotFoundDescription": "找不到请求的器材。",

--- a/src/app/[locale]/(admin)/admin/gear/columns.tsx
+++ b/src/app/[locale]/(admin)/admin/gear/columns.tsx
@@ -106,7 +106,6 @@ function GearActionsCell({ row }: { row: { original: AdminGearTableRow } }) {
         gearId={row.original.id}
         currentName={row.original.name}
         currentSlug={row.original.slug}
-        brandName={row.original.brandName}
         showNavigateOption
         onSuccess={(res) => {
           // Optimistically update any cached admin gear list pages where this row exists,

--- a/src/app/[locale]/(pages)/gear/[slug]/page.tsx
+++ b/src/app/[locale]/(pages)/gear/[slug]/page.tsx
@@ -310,7 +310,6 @@ export default async function GearPage({ params }: GearPageProps) {
               gearId={item.id}
               currentName={item.name}
               currentSlug={item.slug}
-              brandName={item.brands?.name ?? brand?.name ?? null}
               regionalAliases={item.regionalAliases ?? undefined}
             />
           </div>

--- a/src/app/[locale]/(pages)/u/_components/lists/list-sortable-items.tsx
+++ b/src/app/[locale]/(pages)/u/_components/lists/list-sortable-items.tsx
@@ -30,7 +30,7 @@ export type SortableUserListItem = {
     name: string;
     regionalAliases: Array<{
       gearId: string;
-      region: "GLOBAL" | "EU" | "JP";
+      region: "GLOBAL" | "US" | "EU" | "JP";
       name: string;
       createdAt: string | Date;
       updatedAt: string | Date;

--- a/src/app/[locale]/(pages)/u/_components/lists/types.ts
+++ b/src/app/[locale]/(pages)/u/_components/lists/types.ts
@@ -15,7 +15,7 @@ export type ProfileUserListState = {
       name: string;
       regionalAliases: Array<{
         gearId: string;
-        region: "GLOBAL" | "EU" | "JP";
+        region: "GLOBAL" | "US" | "EU" | "JP";
         name: string;
         createdAt: string | Date;
         updatedAt: string | Date;

--- a/src/components/gear/rename-gear-button.tsx
+++ b/src/components/gear/rename-gear-button.tsx
@@ -12,14 +12,12 @@ interface RenameGearButtonProps {
   currentName: string;
   currentSlug: string;
   regionalAliases?: GearAlias[] | null;
-  brandName?: string | null;
 }
 
 export function RenameGearButton({
   gearId,
   currentName,
   currentSlug,
-  brandName,
   regionalAliases,
 }: RenameGearButtonProps) {
   const { data } = useSession();
@@ -34,7 +32,6 @@ export function RenameGearButton({
       gearId={gearId}
       currentName={currentName}
       currentSlug={currentSlug}
-      brandName={brandName}
       regionalAliases={regionalAliases ?? undefined}
       trigger={
         <Button variant="ghost" size="sm">

--- a/src/components/gear/rename-gear-dialog-utils.ts
+++ b/src/components/gear/rename-gear-dialog-utils.ts
@@ -1,0 +1,37 @@
+import type { GearRegion } from "~/lib/gear/region";
+import type { GearAlias } from "~/types/gear";
+
+export type AliasMap = Partial<Record<GearRegion, string>>;
+
+export const ALIAS_REGIONS: GearRegion[] = ["US", "EU", "JP"];
+
+export function buildRegionalAliasUpdates(aliases: AliasMap) {
+  return ALIAS_REGIONS.map((region) => {
+    const name = (aliases[region] ?? "").trim();
+    return { region, name: name || null };
+  });
+}
+
+export function buildInitialAliasMap(
+  regionalAliases: readonly GearAlias[] | undefined,
+): AliasMap {
+  const map: AliasMap = {};
+  for (const entry of regionalAliases ?? []) {
+    if (ALIAS_REGIONS.includes(entry.region)) {
+      map[entry.region] = entry.name ?? "";
+    }
+  }
+  return map;
+}
+
+export function getRenameGearDialogOpenState(params: {
+  currentName: string;
+  defaultNavigateAfterRename: boolean;
+  regionalAliases: readonly GearAlias[] | undefined;
+}) {
+  return {
+    newName: params.currentName,
+    navigateAfterRename: params.defaultNavigateAfterRename,
+    aliases: buildInitialAliasMap(params.regionalAliases),
+  };
+}

--- a/src/components/gear/rename-gear-dialog.tsx
+++ b/src/components/gear/rename-gear-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useEffect,useMemo,useState,useTransition } from "react";
 import { toast } from "sonner";
 import { Button } from "~/components/ui/button";
@@ -16,57 +17,25 @@ import {
 } from "~/components/ui/dialog";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
-import { type GearRegion } from "~/lib/gear/region";
 import {
   actionRenameGear,
   actionUpdateGearAliases,
 } from "~/server/admin/gear/actions";
 import type { GearAlias } from "~/types/gear";
+import {
+  ALIAS_REGIONS,
+  buildInitialAliasMap,
+  buildRegionalAliasUpdates,
+  getRenameGearDialogOpenState,
+  type AliasMap,
+} from "./rename-gear-dialog-utils";
 
-type AliasMap = Partial<Record<GearRegion, string>>;
-const ALIAS_REGIONS: GearRegion[] = ["EU", "JP"];
 const EMPTY_REGIONAL_ALIASES: GearAlias[] = [];
-
-function ensureBrandPrefix(value: string, brandName: string | null): string {
-  if (!brandName) return value;
-  const normalizedValue = value.trim();
-  const normalizedBrand = brandName.trim();
-  if (!normalizedBrand) return normalizedValue;
-  const lowerValue = normalizedValue.toLowerCase();
-  const lowerBrand = normalizedBrand.toLowerCase();
-  if (lowerValue.startsWith(lowerBrand)) return normalizedValue;
-  return `${normalizedBrand} ${normalizedValue}`.trim();
-}
-
-export function buildInitialAliasMap(
-  regionalAliases: readonly GearAlias[] | undefined,
-): AliasMap {
-  const map: AliasMap = {};
-  for (const entry of regionalAliases ?? EMPTY_REGIONAL_ALIASES) {
-    if (ALIAS_REGIONS.includes(entry.region)) {
-      map[entry.region] = entry.name ?? "";
-    }
-  }
-  return map;
-}
-
-export function getRenameGearDialogOpenState(params: {
-  currentName: string;
-  defaultNavigateAfterRename: boolean;
-  regionalAliases: readonly GearAlias[] | undefined;
-}) {
-  return {
-    newName: params.currentName,
-    navigateAfterRename: params.defaultNavigateAfterRename,
-    aliases: buildInitialAliasMap(params.regionalAliases),
-  };
-}
 
 interface RenameGearDialogProps {
   gearId: string;
   currentName: string;
   currentSlug: string;
-  brandName?: string | null;
   regionalAliases?: GearAlias[];
   trigger?: React.ReactNode;
   onSuccess?: (result: { id: string; name: string; slug: string }) => void;
@@ -86,7 +55,6 @@ export function RenameGearDialog({
   gearId,
   currentName,
   currentSlug,
-  brandName,
   regionalAliases,
   trigger,
   onSuccess,
@@ -101,6 +69,7 @@ export function RenameGearDialog({
   );
   const [isPending, startTransition] = useTransition();
   const router = useRouter();
+  const t = useTranslations("gearDetail.renameDialog");
   const stableRegionalAliases = regionalAliases ?? EMPTY_REGIONAL_ALIASES;
 
   const initialAliasMap = useMemo<AliasMap>(() => {
@@ -141,12 +110,12 @@ export function RenameGearDialog({
     e.preventDefault();
 
     if (!trimmedName) {
-      toast.error("Please enter a new name");
+      toast.error(t("enterNewName"));
       return;
     }
 
     if (!hasChanges) {
-      toast.info("No changes to save");
+      toast.info(t("noChanges"));
       return;
     }
 
@@ -167,22 +136,15 @@ export function RenameGearDialog({
 
         // Handle alias updates if changed
         if (aliasChanged) {
-          const brandAwareAliases = ALIAS_REGIONS.map((region) => {
-            const raw = trimmedAliases[region] || "";
-            return {
-              region,
-              name: raw ? ensureBrandPrefix(raw, brandName ?? null) : null,
-            };
-          });
           await actionUpdateGearAliases({
             gearId,
             gearSlug: resultSlug,
-            aliases: brandAwareAliases,
+            aliases: buildRegionalAliasUpdates(trimmedAliases),
           });
         }
 
         toast.success(
-          `Saved${nameChanged ? ` — renamed to "${resultName}"` : ""}`,
+          nameChanged ? t("savedRenamed", { name: resultName }) : t("saved"),
         );
         setOpen(false);
 
@@ -197,8 +159,7 @@ export function RenameGearDialog({
 
         onSuccess?.({ id: gearId, name: resultName, slug: resultSlug });
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "Failed to rename gear";
+        const message = error instanceof Error ? error.message : t("failure");
         toast.error(message);
       }
     });
@@ -207,21 +168,18 @@ export function RenameGearDialog({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        {trigger ?? <Button variant="outline">Rename</Button>}
+        {trigger ?? <Button variant="outline">{t("trigger")}</Button>}
       </DialogTrigger>
       <DialogContent className="sm:max-w-[500px]">
         <form onSubmit={handleSubmit}>
           <DialogHeader>
-            <DialogTitle>Rename Gear Item</DialogTitle>
-            <DialogDescription>
-              Update the name of this gear item. The slug and search index will
-              be automatically updated.
-            </DialogDescription>
+            <DialogTitle>{t("title")}</DialogTitle>
+            <DialogDescription>{t("description")}</DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 py-4">
             <div className="grid gap-2">
               <Label htmlFor="current-name" className="text-muted-foreground">
-                Current Name
+                {t("currentName")}
               </Label>
               <Input
                 id="current-name"
@@ -231,24 +189,23 @@ export function RenameGearDialog({
               />
             </div>
             <div className="grid gap-2">
-              <Label htmlFor="new-name">New Name</Label>
+              <Label htmlFor="new-name">{t("newName")}</Label>
               <Input
                 id="new-name"
-                placeholder="Enter new name..."
+                placeholder={t("newNamePlaceholder")}
                 value={newName}
                 onChange={(e) => setNewName(e.target.value)}
                 disabled={isPending}
                 autoFocus
               />
               <p className="text-muted-foreground text-xs">
-                Brand prefix will be added automatically if not present.
+                {t("canonicalHelp")}
               </p>
             </div>
             <div className="grid gap-2">
-              <Label>Regional Aliases</Label>
+              <Label>{t("regionalAliases")}</Label>
               <p className="text-muted-foreground text-xs">
-                Optional localized names for specific regions (leave blank to
-                remove). Brand prefix will be added automatically.
+                {t("regionalHelp")}
               </p>
               <div className="grid gap-2">
                 {ALIAS_REGIONS.map((region) => (
@@ -257,7 +214,7 @@ export function RenameGearDialog({
                       {region}
                     </Label>
                     <Input
-                      placeholder={`Alias for ${region}`}
+                      placeholder={t("aliasPlaceholder", { region })}
                       value={aliases[region] ?? ""}
                       onChange={(e) =>
                         setAliases((prev) => ({
@@ -282,7 +239,7 @@ export function RenameGearDialog({
                   disabled={isPending}
                 />
                 <Label htmlFor="navigate-after-rename">
-                  Go to item page after renaming
+                  {t("navigateAfterRename")}
                 </Label>
               </div>
             ) : null}
@@ -294,14 +251,14 @@ export function RenameGearDialog({
               onClick={() => setOpen(false)}
               disabled={isPending}
             >
-              Cancel
+              {t("cancel")}
             </Button>
             <Button
               type="submit"
               disabled={isPending || !trimmedName || !hasChanges}
               loading={isPending}
             >
-              Rename
+              {t("save")}
             </Button>
           </DialogFooter>
         </form>

--- a/src/lib/gear/region.ts
+++ b/src/lib/gear/region.ts
@@ -1,4 +1,4 @@
-export const GEAR_REGIONS = ["GLOBAL", "EU", "JP"] as const;
+export const GEAR_REGIONS = ["GLOBAL", "US", "EU", "JP"] as const;
 
 export type GearRegion = (typeof GEAR_REGIONS)[number];
 
@@ -39,6 +39,7 @@ export function resolveRegionFromCountryCode(
 ): GearRegion {
   if (!countryCode) return "GLOBAL";
   const normalized = countryCode.trim().slice(0, 2).toUpperCase();
+  if (normalized === "US") return "US";
   if (normalized === "UK" || normalized === "GB") return "EU";
   if (normalized === "EU") return "EU";
   if (normalized === JP_COUNTRY_CODE) return "JP";

--- a/src/lib/locale/locales.ts
+++ b/src/lib/locale/locales.ts
@@ -45,7 +45,7 @@ export const LOCALE_OPTIONS: LocaleOption[] = [
     label: "United States",
     countryCode: "US",
     affiliateCountryCode: "US",
-    gearRegion: "GLOBAL",
+    gearRegion: "US",
     mpb: {
       isSupported: true,
       market: "US",
@@ -252,9 +252,10 @@ const DEFAULT_LANGUAGE_MARKET_BY_LOCALE: Record<Locale, LanguageMarketOption> = 
 };
 
 const REGION_DEFAULT_LOCALE_ID: Partial<Record<GearRegion, LocaleId>> = {
+  US: "us",
   EU: "eu",
   JP: "jp",
-  GLOBAL: "us",
+  GLOBAL: "global",
 };
 
 export function getLocaleById(

--- a/src/lib/specs/registry.tsx
+++ b/src/lib/specs/registry.tsx
@@ -575,6 +575,11 @@ export const specDictionary: SpecSectionDef[] = [
             entries.push({ label: "Default Name", name: item.name });
           }
 
+          const usAlias = findAlias("US");
+          if (usAlias && viewer !== "US") {
+            entries.push({ label: "US", name: usAlias });
+          }
+
           const euAlias = findAlias("EU");
           if (euAlias && viewer !== "EU") {
             entries.push({ label: "EU Name", name: euAlias });

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -52,7 +52,12 @@ export const gearPublicationStateEnum = pgEnum("gear_publication_state", [
   "RUMORED",
   "HIDDEN",
 ]);
-export const gearRegionEnum = pgEnum("gear_region", ["GLOBAL", "EU", "JP"]);
+export const gearRegionEnum = pgEnum("gear_region", [
+  "GLOBAL",
+  "US",
+  "EU",
+  "JP",
+]);
 export const proposalStatusEnum = pgEnum("proposal_status", [
   "PENDING",
   "APPROVED",

--- a/src/server/developer-api/schemas.ts
+++ b/src/server/developer-api/schemas.ts
@@ -31,13 +31,13 @@ export function parseSuggestionParams(searchParams: URLSearchParams) {
   const query = querySchema.safeParse(searchParams.get("q"));
   const limit = positiveInteger(searchParams.get("limit"), 8, 10);
   const regionValue = searchParams.get("region") ?? "GLOBAL";
-  const region = z.enum(["GLOBAL", "EU", "JP"]).safeParse(regionValue);
+  const region = z.enum(["GLOBAL", "US", "EU", "JP"]).safeParse(regionValue);
 
   if (!query.success || limit === null || !region.success) {
     throw new DeveloperApiError(
       "invalid_request",
       400,
-      "q must be 2–200 characters, limit must be a positive integer, and region must be GLOBAL, EU, or JP.",
+      "q must be 2–200 characters, limit must be a positive integer, and region must be GLOBAL, US, EU, or JP.",
     );
   }
 

--- a/src/server/user-lists/service.ts
+++ b/src/server/user-lists/service.ts
@@ -43,7 +43,7 @@ export type UserListItemDto = {
     name: string;
     regionalAliases: Array<{
       gearId: string;
-      region: "GLOBAL" | "EU" | "JP";
+      region: "GLOBAL" | "US" | "EU" | "JP";
       name: string;
       createdAt: Date;
       updatedAt: Date;

--- a/tests/unit/developer-api-schemas-serializers.test.ts
+++ b/tests/unit/developer-api-schemas-serializers.test.ts
@@ -27,11 +27,17 @@ describe("developer API request schemas", () => {
       parseSearchParams(new URLSearchParams("q=x&limit=26")),
     ).toThrow(DeveloperApiError);
     expect(() =>
-      parseSuggestionParams(new URLSearchParams("q=Z6&region=US")),
+      parseSuggestionParams(new URLSearchParams("q=Z6&region=CA")),
     ).toThrow(DeveloperApiError);
     expect(() => parseSpecSelectors(new URLSearchParams())).toThrow(
       DeveloperApiError,
     );
+  });
+
+  it("accepts the US suggestion region", () => {
+    expect(
+      parseSuggestionParams(new URLSearchParams("q=Rokinon&region=US")),
+    ).toEqual({ query: "Rokinon", limit: 8, region: "US" });
   });
 
   it("parses bounded spec field and category selectors", () => {

--- a/tests/unit/gear-naming.test.ts
+++ b/tests/unit/gear-naming.test.ts
@@ -1,0 +1,66 @@
+import { describe,expect,it } from "vitest";
+import {
+  buildGearSearchName,
+  GetGearDisplayName,
+} from "~/lib/gear/naming";
+import { resolveRegionFromCountryCode } from "~/lib/gear/region";
+import type { GearAlias } from "~/types/gear";
+
+const aliases = [
+  { region: "US", name: "Rokinon AF 35mm F1.8" },
+  { region: "EU", name: "Samyang AF 35mm F1.8" },
+  { region: "JP", name: "Samyang AF 35mm F1.8 FE" },
+] as GearAlias[];
+
+describe("regional gear naming", () => {
+  it("resolves US aliases without changing other regional behavior", () => {
+    const item = { name: "Samyang AF 35mm F1.8", regionalAliases: aliases };
+
+    expect(GetGearDisplayName(item, { region: "US" })).toBe(
+      "Rokinon AF 35mm F1.8",
+    );
+    expect(GetGearDisplayName(item, { region: "EU" })).toBe(
+      "Samyang AF 35mm F1.8",
+    );
+    expect(GetGearDisplayName(item, { region: "JP" })).toBe(
+      "Samyang AF 35mm F1.8 FE",
+    );
+    expect(GetGearDisplayName(item, { region: "GLOBAL" })).toBe(
+      "Samyang AF 35mm F1.8",
+    );
+  });
+
+  it("falls back from a missing US alias directly to the canonical name", () => {
+    expect(
+      GetGearDisplayName(
+        {
+          name: "Canon EOS Rebel T7i",
+          regionalAliases: [
+            { region: "GLOBAL", name: "Unexpected global alias" },
+            { region: "EU", name: "Canon EOS 800D" },
+            { region: "JP", name: "Canon EOS Kiss X9i" },
+          ] as GearAlias[],
+        },
+        { region: "US" },
+      ),
+    ).toBe("Canon EOS Rebel T7i");
+  });
+
+  it("maps US country codes to the US region", () => {
+    expect(resolveRegionFromCountryCode("US")).toBe("US");
+    expect(resolveRegionFromCountryCode(null)).toBe("GLOBAL");
+    expect(resolveRegionFromCountryCode("DE")).toBe("EU");
+    expect(resolveRegionFromCountryCode("JP")).toBe("JP");
+  });
+
+  it("indexes canonical and brand-independent US names together", () => {
+    const searchName = buildGearSearchName({
+      name: "Samyang AF 35mm F1.8",
+      brandName: "Samyang",
+      aliases: ["Rokinon AF 35mm F1.8"],
+    });
+
+    expect(searchName).toContain("samyang af 35mm f1 8");
+    expect(searchName).toContain("rokinon af 35mm f1 8");
+  });
+});

--- a/tests/unit/locale-market-detection.test.ts
+++ b/tests/unit/locale-market-detection.test.ts
@@ -6,6 +6,13 @@ import {
 } from "~/lib/locale/locales";
 
 describe("locale market detection", () => {
+  it("maps the United States locale to the US gear region", () => {
+    expect(resolveLocaleFromCountryCode("US")).toMatchObject({
+      id: "us",
+      gearRegion: "US",
+    });
+  });
+
   it("resolves dedicated MPB countries to their own markets", () => {
     expect(resolveLocaleFromCountryCode("DE").id).toBe("de");
     expect(resolveLocaleFromCountryCode("FR").id).toBe("fr");

--- a/tests/unit/rename-gear-dialog.test.ts
+++ b/tests/unit/rename-gear-dialog.test.ts
@@ -10,6 +10,17 @@ const navigationMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("next/navigation", () => navigationMocks);
+vi.mock("next-intl", () => ({
+  useTranslations: () =>
+    (key: string, values?: Record<string, string>) => {
+      const messages: Record<string, string> = {
+        title: "Rename Gear Item",
+        navigateAfterRename: "Go to item page after renaming",
+      };
+      if (key === "aliasPlaceholder") return `Name for ${values?.region}`;
+      return messages[key] ?? key;
+    },
+}));
 vi.mock("sonner", () => ({
   toast: {
     error: vi.fn(),
@@ -68,11 +79,12 @@ vi.mock("~/components/ui/dialog", () => ({
     createElement("h2", props, children),
 }));
 
+import { RenameGearDialog } from "~/components/gear/rename-gear-dialog";
 import {
   buildInitialAliasMap,
+  buildRegionalAliasUpdates,
   getRenameGearDialogOpenState,
-  RenameGearDialog,
-} from "~/components/gear/rename-gear-dialog";
+} from "~/components/gear/rename-gear-dialog-utils";
 
 describe("RenameGearDialog", () => {
   it("renders without aliases and includes the navigate option", () => {
@@ -106,8 +118,15 @@ describe("RenameGearDialog", () => {
     });
   });
 
-  it("prepopulates the EU and JP aliases in the dialog open state", () => {
+  it("prepopulates the US, EU, and JP aliases in the dialog open state", () => {
     const regionalAliases = [
+      {
+        gearId: "gear-1",
+        region: "US" as const,
+        name: "Rokinon AF 35mm F1.8",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
       {
         gearId: "gear-1",
         region: "EU" as const,
@@ -125,6 +144,7 @@ describe("RenameGearDialog", () => {
     ];
 
     expect(buildInitialAliasMap(regionalAliases)).toEqual({
+      US: "Rokinon AF 35mm F1.8",
       EU: "Canon EOS R5 EU",
       JP: "Canon EOS R5 JP",
     });
@@ -139,9 +159,24 @@ describe("RenameGearDialog", () => {
       newName: "Canon EOS R5",
       navigateAfterRename: false,
       aliases: {
+        US: "Rokinon AF 35mm F1.8",
         EU: "Canon EOS R5 EU",
         JP: "Canon EOS R5 JP",
       },
     });
+  });
+
+  it("builds verbatim regional alias updates and nulls blank values", () => {
+    expect(
+      buildRegionalAliasUpdates({
+        US: "  Rokinon AF 35mm F1.8  ",
+        EU: "Samyang AF 35mm F1.8",
+        JP: "   ",
+      }),
+    ).toEqual([
+      { region: "US", name: "Rokinon AF 35mm F1.8" },
+      { region: "EU", name: "Samyang AF 35mm F1.8" },
+      { region: "JP", name: null },
+    ]);
   });
 });

--- a/tests/unit/search-service.test.ts
+++ b/tests/unit/search-service.test.ts
@@ -179,6 +179,38 @@ describe("search service high-impact behavior", () => {
     });
   });
 
+  it("shows a brand-independent US alias with the canonical name underneath", async () => {
+    searchDataMocks.queryGearSuggestions.mockResolvedValue([
+      {
+        id: "gear-1",
+        name: "Samyang AF 35mm F1.8",
+        slug: "samyang-af-35mm-f1-8",
+        brandName: "Samyang",
+        gearType: "LENS",
+        relevance: 0.95,
+      },
+    ]);
+    gearDataMocks.fetchGearAliasesByGearIds.mockResolvedValue(
+      new Map([
+        [
+          "gear-1",
+          [{ region: "US", name: "Rokinon AF 35mm F1.8" }],
+        ],
+      ]),
+    );
+
+    const suggestions = await getSuggestions("Rokinon AF 35mm", 8, "US");
+
+    expect(suggestions[0]).toMatchObject({
+      title: "Rokinon AF 35mm F1.8",
+      subtitle: "Samyang AF 35mm F1.8",
+      localizedName: "Rokinon AF 35mm F1.8",
+      matchedName: "Rokinon AF 35mm F1.8",
+      matchSource: "localized",
+      isBestMatch: true,
+    });
+  });
+
   it("shows a matched non-local alias as the title with the viewer-local name underneath", async () => {
     searchDataMocks.queryGearSuggestions.mockResolvedValue([
       {


### PR DESCRIPTION
## Summary

- add `US` as a distinct optional gear naming region
- allow complete US/EU/JP regional names without forcing the canonical brand prefix
- preserve canonical fallback behavior when a US alias is absent
- include the generated `0025` migration for the `gear_region` enum
- update locale resolution, search, developer API validation, specs display, translations, tests, and documentation

## Why

Some products use a different market-facing brand in the United States, such as Samyang products sold as Rokinon. This supports that naming without changing the canonical/global catalog identity.

## Validation

- `npm run test` — 165 files, 729 tests passed
- targeted regional naming/search/API/translation suite — 56 tests passed
- scoped ESLint — passed with no errors
- React Doctor — no issues
- migration journal and snapshot chain verified against `0024`

## Known baseline issue

Repository-wide TypeScript checking still reports the existing untouched `tests/unit/spec-registry-i18n.test.ts:257` mismatch where the test supplies `string | number` to numeric `weightGrams`.