### PR TITLE
feat: backfill Nikon lens image circles from DX naming

### DIFF
--- a/docs/gear-specification-system.md
+++ b/docs/gear-specification-system.md
@@ -141,6 +141,20 @@ Stores detailed lens-specific specifications:
 - **Stabilization**: Whether the lens has stabilization
 - **Flexibility**: JSONB extra field for additional specs
 
+Nikon DX naming heuristic: for `gear_type = LENS` with brand slug `nikon`, a
+whole-token `DX` in the gear name (case-insensitive) maps to sensor format slug
+`aps-c`; otherwise the lens maps to `full-frame`. Apply with the CLI backfill
+(dry-run by default; pass `--apply` to write):
+
+```bash
+npm run gear:backfill-nikon-image-circles
+npm run gear:backfill-nikon-image-circles -- --apply
+```
+
+The script updates `lens_specs.image_circle_size_id` only when the target differs
+from the current value. It does not touch `fixed_lens_specs` or non-LENS gear.
+Point `DATABASE_URL` at a development/preview database before applying.
+
 Admin CSV bulk import can create the initial lens spec row with mapped values.
 The lens-oriented template includes `imageCircleSize`, which accepts a sensor
 format slug, id, or exact name and stores the resolved `sensor_formats.id`.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "db:seed": "tsx scripts/seed.ts",
     "reviews:generate-fake-summary": "tsx scripts/generate-fake-review-summary.ts",
     "gear:list-missing-links": "tsx scripts/list-missing-links.ts",
+    "gear:backfill-nikon-image-circles": "tsx scripts/backfill-nikon-lens-image-circles.ts",
     "raw-samples:cleanup": "tsx scripts/cleanup-deleted-raw-samples.ts",
     "constants:generate": "tsx scripts/generate-constants.ts",
     "dev": "next dev --turbo",

