### PR TITLE
Remove redundant brand link above gear item name

### DIFF
--- a/src/app/[locale]/(pages)/gear/[slug]/page.tsx
+++ b/src/app/[locale]/(pages)/gear/[slug]/page.tsx
@@ -293,21 +293,8 @@ export default async function GearPage({ params }: GearPageProps) {
             regionalAliases={item.regionalAliases ?? []}
           />
         </div>
-        {/* Item Name and Brand */}
+        {/* Item Name */}
         <div>
-          <div className="flex items-center gap-3">
-            {/* <span className="bg-secondary rounded-full px-3 py-1 text-xs font-medium">
-            {item.gearType}
-          </span> */}
-            {item.brands && (
-              <Link
-                href={`/brand/${item.brands.slug}`}
-                className="text-muted-foreground text-sm"
-              >
-                {item.brands.name}
-              </Link>
-            )}
-          </div>
           <div className="flex items-center gap-2">
             <h1 className="text-3xl font-bold sm:text-5xl">
               <GearDisplayName


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Gear detail pages showed a muted brand link directly above the bold item name, even though breadcrumbs already include the brand.

This wasn't a recent addition — the brand link has been on the page since the Sep 2025 gear page structure work, and stayed when richer brand/category/mount breadcrumbs were added later. The result is duplicate brand navigation.

## Change
- Remove the brand `Link` above the gear `h1` on `/gear/[slug]`
- Keep breadcrumbs → bold item name → price/badges flow

## Test plan
- [ ] Open a gear page on desktop: confirm breadcrumbs include brand, and no brand link appears above the title
- [ ] Confirm the bold item name is the first content after breadcrumbs
- [ ] Spot-check mobile (breadcrumbs hidden): title still renders correctly without a brand line above it
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9a1e-7e98-7348-b697-226db6af3eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9a1e-7e98-7348-b697-226db6af3eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

