### PR TITLE
Support glued Fujifilm lens name optics parsing

### DIFF
--- a/src/lib/admin/gear-bulk-import.ts
+++ b/src/lib/admin/gear-bulk-import.ts
@@ -291,9 +291,9 @@ export function parseFocalLengthFromName(
   name: string,
 ): { min: number; max: number; isPrime: boolean } | null {
   // Allow mount prefixes glued to the focal token (FD100mm, FE24-70mm).
-  // Do not require a leading word boundary before the digits.
+  // Also allow glued aperture tokens (XF23mmF2, XF16-55mmF2.8-4).
   const range = name.match(
-    /(\d+(?:\.\d+)?)\s*[-–]\s*(\d+(?:\.\d+)?)\s*mm\b/i,
+    /(\d+(?:\.\d+)?)\s*[-–]\s*(\d+(?:\.\d+)?)\s*mm(?=\b|\s*[ft]\s*\/?\s*\d)/i,
   );
   if (range?.[1] && range[2]) {
     const min = Number(range[1]);
@@ -303,7 +303,9 @@ export function parseFocalLengthFromName(
     }
   }
 
-  const prime = name.match(/(\d+(?:\.\d+)?)\s*mm\b/i);
+  const prime = name.match(
+    /(\d+(?:\.\d+)?)\s*mm(?=\b|\s*[ft]\s*\/?\s*\d)/i,
+  );
   if (prime?.[1]) {
     const focal = Number(prime[1]);
     if (Number.isFinite(focal)) {
@@ -329,9 +331,11 @@ export function parseApertureFromName(
     .replace(/[—–]/g, "-");
 
   const patterns = [
-    /\bf\s*\/?\s*(\d+(?:\.\d+)?)(?:\s*-\s*(\d+(?:\.\d+)?))?/i,
+    // Accept glued forms after focal length tokens (XF23mmF2), but avoid
+    // matching brand/mount prefixes like "RF24" by requiring a safe prefix.
+    /(?:^|[^a-z0-9]|mm)\s*f\s*\/?\s*(\d+(?:\.\d+)?)(?:\s*-\s*(\d+(?:\.\d+)?))?/i,
     /\b1\s*:\s*(\d+(?:\.\d+)?)(?:\s*-\s*(\d+(?:\.\d+)?))?/i,
-    /\bt\s*\/?\s*(\d+(?:\.\d+)?)(?:\s*-\s*(\d+(?:\.\d+)?))?/i,
+    /(?:^|[^a-z0-9]|mm)\s*t\s*\/?\s*(\d+(?:\.\d+)?)(?:\s*-\s*(\d+(?:\.\d+)?))?/i,
   ];
 
   for (const pattern of patterns) {

--- a/tests/unit/gear-bulk-import.test.ts
+++ b/tests/unit/gear-bulk-import.test.ts
@@ -36,6 +36,7 @@ describe("gear bulk import utilities", () => {
     ["Canon EF 8-15mm f/4L Fisheye USM", { min: 8, max: 15, isPrime: false }],
     ["Canon FD100mm f/2.8 S.S.C.", { min: 100, max: 100, isPrime: true }],
     ["Sony FE24-70mm F2.8 GM", { min: 24, max: 70, isPrime: false }],
+    ["Fujifilm XF23mmF2 R WR", { min: 23, max: 23, isPrime: true }],
   ])("parses focal length from %s", (name, expected) => {
     expect(parseFocalLengthFromName(name)).toEqual(expected);
   });
@@ -68,6 +69,7 @@ describe("gear bulk import utilities", () => {
     ["Nikon Nikkor Z 50mm ƒ/1.8", { wide: 1.8 }],
     ["Sigma 24-70mm F2.8 DG DN Art", { wide: 2.8 }],
     ["Sigma 150-600mm F4.5-6.3", { wide: 4.5, tele: 6.3 }],
+    ["Fujifilm XF23mmF2 R WR", { wide: 2 }],
     ["Canon RF 24-105mm f/4-7.1", { wide: 4, tele: 7.1 }],
     ["Canon EF 24-105mm f/4L IS USM", { wide: 4 }],
     ["Nikon AF-S NIKKOR 500mm f/5.6E PF", { wide: 5.6 }],
@@ -86,6 +88,7 @@ describe("gear bulk import utilities", () => {
 
   it("returns null when no aperture token is present", () => {
     expect(parseApertureFromName("Nikon Nikkor Z 50mm")).toBeNull();
+    expect(parseApertureFromName("Canon RF24-70mm")).toBeNull();
   });
 
   it("parses structured CSV rows with inferred brand, mounts, focal length, and aperture", () => {

--- a/tests/unit/lens-optics-backfill.test.ts
+++ b/tests/unit/lens-optics-backfill.test.ts
@@ -45,6 +45,20 @@ describe("proposeLensOpticsBackfillFromName", () => {
     });
   });
 
+  it("fills optics from glued focal+aperture tokens used by Fujifilm names", () => {
+    const proposal = proposeLensOpticsBackfillFromName(
+      "Fujifilm XF23mmF2 R WR",
+      emptyOptics,
+    );
+
+    expect(proposal.proposed).toMatchObject({
+      focalLengthMinMm: 23,
+      focalLengthMaxMm: 23,
+      isPrime: true,
+      maxApertureWide: 2,
+    });
+  });
+
   it("fills aperture only when focal and isPrime already exist", () => {
     const proposal = proposeLensOpticsBackfillFromName(
       "Sigma 150-600mm F4.5-6.3",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update focal-length parsing so `mm` tokens still match when an aperture marker is glued directly after them (e.g. `XF23mmF2`, `XF16-55mmF2.8-4`)
- update aperture parsing to support glued `mmF...` / `mmT...` forms while avoiding false positives on prefixes like `RF24`
- add regression coverage for `Fujifilm XF23mmF2 R WR` in both parser-level and optics-backfill proposal tests

## Testing
- `npm run test -- tests/unit/gear-bulk-import.test.ts tests/unit/lens-optics-backfill.test.ts`
- `npm run test -- tests/unit/gear-optics-backfill-route.test.ts`
- `npm run lint -- src/lib/admin/gear-bulk-import.ts tests/unit/gear-bulk-import.test.ts tests/unit/lens-optics-backfill.test.ts` (warnings only: test files are ignored by ESLint config, zero lint errors)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9a11-5942-7605-9975-2c2b8712fc8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9a11-5942-7605-9975-2c2b8712fc8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