--- a/scripts/backfill-nikon-lens-image-circles.ts
+++ b/scripts/backfill-nikon-lens-image-circles.ts
@@ -1,0 +1,221 @@
+/**
+ * Backfill Nikon LENS imageCircleSizeId from DX naming.
+ *
+ * Rule:
+ *   - Brand slug `nikon`, gear_type `LENS`
+ *   - Name contains whole-token "DX" (case-insensitive) → aps-c
+ *   - Otherwise → full-frame
+ *
+ * Updates lens_specs only when the target differs from the current value.
+ * Does not touch fixed_lens_specs or non-LENS gear.
+ *
+ * Usage:
+ *   npm run gear:backfill-nikon-image-circles
+ *   npm run gear:backfill-nikon-image-circles -- --apply
+ *   npm run gear:backfill-nikon-image-circles -- --sample=30
+ */
+
+import "dotenv/config";
+import { and, eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+
+import { targetImageCircleSlugFromNikonLensName } from "../src/lib/admin/nikon-lens-image-circle";
+import {
+  brands,
+  gear,
+  lensSpecs,
+  sensorFormats,
+} from "../src/server/db/schema";
+
+const LOG_PREFIX = "[backfill-nikon-lens-image-circles]";
+
+function parseArgs() {
+  const apply = process.argv.includes("--apply");
+  const sampleFlag = process.argv.find((arg) => arg.startsWith("--sample="));
+  const samplePositional = process.argv.indexOf("--sample");
+  const sampleRaw =
+    sampleFlag?.split("=")[1] ??
+    (samplePositional >= 0 ? process.argv[samplePositional + 1] : undefined);
+  const sample = Number.parseInt(sampleRaw ?? "20", 10);
+  return {
+    apply,
+    sample: Number.isFinite(sample) && sample > 0 ? sample : 20,
+  };
+}
+
+type CandidateRow = {
+  gearId: string;
+  slug: string;
+  name: string;
+  currentImageCircleSizeId: string | null;
+  currentImageCircleSlug: string | null;
+  targetSlug: "aps-c" | "full-frame";
+  targetImageCircleSizeId: string;
+};
+
+async function main() {
+  const { apply, sample } = parseArgs();
+
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) {
+    throw new Error("DATABASE_URL is required to run this script");
+  }
+
+  console.log(`${LOG_PREFIX} Starting...`);
+  console.log(`${LOG_PREFIX} Mode: ${apply ? "apply" : "dry-run"}`);
+
+  const client = postgres(dbUrl, { max: 1 });
+  const db = drizzle(client);
+
+  try {
+    const [nikonBrand] = await db
+      .select({ id: brands.id, slug: brands.slug, name: brands.name })
+      .from(brands)
+      .where(eq(brands.slug, "nikon"))
+      .limit(1);
+
+    if (!nikonBrand) {
+      throw new Error('Brand with slug "nikon" not found');
+    }
+
+    const allFormats = await db
+      .select({
+        id: sensorFormats.id,
+        slug: sensorFormats.slug,
+        name: sensorFormats.name,
+      })
+      .from(sensorFormats);
+
+    const apsC = allFormats.find((row) => row.slug === "aps-c");
+    const fullFrame = allFormats.find((row) => row.slug === "full-frame");
+
+    if (!apsC || !fullFrame) {
+      throw new Error(
+        `Missing sensor formats: aps-c=${Boolean(apsC)}, full-frame=${Boolean(fullFrame)}`,
+      );
+    }
+
+    const formatIdBySlug = {
+      "aps-c": apsC.id,
+      "full-frame": fullFrame.id,
+    } as const;
+
+    const slugByFormatId = new Map(
+      allFormats.map((row) => [row.id, row.slug] as const),
+    );
+
+    const nikonLenses = await db
+      .select({
+        gearId: gear.id,
+        slug: gear.slug,
+        name: gear.name,
+        lensSpecsGearId: lensSpecs.gearId,
+        currentImageCircleSizeId: lensSpecs.imageCircleSizeId,
+      })
+      .from(gear)
+      .leftJoin(lensSpecs, eq(lensSpecs.gearId, gear.id))
+      .where(and(eq(gear.brandId, nikonBrand.id), eq(gear.gearType, "LENS")));
+
+    const missingLensSpecs: Array<{ slug: string; name: string }> = [];
+    const candidates: CandidateRow[] = [];
+    let alreadyCorrect = 0;
+    let wouldUpdateApsC = 0;
+    let wouldUpdateFullFrame = 0;
+
+    for (const row of nikonLenses) {
+      if (!row.lensSpecsGearId) {
+        missingLensSpecs.push({ slug: row.slug, name: row.name });
+        continue;
+      }
+
+      const targetSlug = targetImageCircleSlugFromNikonLensName(row.name);
+      const targetImageCircleSizeId = formatIdBySlug[targetSlug];
+      const currentSlug = row.currentImageCircleSizeId
+        ? (slugByFormatId.get(row.currentImageCircleSizeId) ?? null)
+        : null;
+
+      if (row.currentImageCircleSizeId === targetImageCircleSizeId) {
+        alreadyCorrect += 1;
+        continue;
+      }
+
+      if (targetSlug === "aps-c") {
+        wouldUpdateApsC += 1;
+      } else {
+        wouldUpdateFullFrame += 1;
+      }
+
+      candidates.push({
+        gearId: row.gearId,
+        slug: row.slug,
+        name: row.name,
+        currentImageCircleSizeId: row.currentImageCircleSizeId,
+        currentImageCircleSlug: currentSlug,
+        targetSlug,
+        targetImageCircleSizeId,
+      });
+    }
+
+    console.log(
+      `${LOG_PREFIX} Nikon brand: ${nikonBrand.name} (${nikonBrand.id})`,
+    );
+    console.log(
+      `${LOG_PREFIX} Formats: aps-c=${apsC.id}, full-frame=${fullFrame.id}`,
+    );
+    console.log(`${LOG_PREFIX} Total Nikon lenses: ${nikonLenses.length}`);
+    console.log(`${LOG_PREFIX} Already correct: ${alreadyCorrect}`);
+    console.log(`${LOG_PREFIX} Missing lens_specs: ${missingLensSpecs.length}`);
+    console.log(
+      `${LOG_PREFIX} Would update → aps-c: ${wouldUpdateApsC}, full-frame: ${wouldUpdateFullFrame}, total: ${candidates.length}`,
+    );
+
+    if (missingLensSpecs.length > 0) {
+      const missingSample = missingLensSpecs.slice(0, sample);
+      console.log(`${LOG_PREFIX} Missing lens_specs sample:`);
+      for (const row of missingSample) {
+        console.log(`  ${row.slug} | ${row.name}`);
+      }
+    }
+
+    if (candidates.length > 0) {
+      const sampleRows = candidates.slice(0, sample);
+      console.log(`${LOG_PREFIX} Sample updates:`);
+      for (const row of sampleRows) {
+        const currentLabel = row.currentImageCircleSlug ?? "null";
+        console.log(
+          `  ${row.slug} | ${row.name} | ${currentLabel} → ${row.targetSlug}`,
+        );
+      }
+    }
+
+    if (!apply) {
+      console.log(
+        `${LOG_PREFIX} Dry run complete. Re-run with --apply to persist changes.`,
+      );
+      return;
+    }
+
+    let updatedCount = 0;
+    for (const candidate of candidates) {
+      await db
+        .update(lensSpecs)
+        .set({
+          imageCircleSizeId: candidate.targetImageCircleSizeId,
+          updatedAt: new Date(),
+        })
+        .where(eq(lensSpecs.gearId, candidate.gearId));
+      updatedCount += 1;
+    }
+
+    console.log(`${LOG_PREFIX} Updated rows: ${updatedCount}`);
+    console.log(`${LOG_PREFIX} Backfill complete.`);
+  } finally {
+    await client.end({ timeout: 5 });
+  }
+}
+
+main().catch((error) => {
+  console.error(`${LOG_PREFIX} Error:`, error);
+  process.exit(1);
+});

