### PR TITLE
Add discontinued date and precision to core gear specs

### DIFF
--- a/docs/developer-api.md
+++ b/docs/developer-api.md
@@ -41,8 +41,9 @@ Required query parameter: `q` (2–200 characters). Optional `limit` defaults to
 
 Downloads one shared, lightweight snapshot of every published gear record. It is
 slug-sorted and contains only `name`, `slug`, `brandName`, `gearType`,
-`thumbnailUrl`, `releaseDate`, `releaseDatePrecision`, `announcedDate`, and
-`announceDatePrecision` for each item. It deliberately excludes specifications,
+`thumbnailUrl`, `releaseDate`, `releaseDatePrecision`, `announcedDate`,
+`announceDatePrecision`, `discontinuedDate`, and `discontinuedDatePrecision`
+for each item. It deliberately excludes specifications,
 aliases, samples, colourways, prices, IDs, and audit metadata.
 
 ```json

--- a/docs/gear-editing/auto-approvals.md
+++ b/docs/gear-editing/auto-approvals.md
@@ -79,7 +79,7 @@ Publication state and completeness are separate:
 
 - For each included key under `core`, `camera`, `analogCamera`, `lens`, and `fixedLens`, the **current** value on the gear must be “empty” and the **proposed** value must be non-empty (no overwrites, no clearing), except registered overwrite allowlist entries.
 - Same idea for top-level **`cameraCardSlots`** and **`videoModes`**: only allowed when the current value is empty and the proposal fills them.
-- The current overwrite allowlist permits non-empty replacements of `core.releaseDatePrecision` and `core.announceDatePrecision`; clearing either field or replacing any other populated value still requires review.
+- The current overwrite allowlist permits non-empty replacements of `core.releaseDatePrecision`, `core.announceDatePrecision`, and `core.discontinuedDatePrecision`; clearing any of those fields or replacing any other populated value still requires review.
 
 **Slug:** Eligibility loads the full gear row by **`gearMeta.slug`**; if slug is missing, trusted eligibility is false.
 

--- a/docs/gear-specification-system.md
+++ b/docs/gear-specification-system.md
@@ -198,7 +198,7 @@ CREATE TABLE sharply_gear (
   -- Primary key and identifiers
   -- Basic information (name, slug, search name)
   -- Classification (gear type, brand, mount)
-  -- Metadata (release date, price, thumbnail, top/rear secondary images)
+  -- Metadata (announced/release/discontinued dates + precision, price, thumbnail, top/rear secondary images)
   -- Timestamps
 );
 

--- a/docs/spec-editing-flow-design.md
+++ b/docs/spec-editing-flow-design.md
@@ -207,7 +207,7 @@ type ComponentName = keyof typeof SPEC_INPUT_COMPONENTS;
 - **Notes**: Optional explanation of why changes are needed
 - **Role-Aware Submit**:
   - Editors/Admins: If there are no existing change requests, their submission applies immediately—no review queue, preventing stale merges
-  - Trusted contributors: If they have at least one approved spec edit, there are no existing change requests, and the proposal is strictly add-only (fills empty values without overwriting or clearing existing data), the submission applies immediately regardless of gear completeness or publication state. The only registered overwrite exceptions are non-empty replacements of `releaseDatePrecision` and `announceDatePrecision`; clearing either precision, or changing either date value, still requires review.
+  - Trusted contributors: If they have at least one approved spec edit, there are no existing change requests, and the proposal is strictly add-only (fills empty values without overwriting or clearing existing data), the submission applies immediately regardless of gear completeness or publication state. The only registered overwrite exceptions are non-empty replacements of `releaseDatePrecision`, `announceDatePrecision`, and `discontinuedDatePrecision`; clearing any of those precisions, or changing any of the paired date values, still requires review.
   - Everyone else (or staff when another request is open, or trusted contributors whose proposal is not add-only): Submission enters the proposal queue (`status: PENDING`) for review
 - **Publication-state awareness**:
   - Rumored and hidden items still keep the internal edit flow available to staff so content can be prepared before publication.

--- a/messages/de.json
+++ b/messages/de.json
@@ -594,6 +594,7 @@
       "fields": {
         "announcedDatePrecision": "Präzision des Ankündigungsdatums",
         "releaseDatePrecision": "Präzision des Veröffentlichungsdatums",
+        "discontinuedDatePrecision": "Präzision des Einstellungsdatums",
         "datePrecisionHelp": "Wähle eine Genauigkeitsstufe für das Datum. Wenn du zum Beispiel „Monat“ auswählst, wird das Datum als „September 2025“ statt „5. September 2025“ angezeigt. Mit „Jahr“ wird nur das Jahr gezeigt. Verwende „Tag“, wenn das vollständige Datum bekannt ist.",
         "datePrecisionYear": "Jahr",
         "datePrecisionMonth": "Monat",
@@ -756,6 +757,9 @@
             },
             "releaseDate": {
               "label": "Veröffentlichungsdatum"
+            },
+            "discontinuedDate": {
+              "label": "Einstellungsdatum"
             },
             "msrpAtLaunchUsdCents": {
               "label": "UVP zum Marktstart"

--- a/messages/en.json
+++ b/messages/en.json
@@ -595,6 +595,7 @@
         "aperture": "Aperture",
         "announcedDatePrecision": "Announced Date Precision",
         "releaseDatePrecision": "Release Date Precision",
+        "discontinuedDatePrecision": "Discontinued Date Precision",
         "datePrecisionHelp": "Select a precision level for the date. For example, selecting \"Month\" will display the date as \"September 2025\" instead of \"September 5, 2025\". Selecting \"Year\" will only show the year. Use \"Day\" when the full date is known.",
         "datePrecisionYear": "Year",
         "datePrecisionMonth": "Month",
@@ -756,6 +757,9 @@
             },
             "releaseDate": {
               "label": "Release Date"
+            },
+            "discontinuedDate": {
+              "label": "Discontinued Date"
             },
             "msrpAtLaunchUsdCents": {
               "label": "MSRP At Launch"

--- a/messages/es.json
+++ b/messages/es.json
@@ -594,6 +594,7 @@
       "fields": {
         "announcedDatePrecision": "Precisión de la fecha de anuncio",
         "releaseDatePrecision": "Precisión de la fecha de lanzamiento",
+        "discontinuedDatePrecision": "Precisión de la fecha de discontinuación",
         "datePrecisionHelp": "Selecciona un nivel de precisión para la fecha. Por ejemplo, al elegir \"Mes\" la fecha se mostrará como \"septiembre de 2025\" en lugar de \"5 de septiembre de 2025\". Al elegir \"Año\" solo se mostrará el año. Usa \"Día\" cuando se conozca la fecha completa.",
         "datePrecisionYear": "Año",
         "datePrecisionMonth": "Mes",
@@ -756,6 +757,9 @@
             },
             "releaseDate": {
               "label": "Fecha de lanzamiento"
+            },
+            "discontinuedDate": {
+              "label": "Fecha de discontinuación"
             },
             "msrpAtLaunchUsdCents": {
               "label": "PVP de lanzamiento"

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -594,6 +594,7 @@
       "fields": {
         "announcedDatePrecision": "Précision de la date d’annonce",
         "releaseDatePrecision": "Précision de la date de sortie",
+        "discontinuedDatePrecision": "Précision de la date de fin de commercialisation",
         "datePrecisionHelp": "Choisissez un niveau de précision pour la date. Par exemple, sélectionner « Mois » affichera la date comme « septembre 2025 » au lieu de « 5 septembre 2025 ». « Année » n’affichera que l’année. Utilisez « Jour » lorsque la date complète est connue.",
         "datePrecisionYear": "Année",
         "datePrecisionMonth": "Mois",
@@ -756,6 +757,9 @@
             },
             "releaseDate": {
               "label": "Date de sortie"
+            },
+            "discontinuedDate": {
+              "label": "Date de fin de commercialisation"
             },
             "msrpAtLaunchUsdCents": {
               "label": "Prix de lancement conseillé"

--- a/messages/it.json
+++ b/messages/it.json
@@ -594,6 +594,7 @@
       "fields": {
         "announcedDatePrecision": "Precisione della data di annuncio",
         "releaseDatePrecision": "Precisione della data di uscita",
+        "discontinuedDatePrecision": "Precisione della data di dismissione",
         "datePrecisionHelp": "Seleziona un livello di precisione per la data. Ad esempio, scegliendo \"Mese\" la data sarà mostrata come \"settembre 2025\" invece di \"5 settembre 2025\". Scegliendo \"Anno\" verrà mostrato solo l’anno. Usa \"Giorno\" quando è disponibile la data completa.",
         "datePrecisionYear": "Anno",
         "datePrecisionMonth": "Mese",
@@ -756,6 +757,9 @@
             },
             "releaseDate": {
               "label": "Data di uscita"
+            },
+            "discontinuedDate": {
+              "label": "Data di dismissione"
             },
             "msrpAtLaunchUsdCents": {
               "label": "Prezzo di listino al lancio"

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -594,6 +594,7 @@
       "fields": {
         "announcedDatePrecision": "発表日の精度",
         "releaseDatePrecision": "発売日の精度",
+        "discontinuedDatePrecision": "販売終了日の精度",
         "datePrecisionHelp": "日付の精度レベルを選択してください。たとえば「月」を選ぶと、日付は「2025年9月」のように表示され、「2025年9月5日」では表示されません。「年」を選ぶと年のみ表示されます。完全な日付が分かっている場合は「日」を使ってください。",
         "datePrecisionYear": "年",
         "datePrecisionMonth": "月",
@@ -756,6 +757,9 @@
             },
             "releaseDate": {
               "label": "発売日"
+            },
+            "discontinuedDate": {
+              "label": "販売終了日"
             },
             "msrpAtLaunchUsdCents": {
               "label": "発売時希望小売価格"

--- a/messages/ms.json
+++ b/messages/ms.json
@@ -594,6 +594,7 @@
       "fields": {
         "announcedDatePrecision": "Ketepatan tarikh pengumuman",
         "releaseDatePrecision": "Ketepatan tarikh keluaran",
+        "discontinuedDatePrecision": "Ketepatan tarikh dihentikan",
         "datePrecisionHelp": "Pilih tahap ketepatan untuk tarikh. Contohnya, memilih \"Bulan\" akan memaparkan tarikh sebagai \"September 2025\" dan bukannya \"5 September 2025\". Memilih \"Tahun\" hanya akan memaparkan tahun. Gunakan \"Hari\" apabila tarikh penuh diketahui.",
         "datePrecisionYear": "Tahun",
         "datePrecisionMonth": "Bulan",
@@ -756,6 +757,9 @@
             },
             "releaseDate": {
               "label": "Tarikh pelancaran"
+            },
+            "discontinuedDate": {
+              "label": "Tarikh dihentikan"
             },
             "msrpAtLaunchUsdCents": {
               "label": "MSRP semasa pelancaran"

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -595,6 +595,7 @@
         "aperture": "光圈",
         "announcedDatePrecision": "公布的日期精度",
         "releaseDatePrecision": "发布日期精度",
+        "discontinuedDatePrecision": "停产日期精度",
         "datePrecisionHelp": "选择日期的精度级别。例如，选择“月”会将日期显示为“2025 年 9 月”，而不是“2025 年 9 月 5 日”。选择“年份”将仅显示年份。当完整日期已知时，使用“日”。",
         "datePrecisionYear": "年",
         "datePrecisionMonth": "月",
@@ -756,6 +757,9 @@
             },
             "releaseDate": {
               "label": "发布日期"
+            },
+            "discontinuedDate": {
+              "label": "停产日期"
             },
             "msrpAtLaunchUsdCents": {
               "label": "发布时的建议零售价"

--- a/src/app/[locale]/(admin)/admin/gear-proposals-list.tsx
+++ b/src/app/[locale]/(admin)/admin/gear-proposals-list.tsx
@@ -213,7 +213,12 @@ export function GearProposalsList() {
       k === "msrpAtLaunchUsdCents"
     )
       return formatPrice(v as number);
-    if (k === "releaseDate") return formatDisplayDate(v);
+    if (
+      k === "releaseDate" ||
+      k === "announcedDate" ||
+      k === "discontinuedDate"
+    )
+      return formatDisplayDate(v);
     if (k === "sensorFormatId") return sensorNameFromSlug(v as string);
     if (k === "mountId") return getMountLongNameById(v as string);
     if (k === "mountIds") {
@@ -237,7 +242,12 @@ export function GearProposalsList() {
       k === "msrpAtLaunchUsdCents"
     )
       return formatPrice(v as number);
-    if (k === "releaseDate") return formatDisplayDate(v);
+    if (
+      k === "releaseDate" ||
+      k === "announcedDate" ||
+      k === "discontinuedDate"
+    )
+      return formatDisplayDate(v);
     if (k === "sensorFormatId") return sensorNameFromId(v as string);
     if (k === "mountId") return getMountLongNameById(v as string);
     if (k === "mountIds") {

--- a/src/app/[locale]/(pages)/edit-success/page.tsx
+++ b/src/app/[locale]/(pages)/edit-success/page.tsx
@@ -195,7 +195,11 @@ export default async function EditSuccessPage({
                             k === "msrpAtLaunchUsdCents"
                           )
                             display = formatPrice(v as number);
-                          if (k === "releaseDate")
+                          if (
+                            k === "releaseDate" ||
+                            k === "announcedDate" ||
+                            k === "discontinuedDate"
+                          )
                             display = formatDate(v as any, {
                               locale,
                               preset: "date-long",

--- a/src/app/[locale]/(pages)/gear/_components/edit-gear/edit-gear-form.tsx
+++ b/src/app/[locale]/(pages)/gear/_components/edit-gear/edit-gear-form.tsx
@@ -298,6 +298,18 @@ function EditGearForm({
           return getSpecFieldLabel(t, "core", "releaseDate", "Release Date");
         case "releaseDatePrecision":
           return tf("editGear.fields.releaseDatePrecision", "Release Date Precision");
+        case "discontinuedDate":
+          return getSpecFieldLabel(
+            t,
+            "core",
+            "discontinuedDate",
+            "Discontinued Date",
+          );
+        case "discontinuedDatePrecision":
+          return tf(
+            "editGear.fields.discontinuedDatePrecision",
+            "Discontinued Date Precision",
+          );
         case "msrpNowUsdCents":
           return tf("editGear.fields.msrpNow", "MSRP now (USD)");
         case "msrpAtLaunchUsdCents":
@@ -598,6 +610,8 @@ function EditGearForm({
       "announceDatePrecision",
       "releaseDate",
       "releaseDatePrecision",
+      "discontinuedDate",
+      "discontinuedDatePrecision",
       "msrpNowUsdCents",
       "msrpAtLaunchUsdCents",
       "mpbMaxPriceUsdCents",
@@ -1106,6 +1120,8 @@ function EditGearForm({
           announceDatePrecision: formData.announceDatePrecision,
           releaseDate: formData.releaseDate ?? null,
           releaseDatePrecision: formData.releaseDatePrecision,
+          discontinuedDate: formData.discontinuedDate ?? null,
+          discontinuedDatePrecision: formData.discontinuedDatePrecision,
           msrpNowUsdCents: formData.msrpNowUsdCents ?? null,
           msrpAtLaunchUsdCents: formData.msrpAtLaunchUsdCents ?? null,
           mpbMaxPriceUsdCents: formData.mpbMaxPriceUsdCents ?? null,
@@ -1128,6 +1144,9 @@ function EditGearForm({
           announceDatePrecision: initialCoreSpecs.announceDatePrecision,
           releaseDate: initialCoreSpecs.releaseDate ?? null,
           releaseDatePrecision: initialCoreSpecs.releaseDatePrecision,
+          discontinuedDate: initialCoreSpecs.discontinuedDate ?? null,
+          discontinuedDatePrecision:
+            initialCoreSpecs.discontinuedDatePrecision,
           msrpNowUsdCents: initialCoreSpecs.msrpNowUsdCents ?? null,
           msrpAtLaunchUsdCents: initialCoreSpecs.msrpAtLaunchUsdCents ?? null,
           mpbMaxPriceUsdCents: initialCoreSpecs.mpbMaxPriceUsdCents ?? null,
@@ -1309,7 +1328,9 @@ function EditGearForm({
                           )
                             display = formatPrice(normalizePriceCents(v));
                           if (
-                            (k === "releaseDate" || k === "announcedDate") &&
+                            (k === "releaseDate" ||
+                              k === "announcedDate" ||
+                              k === "discontinuedDate") &&
                             (typeof v === "string" || v instanceof Date)
                           )
                             display = formatDate(v, {

--- a/src/app/[locale]/(pages)/gear/_components/edit-gear/fields-core.tsx
+++ b/src/app/[locale]/(pages)/gear/_components/edit-gear/fields-core.tsx
@@ -48,6 +48,8 @@ interface CoreFieldsProps {
     announceDatePrecision?: DatePrecision | null;
     releaseDate: Date | null;
     releaseDatePrecision?: DatePrecision | null;
+    discontinuedDate: Date | null;
+    discontinuedDatePrecision?: DatePrecision | null;
     msrpNowUsdCents?: number | null;
     msrpAtLaunchUsdCents?: number | null;
     mpbMaxPriceUsdCents?: number | null;
@@ -153,6 +155,22 @@ function CoreFieldsComponent({
       const d = Number(dStr);
       const utcDate = new Date(Date.UTC(y, m - 1, d));
       onChange("announcedDate", utcDate);
+    },
+    [onChange],
+  );
+
+  const handleDiscontinuedDateChange = useCallback(
+    (value: string) => {
+      if (!value) {
+        onChange("discontinuedDate", null);
+        return;
+      }
+      const [yStr, mStr, dStr] = value.split("-");
+      const y = Number(yStr);
+      const m = Number(mStr);
+      const d = Number(dStr);
+      const utcDate = new Date(Date.UTC(y, m - 1, d));
+      onChange("discontinuedDate", utcDate);
     },
     [onChange],
   );
@@ -314,6 +332,10 @@ function CoreFieldsComponent({
     return formatDateInputValue(currentSpecs.releaseDate);
   }, [currentSpecs.releaseDate]);
 
+  const formattedDiscontinuedDate = useMemo(() => {
+    return formatDateInputValue(currentSpecs.discontinuedDate);
+  }, [currentSpecs.discontinuedDate]);
+
   // Safely format the current MSRP and launch MSRP for the inputs (convert cents to dollars)
   const formattedMsrpNow = useMemo(() => {
     return centsToUsd(currentSpecs.msrpNowUsdCents);
@@ -410,6 +432,8 @@ function CoreFieldsComponent({
   const user = data.user;
   const announcedDatePrecision = currentSpecs.announceDatePrecision ?? "DAY";
   const releaseDatePrecision = currentSpecs.releaseDatePrecision ?? "DAY";
+  const discontinuedDatePrecision =
+    currentSpecs.discontinuedDatePrecision ?? "DAY";
 
   if (!session) return null;
 
@@ -577,6 +601,85 @@ function CoreFieldsComponent({
                       releaseDatePrecision === "YEAR"
                         ? "year"
                         : releaseDatePrecision === "MONTH"
+                        ? "month"
+                        : "day"
+                    }
+                />
+              </>
+            );
+          })()}
+
+          {/* Discontinued Date + Precision (paired) */}
+          {(() => {
+            const showPair =
+              showWhenMissing(initialSpecs?.discontinuedDate) ||
+              showWhenMissing(initialSpecs?.discontinuedDatePrecision);
+            if (!showPair) return null;
+            return (
+              <>
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Label>
+                      {tf(
+                        "editGear.fields.discontinuedDatePrecision",
+                        "Discontinued Date Precision",
+                      )}
+                    </Label>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <InfoIcon className="text-muted-foreground h-4 w-4" />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-md">
+                        {tf(
+                          "editGear.fields.datePrecisionHelp",
+                          'Select a precision level for the date. For example, selecting "Month" will display the date as "September 2025" instead of "September 5, 2025". Selecting "Year" will only show the year. Use "Day" when the full date is known.',
+                        )}
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                  <ToggleGroup
+                    type="single"
+                    value={discontinuedDatePrecision}
+                    onValueChange={(v) =>
+                      v && onChange("discontinuedDatePrecision", v)
+                    }
+                    variant="outline"
+                    className="w-full"
+                  >
+                    <ToggleGroupItem
+                      className="data-[state=on]:bg-accent hover:bg-accent/50"
+                      value="YEAR"
+                    >
+                      {tf("editGear.fields.datePrecisionYear", "Year")}
+                    </ToggleGroupItem>
+                    <ToggleGroupItem
+                      className="data-[state=on]:bg-accent hover:bg-accent/50"
+                      value="MONTH"
+                    >
+                      {tf("editGear.fields.datePrecisionMonth", "Month")}
+                    </ToggleGroupItem>
+                    <ToggleGroupItem
+                      className="data-[state=on]:bg-accent hover:bg-accent/50"
+                      value="DAY"
+                    >
+                      {tf("editGear.fields.datePrecisionDay", "Day")}
+                    </ToggleGroupItem>
+                  </ToggleGroup>
+                </div>
+
+                  <DateInput
+                    label={getSpecFieldLabel(
+                      t,
+                      "core",
+                      "discontinuedDate",
+                      "Discontinued Date",
+                    )}
+                    value={formattedDiscontinuedDate}
+                    onChange={handleDiscontinuedDateChange}
+                    granularity={
+                      discontinuedDatePrecision === "YEAR"
+                        ? "year"
+                        : discontinuedDatePrecision === "MONTH"
                         ? "month"
                         : "day"
                     }

--- a/src/lib/gear/change-request-field-policy.ts
+++ b/src/lib/gear/change-request-field-policy.ts
@@ -11,6 +11,9 @@ const CHANGE_REQUEST_FIELD_POLICIES: Record<string, ChangeRequestFieldPolicy> =
     "core.announceDatePrecision": {
       allowAutoApprovalOverwrite: true,
     },
+    "core.discontinuedDatePrecision": {
+      allowAutoApprovalOverwrite: true,
+    },
   };
 
 export function allowsAutoApprovalOverwrite(

--- a/src/lib/specs/registry.tsx
+++ b/src/lib/specs/registry.tsx
@@ -468,6 +468,26 @@ export const specDictionary: SpecSectionDef[] = [
         editElementId: "release-date",
       },
       {
+        key: "discontinuedDate",
+        label: "Discontinued Date",
+        searchTerms: [
+          "discontinued",
+          "end of life",
+          "EOL",
+          "discontinuation date",
+        ],
+        getRawValue: (item) => item.discontinuedDate,
+        formatDisplay: (_, item, __, ___, locale) =>
+          item.discontinuedDate
+            ? formatDateWithPrecision(item.discontinuedDate, {
+                locale: locale ?? "en",
+                precision: (item.discontinuedDatePrecision ??
+                  "DAY") as DatePrecision,
+              })
+            : undefined,
+        editElementId: "discontinued-date",
+      },
+      {
         key: "msrpAtLaunchUsdCents",
         label: "MSRP At Launch",
         searchTerms: ["price", "launch price", "retail price", "cost", "msrp"],

--- a/src/server/admin/proposals/service.ts
+++ b/src/server/admin/proposals/service.ts
@@ -49,6 +49,8 @@ const CATALOG_CORE_FIELDS = new Set([
   "releaseDatePrecision",
   "announcedDate",
   "announceDatePrecision",
+  "discontinuedDate",
+  "discontinuedDatePrecision",
   "publicationState",
 ]);
 

--- a/src/server/db/normalizers.ts
+++ b/src/server/db/normalizers.ts
@@ -169,6 +169,26 @@ export function normalizeProposalPayloadForDb(
           return allowed.includes(v) ? v : undefined;
         }, z.string().nullable().optional())
         .optional(),
+      discontinuedDate: z
+        .preprocess((value) => {
+          if (value === null) return null; // allow explicit clearing
+          if (value instanceof Date) return value;
+          if (typeof value === "string")
+            return parseDateUTC(value) ?? undefined;
+          return undefined;
+        }, z.date().nullable().optional())
+        .optional(),
+      discontinuedDatePrecision: z
+        .preprocess((value) => {
+          if (value === null) return null;
+          if (typeof value !== "string") return undefined;
+          const v = value.toUpperCase();
+          const allowed =
+            ((ENUMS as any).date_precision_enum as readonly string[]) ??
+            (["YEAR", "MONTH", "DAY"] as const);
+          return allowed.includes(v) ? v : undefined;
+        }, z.string().nullable().optional())
+        .optional(),
       // Mount support: single mountId for cameras, array mountIds for lenses
       mountId: z
         .preprocess((value) => {

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -624,6 +624,10 @@ export const gear = appSchema.table(
     releaseDatePrecision: datePrecisionEnum("release_date_precision").default(
       "DAY",
     ),
+    discontinuedDate: timestamp("discontinued_date", { withTimezone: true }),
+    discontinuedDatePrecision: datePrecisionEnum(
+      "discontinued_date_precision",
+    ).default("DAY"),
     msrpNowUsdCents: integer("msrp_now_usd_cents"),
     msrpAtLaunchUsdCents: integer("msrp_at_launch_usd_cents"),
     // Max observed price on MPB (USD cents), optional

--- a/src/server/developer-api/data.ts
+++ b/src/server/developer-api/data.ts
@@ -62,6 +62,8 @@ export type DeveloperApiCatalogItem = {
   releaseDatePrecision: string | null;
   announcedDate: Date | null;
   announceDatePrecision: string | null;
+  discontinuedDate: Date | null;
+  discontinuedDatePrecision: string | null;
 };
 
 /** A deliberately narrow, slug-sorted read for the downloadable API catalog. */
@@ -79,6 +81,8 @@ export async function fetchDeveloperCatalogData(): Promise<
       releaseDatePrecision: gear.releaseDatePrecision,
       announcedDate: gear.announcedDate,
       announceDatePrecision: gear.announceDatePrecision,
+      discontinuedDate: gear.discontinuedDate,
+      discontinuedDatePrecision: gear.discontinuedDatePrecision,
     })
     .from(gear)
     .innerJoin(brands, eq(gear.brandId, brands.id))

--- a/src/server/developer-api/serializers.ts
+++ b/src/server/developer-api/serializers.ts
@@ -81,6 +81,8 @@ export function serializeDeveloperCatalogData(
     releaseDatePrecision: item.releaseDatePrecision,
     announcedDate: serializeDate(item.announcedDate),
     announceDatePrecision: item.announceDatePrecision,
+    discontinuedDate: serializeDate(item.discontinuedDate),
+    discontinuedDatePrecision: item.discontinuedDatePrecision,
   }));
 }
 
@@ -450,6 +452,8 @@ export function serializeGear(item: DeveloperApiGear) {
       announceDatePrecision: item.announceDatePrecision,
       releaseDate: serializeDate(item.releaseDate),
       releaseDatePrecision: item.releaseDatePrecision,
+      discontinuedDate: serializeDate(item.discontinuedDate),
+      discontinuedDatePrecision: item.discontinuedDatePrecision,
       msrpNowUsdCents: item.msrpNowUsdCents,
       msrpAtLaunchUsdCents: item.msrpAtLaunchUsdCents,
       mpbMaxPriceUsdCents: item.mpbMaxPriceUsdCents,

--- a/tests/unit/core-fields.test.ts
+++ b/tests/unit/core-fields.test.ts
@@ -31,6 +31,7 @@ function renderCoreFields(gearType: "CAMERA" | "ANALOG_CAMERA" | "LENS") {
           currentSpecs: {
             announcedDate: null,
             releaseDate: null,
+            discontinuedDate: null,
             weightGrams: null,
             mountId: null,
             mountIds: [],
@@ -39,6 +40,7 @@ function renderCoreFields(gearType: "CAMERA" | "ANALOG_CAMERA" | "LENS") {
           initialSpecs: {
             announcedDate: null,
             releaseDate: null,
+            discontinuedDate: null,
             weightGrams: null,
             mountId: null,
             mountIds: [],

--- a/tests/unit/db-normalizers.test.ts
+++ b/tests/unit/db-normalizers.test.ts
@@ -130,4 +130,46 @@ describe("normalizeProposalPayloadForDb", () => {
       }),
     ).toEqual({});
   });
+
+  it("normalizes discontinued date and precision", () => {
+    expect(
+      normalizeProposalPayloadForDb({
+        core: {
+          discontinuedDate: "2024-06-15",
+          discontinuedDatePrecision: "month",
+        },
+      }),
+    ).toEqual({
+      core: {
+        discontinuedDate: new Date(Date.UTC(2024, 5, 15)),
+        discontinuedDatePrecision: "MONTH",
+      },
+    });
+  });
+
+  it("allows clearing discontinued date fields", () => {
+    expect(
+      normalizeProposalPayloadForDb({
+        core: {
+          discontinuedDate: null,
+          discontinuedDatePrecision: null,
+        },
+      }),
+    ).toEqual({
+      core: {
+        discontinuedDate: null,
+        discontinuedDatePrecision: null,
+      },
+    });
+  });
+
+  it("drops invalid discontinued date precision", () => {
+    expect(
+      normalizeProposalPayloadForDb({
+        core: {
+          discontinuedDatePrecision: "WEEK",
+        },
+      }),
+    ).toEqual({});
+  });
 });

--- a/tests/unit/developer-api-schemas-serializers.test.ts
+++ b/tests/unit/developer-api-schemas-serializers.test.ts
@@ -62,6 +62,8 @@ describe("developer API serializers", () => {
         releaseDatePrecision: "DAY",
         announcedDate: null,
         announceDatePrecision: null,
+        discontinuedDate: null,
+        discontinuedDatePrecision: null,
         id: "internal-id",
         createdAt: new Date(),
       },
@@ -75,6 +77,8 @@ describe("developer API serializers", () => {
         releaseDatePrecision: null,
         announcedDate: new Date("2024-06-17T00:00:00.000Z"),
         announceDatePrecision: "DAY",
+        discontinuedDate: new Date("2025-01-01T00:00:00.000Z"),
+        discontinuedDatePrecision: "MONTH",
       },
     ] as never);
 
@@ -89,6 +93,8 @@ describe("developer API serializers", () => {
         releaseDatePrecision: "DAY",
         announcedDate: null,
         announceDatePrecision: null,
+        discontinuedDate: null,
+        discontinuedDatePrecision: null,
       },
       {
         name: "Zulu",
@@ -100,6 +106,8 @@ describe("developer API serializers", () => {
         releaseDatePrecision: null,
         announcedDate: "2024-06-17T00:00:00.000Z",
         announceDatePrecision: "DAY",
+        discontinuedDate: "2025-01-01T00:00:00.000Z",
+        discontinuedDatePrecision: "MONTH",
       },
     ]);
   });
@@ -161,6 +169,8 @@ describe("developer API serializers", () => {
       announceDatePrecision: "DAY",
       releaseDate: new Date("2024-01-01T00:00:00.000Z"),
       releaseDatePrecision: "DAY",
+      discontinuedDate: new Date("2026-03-01T00:00:00.000Z"),
+      discontinuedDatePrecision: "MONTH",
       thumbnailUrl: "https://example.test/front.jpg",
       topViewUrl: "https://example.test/top.jpg",
       rearViewUrl: "https://example.test/rear.jpg",
@@ -316,6 +326,8 @@ describe("developer API serializers", () => {
       announceDatePrecision: "DAY",
       releaseDate: "2024-01-01T00:00:00.000Z",
       releaseDatePrecision: "DAY",
+      discontinuedDate: "2026-03-01T00:00:00.000Z",
+      discontinuedDatePrecision: "MONTH",
       thumbnailUrl: "https://example.test/front.jpg",
       topViewUrl: "https://example.test/top.jpg",
       rearViewUrl: "https://example.test/rear.jpg",

--- a/tests/unit/developer-api-service.test.ts
+++ b/tests/unit/developer-api-service.test.ts
@@ -164,6 +164,8 @@ describe("getDeveloperGear", () => {
         releaseDatePrecision: "DAY",
         announcedDate: null,
         announceDatePrecision: null,
+        discontinuedDate: null,
+        discontinuedDatePrecision: null,
       },
     ]);
 

--- a/tests/unit/gear-edit-submission.test.ts
+++ b/tests/unit/gear-edit-submission.test.ts
@@ -441,6 +441,7 @@ describe("gear edit submission", () => {
   it.each([
     ["releaseDatePrecision", "DAY", "MONTH"],
     ["announceDatePrecision", "MONTH", "YEAR"],
+    ["discontinuedDatePrecision", "DAY", "YEAR"],
   ] as const)(
     "auto-approves trusted contributors when they replace %s",
     async (fieldKey, currentValue, proposedValue) => {
@@ -467,7 +468,11 @@ describe("gear edit submission", () => {
     },
   );
 
-  it.each(["releaseDatePrecision", "announceDatePrecision"] as const)(
+  it.each([
+    "releaseDatePrecision",
+    "announceDatePrecision",
+    "discontinuedDatePrecision",
+  ] as const)(
     "keeps trusted contributors pending when they clear %s",
     async (fieldKey) => {
       authMocks.getSessionOrThrow.mockResolvedValue({
@@ -492,7 +497,7 @@ describe("gear edit submission", () => {
     },
   );
 
-  it.each(["releaseDate", "announcedDate"] as const)(
+  it.each(["releaseDate", "announcedDate", "discontinuedDate"] as const)(
     "keeps trusted contributors pending when they replace %s",
     async (fieldKey) => {
       authMocks.getSessionOrThrow.mockResolvedValue({

--- a/tests/unit/spec-registry-i18n.test.ts
+++ b/tests/unit/spec-registry-i18n.test.ts
@@ -123,7 +123,7 @@ describe("spec registry i18n", () => {
     );
 
     expect(discontinuedRow?.label).toBe("Discontinued Date");
-    expect(String(discontinuedRow?.value)).toMatch(/June 2024|Jun 2024/);
+    expect(discontinuedRow?.value).toBe("June 2024");
   });
 
   it("uses the plural mount translation key when a lens has multiple mounts", () => {

--- a/tests/unit/spec-registry-i18n.test.ts
+++ b/tests/unit/spec-registry-i18n.test.ts
@@ -29,6 +29,8 @@ function createGearItem(overrides: Partial<GearItem>): GearItem {
     announceDatePrecision: null,
     releaseDate: null,
     releaseDatePrecision: null,
+    discontinuedDate: null,
+    discontinuedDatePrecision: null,
     regionalAliases: null,
     cameraSpecs: null,
     analogCameraSpecs: null,
@@ -83,6 +85,8 @@ describe("spec registry i18n", () => {
       gearType: "CAMERA",
       announcedDate: new Date("2020-01-02T00:00:00.000Z"),
       announceDatePrecision: "DAY",
+      discontinuedDate: new Date("2024-06-01T00:00:00.000Z"),
+      discontinuedDatePrecision: "MONTH",
     });
 
     const sections = buildGearSpecsSections(item, {
@@ -95,6 +99,31 @@ describe("spec registry i18n", () => {
     expect(coreSection?.data.find((row) => row.key === "announcedDate")?.label).toBe(
       "Announced Date",
     );
+    expect(
+      coreSection?.data.find((row) => row.key === "discontinuedDate")?.label,
+    ).toBe("Discontinued Date");
+  });
+
+  it("formats discontinued date with precision", () => {
+    const item = createGearItem({
+      discontinuedDate: new Date("2024-06-15T00:00:00.000Z"),
+      discontinuedDatePrecision: "MONTH",
+    });
+
+    const sections = buildGearSpecsSections(item, {
+      locale: "en",
+      t: createTranslator({
+        "specRegistry.sections.core.fields.discontinuedDate.label":
+          "Discontinued Date",
+      }),
+    });
+    const coreSection = sections.find((section) => section.id === "core");
+    const discontinuedRow = coreSection?.data.find(
+      (row) => row.key === "discontinuedDate",
+    );
+
+    expect(discontinuedRow?.label).toBe("Discontinued Date");
+    expect(String(discontinuedRow?.value)).toMatch(/June 2024|Jun 2024/);
   });
 
   it("uses the plural mount translation key when a lens has multiple mounts", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `discontinuedDate` and `discontinuedDatePrecision` to core gear specs, mirroring the existing release/announced date+precision pair across the full spec surface.

## Changes

- Schema: new nullable `discontinued_date` + `discontinued_date_precision` columns on `gear`
- Edit UI: paired precision ToggleGroup + DateInput after release date
- Spec registry display with `formatDateWithPrecision`
- Change-request preview, edit-success, and admin approvals date formatting
- Normalizer validation, trusted auto-approval overwrite allowlist for precision, catalog cache invalidation
- Developer API catalog + gear detail serializers
- i18n keys in all locales; docs updated

## Out of scope

Gear cards/tables, browse sort/filter coalesce, bulk import, and “new” badge logic (discontinued stays independent of release/announced coalesce).

## Notes

Schema is additive. Maintainers should run `db:push` / generate migrations on merge — this PR does not include migration files.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9a6b-a750-7883-ac0c-cc587cb4e1e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9a6b-a750-7883-ac0c-cc587cb4e1e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