--- a/src/lib/admin/nikon-lens-image-circle.ts
+++ b/src/lib/admin/nikon-lens-image-circle.ts
@@ -1,0 +1,16 @@
+/**
+ * Nikon DX naming → image-circle coverage heuristic.
+ *
+ * DX-marked Nikkor lenses cover APS-C; other Nikon lenses are treated as full-frame.
+ */
+
+export type NikonImageCircleSlug = "aps-c" | "full-frame";
+
+/** Whole-token DX match (case-insensitive), e.g. "AF-S DX NIKKOR 35mm". */
+const DX_TOKEN_PATTERN = /\bDX\b/i;
+
+export function targetImageCircleSlugFromNikonLensName(
+  name: string,
+): NikonImageCircleSlug {
+  return DX_TOKEN_PATTERN.test(name) ? "aps-c" : "full-frame";
+}

--- a/tests/unit/nikon-lens-image-circle.test.ts
+++ b/tests/unit/nikon-lens-image-circle.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { targetImageCircleSlugFromNikonLensName } from "~/lib/admin/nikon-lens-image-circle";
+
+describe("targetImageCircleSlugFromNikonLensName", () => {
+  it("assigns aps-c when DX appears as a whole token", () => {
+    expect(
+      targetImageCircleSlugFromNikonLensName("AF-S DX NIKKOR 35mm f/1.8G"),
+    ).toBe("aps-c");
+    expect(
+      targetImageCircleSlugFromNikonLensName("NIKKOR Z DX 16-50mm f/3.5-6.3 VR"),
+    ).toBe("aps-c");
+  });
+
+  it("matches DX case-insensitively", () => {
+    expect(targetImageCircleSlugFromNikonLensName("af-s dx nikkor 18-55mm")).toBe(
+      "aps-c",
+    );
+    expect(targetImageCircleSlugFromNikonLensName("NIKKOR Dx 40mm f/2.8G")).toBe(
+      "aps-c",
+    );
+  });
+
+  it("assigns full-frame when DX is absent", () => {
+    expect(
+      targetImageCircleSlugFromNikonLensName("NIKKOR Z 24-70mm f/2.8 S"),
+    ).toBe("full-frame");
+    expect(
+      targetImageCircleSlugFromNikonLensName("AF-S NIKKOR 50mm f/1.8G"),
+    ).toBe("full-frame");
+    expect(
+      targetImageCircleSlugFromNikonLensName("AF-S NIKKOR 14-24mm f/2.8G ED"),
+    ).toBe("full-frame");
+  });
+
+  it("does not treat DX as a substring of another word", () => {
+    expect(targetImageCircleSlugFromNikonLensName("INDEX 50mm f/1.8")).toBe(
+      "full-frame",
+    );
+    expect(targetImageCircleSlugFromNikonLensName("NIKKOR REDX 35mm")).toBe(
+      "full-frame",
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a dry-run-by-default CLI (`npm run gear:backfill-nikon-image-circles`) that sets Nikon `LENS` `imageCircleSizeId` from the name rule: whole-token `DX` → `aps-c`, otherwise → `full-frame`
- Pass `--apply` to write; only updates rows whose current value differs from the target
- Documents the heuristic in `docs/gear-specification-system.md` and covers the classifier with unit tests

## Verification
- `npm run test -- tests/unit/nikon-lens-image-circle.test.ts`
- Dry-run + apply on the connected development/preview DB: 123 rows updated; follow-up dry-run shows 200/200 already correct

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f99cc-45a2-75b7-bcb5-68e02ddf57ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f99cc-45a2-75b7-bcb5-68e02ddf57ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

